### PR TITLE
feat(cli): bilingual zh tail stages for daily / crystal-synth / crystal-theme-pages

### DIFF
--- a/crates/ovp-cli/src/commands/crystal_synth.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth.rs
@@ -773,7 +773,7 @@ fn claims_zh_tail(vault_root: &std::path::Path, client_kind: ClientKind) {
     if pairs.is_empty() {
         return;
     }
-    let cache = vault_root.join(".ovp/cassettes/bilingual");
+    let cache = vault_root.join(ovp_memory::bilingual::CACHE_REL);
     let mut client = match build_client(ClientKind::Live, &cache) {
         Ok(c) => c,
         Err(e) => {

--- a/crates/ovp-cli/src/commands/crystal_synth.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth.rs
@@ -695,9 +695,18 @@ pub(crate) fn run_stats(args: CrystalSynthArgs) -> Result<RunStats, CliError> {
     // self-heals after each live run instead of waiting for a manual
     // `source-work claims-zh` pass. Best-effort: replay/offline, no vault
     // root, flag-off, or any tail error warns/skips and never changes the
-    // run's terminal status.
-    if let Some(vault) = &args.vault_root {
-        claims_zh_tail(vault, args.client_kind);
+    // run's terminal status. The vault is derived from the resolved STORE,
+    // not --vault-root: an explicit `--store <other-vault>/.ovp/crystal`
+    // must top up the vault its ledger actually lives in; a diagnostic
+    // store elsewhere skips (same rule as the run.lock derivation).
+    if args.vault_root.is_some() {
+        match crate::commands::crystal_write::vault_of_crystal_store(&paths.store) {
+            Some(vault) => claims_zh_tail(&vault, args.client_kind),
+            None => sayln!(
+                "  claims_zh tail skipped (store {} is not a <vault>/.ovp/crystal layout)",
+                paths.store.display()
+            ),
+        }
     }
 
     // Default: caveated claims route to review.json and the run succeeds.

--- a/crates/ovp-cli/src/commands/crystal_synth.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth.rs
@@ -791,13 +791,14 @@ fn claims_zh_tail(vault_root: &std::path::Path, client_kind: ClientKind) {
         }
     };
     let model = ovp_memory::ask::AskArgs::default().model_name;
+    // Capped at the vault's per-run auto budget — see cards_zh_tail (codex P1).
     let (done, skipped, errors) = ovp_memory::bilingual::translate_claims_batch(
         vault_root,
         &pairs,
         client.as_mut(),
         &model,
         false,
-        0,
+        cfg.auto_max_per_run,
     );
     sayln!(
         "  claims_zh: translated={done} skipped={skipped} errors={}",

--- a/crates/ovp-cli/src/commands/crystal_synth.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth.rs
@@ -690,6 +690,16 @@ pub(crate) fn run_stats(args: CrystalSynthArgs) -> Result<RunStats, CliError> {
     println!("  ledger: {}", outcome.ledger_path.display());
     println!("  view:   {}", outcome.crystal_md_path.display());
 
+    // Bilingual tail (candidate bilingual_tail-v1): the ledger write
+    // succeeded, so top up the claims_zh projection — the portal's zh surface
+    // self-heals after each live run instead of waiting for a manual
+    // `source-work claims-zh` pass. Best-effort: replay/offline, no vault
+    // root, flag-off, or any tail error warns/skips and never changes the
+    // run's terminal status.
+    if let Some(vault) = &args.vault_root {
+        claims_zh_tail(vault, args.client_kind);
+    }
+
     // Default: caveated claims route to review.json and the run succeeds.
     // `--strict` turns any caveated/review claim into a loud failure (CI gate).
     if args.strict && outcome.review > 0 {
@@ -727,6 +737,66 @@ fn write_json<T: serde::Serialize>(path: &std::path::Path, v: &T) -> Result<(), 
         .map_err(|e| CliError::Io(format!("serializing {}: {e}", path.display())))?;
     std::fs::write(path, format!("{s}\n"))
         .map_err(|e| CliError::Io(format!("writing {}: {e}", path.display())))
+}
+
+/// Bilingual tail for `crystal-synth` (candidate bilingual_tail-v1):
+/// translate the active-claims delta into `.ovp/crystal/claims_zh.json`.
+/// Gates, in order: LIVE client kind only (replay/offline runs skip entirely
+/// — NeverCallsClient is never built); `.ovp/source-work.toml` must parse and
+/// have `auto_claim_zh` (malformed config warns + skips); the live client
+/// must build. Every failure is a warn line — the parent run's exit code is
+/// decided by the EN phases alone. Incremental only: `get_fresh` content-hash
+/// skip means an unchanged authority costs zero LLM calls. Writes ONLY the
+/// rebuildable projection (the ledger is read, never written); never touches
+/// the queue or the worker lock.
+fn claims_zh_tail(vault_root: &std::path::Path, client_kind: ClientKind) {
+    if client_kind != ClientKind::Live {
+        return;
+    }
+    let cfg = match ovp_memory::source_work_config::SourceWorkConfig::load(vault_root) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            sayln!("  claims_zh tail skipped (config: {e})");
+            return;
+        }
+    };
+    if !cfg.auto_claim_zh {
+        return;
+    }
+    let pairs = match crate::commands::source_work_cmd::active_claim_pairs(vault_root) {
+        Ok(p) => p,
+        Err(e) => {
+            sayln!("  claims_zh tail skipped (ledger: {e})");
+            return;
+        }
+    };
+    if pairs.is_empty() {
+        return;
+    }
+    let cache = vault_root.join(".ovp/cassettes/bilingual");
+    let mut client = match build_client(ClientKind::Live, &cache) {
+        Ok(c) => c,
+        Err(e) => {
+            sayln!("  claims_zh tail skipped ({e})");
+            return;
+        }
+    };
+    let model = ovp_memory::ask::AskArgs::default().model_name;
+    let (done, skipped, errors) = ovp_memory::bilingual::translate_claims_batch(
+        vault_root,
+        &pairs,
+        client.as_mut(),
+        &model,
+        false,
+        0,
+    );
+    sayln!(
+        "  claims_zh: translated={done} skipped={skipped} errors={}",
+        errors.len()
+    );
+    for e in &errors {
+        sayln!("    warn claims_zh: {e}");
+    }
 }
 
 #[cfg(test)]
@@ -1262,5 +1332,51 @@ mod tests {
         let w = std::fs::read_to_string(work.join("warnings.json")).unwrap();
         let v: serde_json::Value = serde_json::from_str(&w).unwrap();
         assert_eq!(v["fallback_title_cases"], serde_json::json!(["0951c213"]));
+    }
+
+    // ---- claims_zh bilingual tail gates (candidate bilingual_tail-v1) ----
+
+    const CLAIMS_ZH: &str = ".ovp/crystal/claims_zh.json";
+
+    /// Eval_plan (1): a REPLAY-kind tail returns before any client/config
+    /// work — NeverCallsClient is never built and no projection appears.
+    #[test]
+    fn claims_zh_tail_skipped_for_replay_client() {
+        let tmp = tempfile::tempdir().unwrap();
+        claims_zh_tail(tmp.path(), ClientKind::Replay);
+        assert!(!tmp.path().join(CLAIMS_ZH).exists());
+    }
+
+    /// Eval_plan (4): `auto_claim_zh = false` skips the tail. The flag gate
+    /// returns BEFORE the live client is built, so this is provable offline.
+    #[test]
+    fn claims_zh_tail_skipped_when_flag_off() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tmp.path().join(".ovp/source-work.toml");
+        std::fs::create_dir_all(cfg.parent().unwrap()).unwrap();
+        std::fs::write(&cfg, "auto_claim_zh = false\n").unwrap();
+        claims_zh_tail(tmp.path(), ClientKind::Live);
+        assert!(!tmp.path().join(CLAIMS_ZH).exists());
+    }
+
+    /// Eval_plan (5): a malformed source-work.toml warns + skips — the tail
+    /// returns normally (failure isolation) and writes nothing.
+    #[test]
+    fn claims_zh_tail_warns_and_skips_on_malformed_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tmp.path().join(".ovp/source-work.toml");
+        std::fs::create_dir_all(cfg.parent().unwrap()).unwrap();
+        std::fs::write(&cfg, "auto_claim_zh = [not toml\n").unwrap();
+        claims_zh_tail(tmp.path(), ClientKind::Live);
+        assert!(!tmp.path().join(CLAIMS_ZH).exists());
+    }
+
+    /// The flag-on path with no ledger is a no-op: nothing to translate, and
+    /// the live client is never built (empty-pairs gate comes first).
+    #[test]
+    fn claims_zh_tail_noop_without_ledger() {
+        let tmp = tempfile::tempdir().unwrap();
+        claims_zh_tail(tmp.path(), ClientKind::Live);
+        assert!(!tmp.path().join(CLAIMS_ZH).exists());
     }
 }

--- a/crates/ovp-cli/src/commands/crystal_theme_pages.rs
+++ b/crates/ovp-cli/src/commands/crystal_theme_pages.rs
@@ -266,13 +266,14 @@ fn theme_pages_zh_tail(
         }
     };
     let model = ovp_memory::ask::AskArgs::default().model_name;
+    // Capped at the vault's per-run auto budget — see cards_zh_tail (codex P1).
     let (done, skipped, errors) = ovp_memory::bilingual::topup_theme_pages_zh(
         vault_root,
         &page_inputs,
         client.as_mut(),
         &model,
         false,
-        0,
+        cfg.auto_max_per_run,
     );
     sayln!(
         "  theme_pages_zh: translated={done} skipped={skipped} errors={}",

--- a/crates/ovp-cli/src/commands/crystal_theme_pages.rs
+++ b/crates/ovp-cli/src/commands/crystal_theme_pages.rs
@@ -257,7 +257,7 @@ fn theme_pages_zh_tail(
             )
         })
         .collect();
-    let cache = vault_root.join(".ovp/cassettes/bilingual");
+    let cache = vault_root.join(ovp_memory::bilingual::CACHE_REL);
     let mut client = match build_client(ClientKind::Live, &cache) {
         Ok(c) => c,
         Err(e) => {

--- a/crates/ovp-cli/src/commands/crystal_theme_pages.rs
+++ b/crates/ovp-cli/src/commands/crystal_theme_pages.rs
@@ -217,6 +217,72 @@ fn write_pages_file(
     Ok(())
 }
 
+/// Bilingual tail for `crystal-theme-pages` (candidate bilingual_tail-v1):
+/// translate the theme-pages delta into `.ovp/crystal/theme_pages_zh.json`.
+/// Gates, in order: LIVE client kind only (replay/offline runs skip entirely
+/// — NeverCallsClient is never built); `.ovp/source-work.toml` must parse and
+/// have `auto_memory_zh` (malformed config warns + skips); the live client
+/// must build. Every failure is a warn line — the parent run's exit code is
+/// decided by the EN phases alone. Incremental only: `get_fresh` content-hash
+/// skip means an unchanged authority costs zero LLM calls. Writes ONLY the
+/// rebuildable projection (theme_pages.json is read, never written); never
+/// touches the queue or the worker lock.
+fn theme_pages_zh_tail(
+    vault_root: &std::path::Path,
+    client_kind: ClientKind,
+    pages: &[ThemePage],
+) {
+    if client_kind != ClientKind::Live || pages.is_empty() {
+        return;
+    }
+    let cfg = match ovp_memory::source_work_config::SourceWorkConfig::load(vault_root) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            sayln!("  theme_pages_zh tail skipped (config: {e})");
+            return;
+        }
+    };
+    if !cfg.auto_memory_zh {
+        return;
+    }
+    let page_inputs: Vec<(i64, Vec<(String, String)>)> = pages
+        .iter()
+        .map(|p| {
+            (
+                p.community_id,
+                p.sections
+                    .iter()
+                    .map(|s| (s.heading.clone(), s.body.clone()))
+                    .collect(),
+            )
+        })
+        .collect();
+    let cache = vault_root.join(".ovp/cassettes/bilingual");
+    let mut client = match build_client(ClientKind::Live, &cache) {
+        Ok(c) => c,
+        Err(e) => {
+            sayln!("  theme_pages_zh tail skipped ({e})");
+            return;
+        }
+    };
+    let model = ovp_memory::ask::AskArgs::default().model_name;
+    let (done, skipped, errors) = ovp_memory::bilingual::topup_theme_pages_zh(
+        vault_root,
+        &page_inputs,
+        client.as_mut(),
+        &model,
+        false,
+        0,
+    );
+    sayln!(
+        "  theme_pages_zh: translated={done} skipped={skipped} errors={}",
+        errors.len()
+    );
+    for e in &errors {
+        sayln!("    warn theme_pages_zh: {e}");
+    }
+}
+
 pub fn run(args: CrystalThemePagesArgs) -> Result<(), CliError> {
     if args.min_claims == 0 {
         return Err(CliError::Io(
@@ -304,6 +370,15 @@ pub fn run(args: CrystalThemePagesArgs) -> Result<(), CliError> {
         pages: outcome.pages,
     };
     write_pages_file(&store, &pages_path, &file)?;
+
+    // Bilingual tail (candidate bilingual_tail-v1): the EN pages projection
+    // is on disk, so top up theme_pages_zh — the portal's zh surface
+    // self-heals after each live run instead of waiting for a manual
+    // `source-work memory-zh` pass. Best-effort: replay/offline, flag-off, or
+    // any tail error warns/skips and never changes the run's terminal status
+    // (including the gate-failure return below).
+    theme_pages_zh_tail(&args.vault_root, args.client_kind, &file.pages);
+
     if !outcome.failures.is_empty() {
         let mut msg = format!(
             "crystal-theme-pages: {} theme(s) failed the page gate \
@@ -655,5 +730,63 @@ mod tests {
         let out = build_pages(&records, &themes, None, &mut client, 2, false).unwrap();
         assert_eq!(out.pages.len(), 0);
         assert_eq!((out.built, out.kept, out.skipped_small), (0, 0, 0));
+    }
+
+    // ---- theme_pages_zh bilingual tail gates (candidate bilingual_tail-v1) ----
+
+    const THEME_PAGES_ZH: &str = ".ovp/crystal/theme_pages_zh.json";
+
+    fn sample_pages() -> Vec<ThemePage> {
+        vec![ThemePage {
+            community_id: 0,
+            label: "Agent memory".into(),
+            label_zh: "智能体记忆".into(),
+            claim_keys: vec!["ck-a".into()],
+            sections: vec![ovp_domain::crystal::theme_pages::PageSection {
+                heading: "Memory".into(),
+                body: "Persists [claim:ck-a].".into(),
+            }],
+        }]
+    }
+
+    /// Eval_plan (1): a REPLAY-kind tail returns before any client/config
+    /// work — NeverCallsClient is never built and no projection appears.
+    #[test]
+    fn theme_pages_zh_tail_skipped_for_replay_client() {
+        let tmp = tempfile::tempdir().unwrap();
+        theme_pages_zh_tail(tmp.path(), ClientKind::Replay, &sample_pages());
+        assert!(!tmp.path().join(THEME_PAGES_ZH).exists());
+    }
+
+    /// Eval_plan (4): `auto_memory_zh = false` skips the tail. The flag gate
+    /// returns BEFORE the live client is built, so this is provable offline.
+    #[test]
+    fn theme_pages_zh_tail_skipped_when_flag_off() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tmp.path().join(".ovp/source-work.toml");
+        std::fs::create_dir_all(cfg.parent().unwrap()).unwrap();
+        std::fs::write(&cfg, "auto_memory_zh = false\n").unwrap();
+        theme_pages_zh_tail(tmp.path(), ClientKind::Live, &sample_pages());
+        assert!(!tmp.path().join(THEME_PAGES_ZH).exists());
+    }
+
+    /// Eval_plan (5): a malformed source-work.toml warns + skips — the tail
+    /// returns normally (failure isolation) and writes nothing.
+    #[test]
+    fn theme_pages_zh_tail_warns_and_skips_on_malformed_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tmp.path().join(".ovp/source-work.toml");
+        std::fs::create_dir_all(cfg.parent().unwrap()).unwrap();
+        std::fs::write(&cfg, "auto_memory_zh = [not toml\n").unwrap();
+        theme_pages_zh_tail(tmp.path(), ClientKind::Live, &sample_pages());
+        assert!(!tmp.path().join(THEME_PAGES_ZH).exists());
+    }
+
+    /// An empty page set is a no-op before any config/client work.
+    #[test]
+    fn theme_pages_zh_tail_noop_without_pages() {
+        let tmp = tempfile::tempdir().unwrap();
+        theme_pages_zh_tail(tmp.path(), ClientKind::Live, &[]);
+        assert!(!tmp.path().join(THEME_PAGES_ZH).exists());
     }
 }

--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -941,8 +941,18 @@ fn cards_zh_tail(
         }
     };
     let model = ovp_memory::ask::AskArgs::default().model_name;
-    let (done, skipped, errors) =
-        ovp_memory::bilingual::topup_cards_zh(vault_root, cards, client.as_mut(), &model, false, 0);
+    // Cap the tail at the vault's per-run auto budget (default 30, 0 =
+    // unlimited): steady-state deltas are a handful of cards, but the first
+    // run in a long-stale vault must not fire hundreds of paid calls in one
+    // unattended run — the remainder self-heals over the next runs (codex P1).
+    let (done, skipped, errors) = ovp_memory::bilingual::topup_cards_zh(
+        vault_root,
+        cards,
+        client.as_mut(),
+        &model,
+        false,
+        cfg.auto_max_per_run,
+    );
     sayln!(
         "  cards_zh: translated={done} skipped={skipped} errors={}",
         errors.len()

--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -762,6 +762,21 @@ fn run_inner(
         Err(e) => sayln!("  tags: bootstrap skipped ({e})"),
     }
 
+    // Bilingual tail (candidate bilingual_tail-v1): top up the cards_zh
+    // projection so the portal's zh surface self-heals after each live run
+    // instead of waiting for a manual `source-work memory-zh` pass. Reuses the
+    // evidence built above — no second index walk. Best-effort like the tags
+    // bootstrap: replay/offline, flag-off, or any tail error warns/skips and
+    // never changes the run's terminal status.
+    {
+        let cards: Vec<(String, String, String)> = evidence
+            .cards
+            .iter()
+            .map(|c| (c.id.clone(), c.title.clone(), c.content.clone()))
+            .collect();
+        cards_zh_tail(&args.vault_root, args.client_kind, &cards);
+    }
+
     if failed > 0 {
         // Honest retry guidance: a 3rd failure means the source is now
         // BLOCKED, not silently retried.
@@ -885,6 +900,54 @@ fn stale_theme_packs(
         None => model.packs.len(),
     };
     Some(count)
+}
+
+/// Bilingual tail for `daily` (candidate bilingual_tail-v1): translate the
+/// memory-cards delta ((card_id, title, content)) into
+/// `.ovp/crystal/cards_zh.json`. Gates, in order: LIVE client kind only
+/// (replay/offline runs skip entirely — NeverCallsClient is never built);
+/// `.ovp/source-work.toml` must parse and have `auto_memory_zh` (malformed
+/// config warns + skips); the live client must build. Every failure is a warn
+/// line — the parent run's exit code is decided by the EN phases alone.
+/// Incremental only: `get_fresh` content-hash skip means an unchanged
+/// authority costs zero LLM calls. Writes ONLY the rebuildable projection;
+/// never touches the queue or the worker lock.
+fn cards_zh_tail(
+    vault_root: &std::path::Path,
+    client_kind: ClientKind,
+    cards: &[(String, String, String)],
+) {
+    if client_kind != ClientKind::Live || cards.is_empty() {
+        return;
+    }
+    let cfg = match ovp_memory::source_work_config::SourceWorkConfig::load(vault_root) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            sayln!("  cards_zh tail skipped (config: {e})");
+            return;
+        }
+    };
+    if !cfg.auto_memory_zh {
+        return;
+    }
+    let cache = vault_root.join(".ovp/cassettes/bilingual");
+    let mut client = match build_client(ClientKind::Live, &cache) {
+        Ok(c) => c,
+        Err(e) => {
+            sayln!("  cards_zh tail skipped ({e})");
+            return;
+        }
+    };
+    let model = ovp_memory::ask::AskArgs::default().model_name;
+    let (done, skipped, errors) =
+        ovp_memory::bilingual::topup_cards_zh(vault_root, cards, client.as_mut(), &model, false, 0);
+    sayln!(
+        "  cards_zh: translated={done} skipped={skipped} errors={}",
+        errors.len()
+    );
+    for e in &errors {
+        sayln!("    warn cards_zh: {e}");
+    }
 }
 
 /// Runs needed to drain `queued` sources at `cap` sources per run.
@@ -1040,10 +1103,20 @@ fn live_image_download() -> Result<Box<dyn ovp_enrich::image_download::ImageDown
 #[cfg(test)]
 mod tests {
     use super::{
-        drain_runs, rebuild_projection, refresh_decision, run, stale_theme_packs, DailyArgs,
-        RefreshDecision, REFRESH_DEBOUNCE_SECS,
+        cards_zh_tail, drain_runs, rebuild_projection, refresh_decision, run, stale_theme_packs,
+        DailyArgs, RefreshDecision, REFRESH_DEBOUNCE_SECS,
     };
     use crate::commands::client::ClientKind;
+
+    const CARDS_ZH: &str = ".ovp/crystal/cards_zh.json";
+
+    fn sample_cards() -> Vec<(String, String, String)> {
+        vec![(
+            "c1".to_string(),
+            "Memory budget".to_string(),
+            "Memory is a budget.".to_string(),
+        )]
+    }
 
     /// A mid-run refresh that fails MUST surface an `Err` the caller can catch
     /// and log — the run loop turns it into a `warn` and keeps going, never a
@@ -1137,6 +1210,7 @@ mod tests {
             pinboard_max: None,
             no_lifecycle: false,
             retry_blocked: false,
+            capture_tier: ovp_daily::CaptureTier::Balanced,
             web_fetch_fixture: None,
             web_fetch_live: false,
             github_fixture: None,
@@ -1179,6 +1253,57 @@ mod tests {
 
         // Finalize the active run so its guard's Drop doesn't write aborted.
         active_guard.finalize_completed(ovp_daily::RunCounts::default());
+    }
+
+    /// Bilingual tail, eval_plan (1): a REPLAY daily run skips the cards_zh
+    /// tail entirely — no client is built, no projection file appears, and the
+    /// run's status is exactly what the EN phases decided (offline determinism
+    /// is sacred).
+    #[test]
+    fn replay_daily_run_creates_no_cards_zh_projection() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vault = tmp.path().to_path_buf();
+        // Empty-but-real vault: the intake inbox must exist for plan_daily.
+        std::fs::create_dir_all(vault.join("50-Inbox/01-Raw")).unwrap();
+        run(min_args(vault.clone())).expect("empty replay daily run ok");
+        assert!(
+            !vault.join(CARDS_ZH).exists(),
+            "replay runs must never write .ovp/crystal/cards_zh.json"
+        );
+    }
+
+    /// The tail gate itself: replay kind returns before any client/config
+    /// work, so no projection is created even with cards to translate.
+    #[test]
+    fn cards_zh_tail_skipped_for_replay_client() {
+        let tmp = tempfile::tempdir().unwrap();
+        cards_zh_tail(tmp.path(), ClientKind::Replay, &sample_cards());
+        assert!(!tmp.path().join(CARDS_ZH).exists());
+    }
+
+    /// Bilingual tail, eval_plan (4): `auto_memory_zh = false` skips the tail
+    /// (the Live gate returns BEFORE building a client, so this is provable
+    /// offline) — no projection file.
+    #[test]
+    fn cards_zh_tail_skipped_when_flag_off() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tmp.path().join(".ovp/source-work.toml");
+        std::fs::create_dir_all(cfg.parent().unwrap()).unwrap();
+        std::fs::write(&cfg, "auto_memory_zh = false\n").unwrap();
+        cards_zh_tail(tmp.path(), ClientKind::Live, &sample_cards());
+        assert!(!tmp.path().join(CARDS_ZH).exists());
+    }
+
+    /// Bilingual tail, eval_plan (5): a malformed source-work.toml warns +
+    /// skips — the tail returns normally (failure isolation) and writes nothing.
+    #[test]
+    fn cards_zh_tail_warns_and_skips_on_malformed_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tmp.path().join(".ovp/source-work.toml");
+        std::fs::create_dir_all(cfg.parent().unwrap()).unwrap();
+        std::fs::write(&cfg, "auto_memory_zh = [not toml\n").unwrap();
+        cards_zh_tail(tmp.path(), ClientKind::Live, &sample_cards());
+        assert!(!tmp.path().join(CARDS_ZH).exists());
     }
 
     fn model_with_packs(dirs: &[&str]) -> ovp_index::IndexModel {

--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -767,8 +767,10 @@ fn run_inner(
     // instead of waiting for a manual `source-work memory-zh` pass. Reuses the
     // evidence built above — no second index walk. Best-effort like the tags
     // bootstrap: replay/offline, flag-off, or any tail error warns/skips and
-    // never changes the run's terminal status.
-    {
+    // never changes the run's terminal status. The card collection itself is
+    // gated on Live: the tail returns immediately for replay/offline, so
+    // cloning every evidence card there would be wasted work.
+    if args.client_kind == ClientKind::Live {
         let cards: Vec<(String, String, String)> = evidence
             .cards
             .iter()
@@ -930,7 +932,7 @@ fn cards_zh_tail(
     if !cfg.auto_memory_zh {
         return;
     }
-    let cache = vault_root.join(".ovp/cassettes/bilingual");
+    let cache = vault_root.join(ovp_memory::bilingual::CACHE_REL);
     let mut client = match build_client(ClientKind::Live, &cache) {
         Ok(c) => c,
         Err(e) => {
@@ -1278,6 +1280,15 @@ mod tests {
     fn cards_zh_tail_skipped_for_replay_client() {
         let tmp = tempfile::tempdir().unwrap();
         cards_zh_tail(tmp.path(), ClientKind::Replay, &sample_cards());
+        assert!(!tmp.path().join(CARDS_ZH).exists());
+    }
+
+    /// The flag-on path with no cards is a no-op: nothing to translate, and
+    /// the live client is never built (empty-cards gate comes first).
+    #[test]
+    fn cards_zh_tail_noop_without_cards() {
+        let tmp = tempfile::tempdir().unwrap();
+        cards_zh_tail(tmp.path(), ClientKind::Live, &[]);
         assert!(!tmp.path().join(CARDS_ZH).exists());
     }
 

--- a/crates/ovp-cli/src/commands/source_work_cmd.rs
+++ b/crates/ovp-cli/src/commands/source_work_cmd.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 
 use ovp_index::build_index;
 use ovp_memory::bilingual::{
-    topup_cards_zh, topup_theme_pages_zh, translate_claims_batch, GlossaryFile,
+    CACHE_REL, GlossaryFile, topup_cards_zh, topup_theme_pages_zh, translate_claims_batch,
 };
 use ovp_memory::source_work_auto::candidates_from_index;
 use ovp_memory::source_work_config::SourceWorkConfig;
@@ -145,14 +145,22 @@ pub(crate) fn active_claim_pairs(
     let mut events: Vec<StoreEvent> = Vec::new();
     if ledger.is_file() {
         let raw = std::fs::read_to_string(&ledger).map_err(|e| format!("reading ledger: {e}"))?;
-        for (i, line) in raw.lines().enumerate() {
-            let line = line.trim();
-            if line.is_empty() {
-                continue;
+        let lines: Vec<(usize, &str)> = raw
+            .lines()
+            .enumerate()
+            .map(|(i, l)| (i, l.trim()))
+            .filter(|(_, l)| !l.is_empty())
+            .collect();
+        for (pos, (i, line)) in lines.iter().enumerate() {
+            match serde_json::from_str::<StoreEvent>(line) {
+                Ok(ev) => events.push(ev),
+                // The serve worker appends without a read/write lock, so a
+                // read can catch a half-written FINAL line. Tolerate just
+                // that one — it will be complete next run. Mid-file garbage
+                // stays a loud, line-numbered error.
+                Err(_) if pos + 1 == lines.len() => {}
+                Err(e) => return Err(format!("ledger line {}: {e}", i + 1)),
             }
-            let ev: StoreEvent =
-                serde_json::from_str(line).map_err(|e| format!("ledger line {}: {e}", i + 1))?;
-            events.push(ev);
         }
     }
     Ok(fold_ledger(&events)
@@ -171,7 +179,7 @@ pub fn claims_zh(args: ClaimsZhArgs) -> Result<(), CliError> {
 
     let cache = args
         .cache_dir
-        .unwrap_or_else(|| args.vault_root.join(".ovp/cassettes/bilingual"));
+        .unwrap_or_else(|| args.vault_root.join(CACHE_REL));
     let mut client = build_client(args.client_kind, &cache)?;
     let model = ovp_memory::ask::AskArgs::default().model_name;
     let (done, skipped, errors) = translate_claims_batch(
@@ -210,7 +218,7 @@ pub fn memory_zh(args: MemoryZhArgs) -> Result<(), CliError> {
     let date = today_iso();
     let cache = args
         .cache_dir
-        .unwrap_or_else(|| args.vault_root.join(".ovp/cassettes/bilingual"));
+        .unwrap_or_else(|| args.vault_root.join(CACHE_REL));
     let mut client = build_client(args.client_kind, &cache)?;
     let model_name = ovp_memory::ask::AskArgs::default().model_name;
 
@@ -231,7 +239,8 @@ pub fn memory_zh(args: MemoryZhArgs) -> Result<(), CliError> {
             .map(|c| (c.id.clone(), c.title.clone(), c.content.clone()))
             .collect();
         sayln!("memory-zh cards: {} in evidence", cards.len());
-        let max = if budget == usize::MAX { 0 } else { budget };
+        // First phase: the budget is never exhausted yet, so this never skips.
+        let max = remaining_max(budget).unwrap_or(0);
         let (d, s, errors) = topup_cards_zh(
             &args.vault_root,
             &cards,
@@ -249,6 +258,14 @@ pub fn memory_zh(args: MemoryZhArgs) -> Result<(), CliError> {
     }
 
     if do_pages {
+        // An exhausted --max budget must NOT become unlimited: the helpers
+        // treat max=0 as "no cap", so forwarding a drained budget would
+        // translate EVERY theme page.
+        let Some(max) = remaining_max(budget) else {
+            sayln!("memory-zh theme_pages: skipped (--max budget exhausted by cards)");
+            sayln!("memory-zh done: translated={done} skipped={skipped}");
+            return Ok(());
+        };
         use ovp_domain::crystal::theme_pages::ThemePagesFile;
         let path = args.vault_root.join(".ovp/crystal/theme_pages.json");
         let pages = ThemePagesFile::load(&path).map_err(CliError::Io)?;
@@ -271,7 +288,6 @@ pub fn memory_zh(args: MemoryZhArgs) -> Result<(), CliError> {
                 )
             })
             .collect();
-        let max = if budget == usize::MAX { 0 } else { budget };
         let (d, s, errors) = topup_theme_pages_zh(
             &args.vault_root,
             &page_inputs,
@@ -291,7 +307,120 @@ pub fn memory_zh(args: MemoryZhArgs) -> Result<(), CliError> {
     Ok(())
 }
 
+/// Map the remaining `--max` budget onto a phase's `max` argument.
+/// `usize::MAX` (no `--max` given) means unlimited — the helpers take 0 for
+/// that. An exhausted budget means the phase must NOT run at all (`None`):
+/// forwarding 0 there would silently become unlimited.
+fn remaining_max(budget: usize) -> Option<usize> {
+    match budget {
+        usize::MAX => Some(0),
+        0 => None,
+        n => Some(n),
+    }
+}
+
 fn today_iso() -> String {
     // Local civil day — same as `ovp2 daily` default date.
     chrono::Local::now().format("%Y-%m-%d").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ovp_domain::crystal::{
+        CrystalStatus, DurableRecord, FinalClass, ProvenanceClass, StoreEvent, StoreOp,
+        StrengthClass,
+    };
+
+    fn record(claim_key: &str, claim: &str) -> DurableRecord {
+        DurableRecord {
+            claim_key: claim_key.into(),
+            claim_id: format!("cl-{claim_key}"),
+            claim: claim.into(),
+            theme: "t".into(),
+            source_cases: vec![],
+            citations: vec![],
+            provenance_score: 0.9,
+            provenance_class: ProvenanceClass::Durable,
+            strength: StrengthClass::Supported,
+            strength_rationale: "r".into(),
+            final_class: FinalClass::Durable,
+            run_id: "run-test".into(),
+            status: CrystalStatus::Active,
+        }
+    }
+
+    fn write_event(claim_key: &str, claim: &str) -> StoreEvent {
+        StoreEvent {
+            op: StoreOp::Write,
+            record: record(claim_key, claim),
+            supersedes: None,
+            reason: None,
+        }
+    }
+
+    fn write_ledger(vault: &std::path::Path, body: &str) {
+        let dir = vault.join(".ovp/crystal");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("ledger.jsonl"), body).unwrap();
+    }
+
+    /// Regression (F1): an exhausted --max budget must map to "phase must not
+    /// run", never to 0 — the topup helpers treat max=0 as UNLIMITED.
+    #[test]
+    fn remaining_max_maps_budget_to_phase_cap() {
+        assert_eq!(remaining_max(usize::MAX), Some(0), "no --max = unlimited");
+        assert_eq!(remaining_max(5), Some(5));
+        assert_eq!(remaining_max(1), Some(1));
+        assert_eq!(remaining_max(0), None, "exhausted budget = phase must not run");
+    }
+
+    #[test]
+    fn active_claim_pairs_missing_ledger_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(active_claim_pairs(tmp.path()).unwrap(), Vec::new());
+    }
+
+    #[test]
+    fn active_claim_pairs_returns_only_active_records() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active = serde_json::to_string(&write_event("ck-a", "Active claim.")).unwrap();
+        let retract = serde_json::to_string(&StoreEvent {
+            op: StoreOp::Retract,
+            record: record("ck-r", "Retracted claim."),
+            supersedes: None,
+            reason: Some("stale".into()),
+        })
+        .unwrap();
+        write_ledger(tmp.path(), &format!("{active}\n{retract}"));
+        let pairs = active_claim_pairs(tmp.path()).unwrap();
+        assert_eq!(
+            pairs,
+            vec![("ck-a".to_string(), "Active claim.".to_string())]
+        );
+    }
+
+    #[test]
+    fn active_claim_pairs_midfile_garbage_errors_with_line_number() {
+        let tmp = tempfile::tempdir().unwrap();
+        let good = serde_json::to_string(&write_event("ck-a", "Active claim.")).unwrap();
+        write_ledger(tmp.path(), &format!("{good}\n{{garbage\n{good}"));
+        let err = active_claim_pairs(tmp.path()).unwrap_err();
+        assert!(err.contains("ledger line 2"), "{err}");
+    }
+
+    /// The serve worker appends without a read/write lock: a read can catch a
+    /// half-written FINAL line. Skip just that line — it will be complete
+    /// next run — and still fold the events before it.
+    #[test]
+    fn active_claim_pairs_tolerates_trailing_partial_line() {
+        let tmp = tempfile::tempdir().unwrap();
+        let good = serde_json::to_string(&write_event("ck-a", "Active claim.")).unwrap();
+        write_ledger(tmp.path(), &format!("{good}\n{{\"op\":\"write\",\"rec"));
+        let pairs = active_claim_pairs(tmp.path()).unwrap();
+        assert_eq!(
+            pairs,
+            vec![("ck-a".to_string(), "Active claim.".to_string())]
+        );
+    }
 }

--- a/crates/ovp-cli/src/commands/source_work_cmd.rs
+++ b/crates/ovp-cli/src/commands/source_work_cmd.rs
@@ -12,8 +12,7 @@ use std::path::PathBuf;
 
 use ovp_index::build_index;
 use ovp_memory::bilingual::{
-    theme_page_en_hash, translate_card, translate_claim, translate_theme_page, CardsZhFile,
-    ClaimsZhFile, GlossaryFile, ThemePagesZhFile,
+    topup_cards_zh, topup_theme_pages_zh, translate_claims_batch, GlossaryFile,
 };
 use ovp_memory::source_work_auto::candidates_from_index;
 use ovp_memory::source_work_config::SourceWorkConfig;
@@ -135,32 +134,36 @@ pub fn backfill(args: BackfillArgs) -> Result<(), CliError> {
     Ok(())
 }
 
-pub fn claims_zh(args: ClaimsZhArgs) -> Result<(), CliError> {
-    use ovp_domain::crystal::{fold_ledger, CrystalStatus, StoreEvent};
-    let ledger = args.vault_root.join(".ovp/crystal/ledger.jsonl");
-    let events: Vec<StoreEvent> = if ledger.is_file() {
-        let raw = std::fs::read_to_string(&ledger)
-            .map_err(|e| CliError::Io(format!("reading ledger: {e}")))?;
-        let mut out = Vec::new();
+/// Active durable (claim_key, claim) pairs folded from the crystal ledger.
+/// Shared by `claims-zh` and the crystal-synth bilingual tail. Read-only —
+/// the ledger is the English authority and is never opened for write here.
+pub(crate) fn active_claim_pairs(
+    vault_root: &std::path::Path,
+) -> Result<Vec<(String, String)>, String> {
+    use ovp_domain::crystal::{CrystalStatus, StoreEvent, fold_ledger};
+    let ledger = vault_root.join(".ovp/crystal/ledger.jsonl");
+    let mut events: Vec<StoreEvent> = Vec::new();
+    if ledger.is_file() {
+        let raw = std::fs::read_to_string(&ledger).map_err(|e| format!("reading ledger: {e}"))?;
         for (i, line) in raw.lines().enumerate() {
             let line = line.trim();
             if line.is_empty() {
                 continue;
             }
-            let ev: StoreEvent = serde_json::from_str(line).map_err(|e| {
-                CliError::Io(format!("ledger line {}: {e}", i + 1))
-            })?;
-            out.push(ev);
+            let ev: StoreEvent =
+                serde_json::from_str(line).map_err(|e| format!("ledger line {}: {e}", i + 1))?;
+            events.push(ev);
         }
-        out
-    } else {
-        Vec::new()
-    };
-    let pairs: Vec<(String, String)> = fold_ledger(&events)
+    }
+    Ok(fold_ledger(&events)
         .into_iter()
         .filter(|r| r.status == CrystalStatus::Active)
         .map(|r| (r.claim_key, r.claim))
-        .collect();
+        .collect())
+}
+
+pub fn claims_zh(args: ClaimsZhArgs) -> Result<(), CliError> {
+    let pairs = active_claim_pairs(&args.vault_root).map_err(CliError::Io)?;
     sayln!("claims-zh: {} active durable claim(s)", pairs.len());
     if pairs.is_empty() {
         return Ok(());
@@ -171,35 +174,16 @@ pub fn claims_zh(args: ClaimsZhArgs) -> Result<(), CliError> {
         .unwrap_or_else(|| args.vault_root.join(".ovp/cassettes/bilingual"));
     let mut client = build_client(args.client_kind, &cache)?;
     let model = ovp_memory::ask::AskArgs::default().model_name;
-    let existing = ClaimsZhFile::load(&args.vault_root).map_err(CliError::Io)?;
-    let mut done = 0usize;
-    let mut skipped = 0usize;
-    let mut errors = Vec::new();
-    for (key, en) in &pairs {
-        if args.max > 0 && done >= args.max {
-            break;
-        }
-        if !args.force && existing.get_fresh(key, en).is_some() {
-            skipped += 1;
-            continue;
-        }
-        match translate_claim(
-            &args.vault_root,
-            key,
-            en,
-            client.as_mut(),
-            &model,
-            args.force,
-        ) {
-            Ok(_) => {
-                done += 1;
-                sayln!("  ok {key}");
-            }
-            Err(e) => {
-                errors.push(format!("{key}: {e}"));
-                sayln!("  FAIL {key}: {e}");
-            }
-        }
+    let (done, skipped, errors) = translate_claims_batch(
+        &args.vault_root,
+        &pairs,
+        client.as_mut(),
+        &model,
+        args.force,
+        args.max,
+    );
+    for e in &errors {
+        sayln!("  FAIL {e}");
     }
     // Ensure glossary file exists for operators to extend.
     let _ = GlossaryFile::load(&args.vault_root)
@@ -241,32 +225,26 @@ pub fn memory_zh(args: MemoryZhArgs) -> Result<(), CliError> {
             &build_index(&args.vault_root, &date, None).map_err(CliError::Io)?,
         )
         .map_err(CliError::Io)?;
-        let existing = CardsZhFile::load(&args.vault_root).map_err(CliError::Io)?;
-        sayln!("memory-zh cards: {} in evidence", evidence.cards.len());
-        for card in &evidence.cards {
-            if budget == 0 {
-                break;
-            }
-            if !args.force && existing.get_fresh(&card.id, &card.title, &card.content).is_some() {
-                skipped += 1;
-                continue;
-            }
-            match translate_card(
-                &args.vault_root,
-                &card.id,
-                &card.title,
-                &card.content,
-                client.as_mut(),
-                &model_name,
-                args.force,
-            ) {
-                Ok(_) => {
-                    done += 1;
-                    budget = budget.saturating_sub(1);
-                    sayln!("  card ok {}", card.id);
-                }
-                Err(e) => sayln!("  card FAIL {}: {e}", card.id),
-            }
+        let cards: Vec<(String, String, String)> = evidence
+            .cards
+            .iter()
+            .map(|c| (c.id.clone(), c.title.clone(), c.content.clone()))
+            .collect();
+        sayln!("memory-zh cards: {} in evidence", cards.len());
+        let max = if budget == usize::MAX { 0 } else { budget };
+        let (d, s, errors) = topup_cards_zh(
+            &args.vault_root,
+            &cards,
+            client.as_mut(),
+            &model_name,
+            args.force,
+            max,
+        );
+        done += d;
+        skipped += s;
+        budget = budget.saturating_sub(d);
+        for e in &errors {
+            sayln!("  card FAIL {e}");
         }
     }
 
@@ -279,37 +257,33 @@ pub fn memory_zh(args: MemoryZhArgs) -> Result<(), CliError> {
             sayln!("memory-zh done: translated={done} skipped={skipped}");
             return Ok(());
         };
-        let existing = ThemePagesZhFile::load(&args.vault_root).map_err(CliError::Io)?;
         sayln!("memory-zh theme_pages: {} page(s)", pages.pages.len());
-        for page in &pages.pages {
-            if budget == 0 {
-                break;
-            }
-            let sections: Vec<(String, String)> = page
-                .sections
-                .iter()
-                .map(|s| (s.heading.clone(), s.body.clone()))
-                .collect();
-            let en_hash = theme_page_en_hash(&sections);
-            if !args.force && existing.get_fresh(page.community_id, &en_hash).is_some() {
-                skipped += 1;
-                continue;
-            }
-            match translate_theme_page(
-                &args.vault_root,
-                page.community_id,
-                &sections,
-                client.as_mut(),
-                &model_name,
-                args.force,
-            ) {
-                Ok(_) => {
-                    done += 1;
-                    budget = budget.saturating_sub(1);
-                    sayln!("  theme ok community={}", page.community_id);
-                }
-                Err(e) => sayln!("  theme FAIL {}: {e}", page.community_id),
-            }
+        let page_inputs: Vec<(i64, Vec<(String, String)>)> = pages
+            .pages
+            .iter()
+            .map(|p| {
+                (
+                    p.community_id,
+                    p.sections
+                        .iter()
+                        .map(|s| (s.heading.clone(), s.body.clone()))
+                        .collect(),
+                )
+            })
+            .collect();
+        let max = if budget == usize::MAX { 0 } else { budget };
+        let (d, s, errors) = topup_theme_pages_zh(
+            &args.vault_root,
+            &page_inputs,
+            client.as_mut(),
+            &model_name,
+            args.force,
+            max,
+        );
+        done += d;
+        skipped += s;
+        for e in &errors {
+            sayln!("  theme FAIL {e}");
         }
     }
 

--- a/crates/ovp-cli/src/commands/source_work_cmd.rs
+++ b/crates/ovp-cli/src/commands/source_work_cmd.rs
@@ -12,7 +12,8 @@ use std::path::PathBuf;
 
 use ovp_index::build_index;
 use ovp_memory::bilingual::{
-    CACHE_REL, GlossaryFile, topup_cards_zh, topup_theme_pages_zh, translate_claims_batch,
+    CACHE_REL, CORRUPT_PROJECTION_MARKER, GlossaryFile, topup_cards_zh, topup_theme_pages_zh,
+    translate_claims_batch,
 };
 use ovp_memory::source_work_auto::candidates_from_index;
 use ovp_memory::source_work_config::SourceWorkConfig;
@@ -155,10 +156,14 @@ pub(crate) fn active_claim_pairs(
             match serde_json::from_str::<StoreEvent>(line) {
                 Ok(ev) => events.push(ev),
                 // The serve worker appends without a read/write lock, so a
-                // read can catch a half-written FINAL line. Tolerate just
-                // that one — it will be complete next run. Mid-file garbage
-                // stays a loud, line-numbered error.
-                Err(_) if pos + 1 == lines.len() => {}
+                // read can catch a half-written FINAL line — recognizable by
+                // the missing terminating newline. Tolerate just that case
+                // (it will be complete next run). A malformed line that IS
+                // newline-terminated is a complete, permanently bad record —
+                // silently dropping it could lose the latest write/retract
+                // and corrupt the claims projection (codex P2), so it stays
+                // a loud, line-numbered error like mid-file garbage.
+                Err(_) if pos + 1 == lines.len() && !raw.ends_with('\n') => {}
                 Err(e) => return Err(format!("ledger line {}: {e}", i + 1)),
             }
         }
@@ -190,6 +195,13 @@ pub fn claims_zh(args: ClaimsZhArgs) -> Result<(), CliError> {
         args.force,
         args.max,
     );
+    // A corrupt projection fails the MANUAL command loud — pre-refactor the
+    // initial `ClaimsZhFile::load?` did exactly that, and a silent Ok would
+    // let automation report success while nothing was repaired (codex P2).
+    // Only the automatic tails degrade this to a warning.
+    if let Some(e) = errors.iter().find(|e| e.contains(CORRUPT_PROJECTION_MARKER)) {
+        return Err(CliError::Io(format!("claims-zh: {e}")));
+    }
     for e in &errors {
         sayln!("  FAIL {e}");
     }
@@ -252,6 +264,10 @@ pub fn memory_zh(args: MemoryZhArgs) -> Result<(), CliError> {
         done += d;
         skipped += s;
         budget = budget.saturating_sub(d);
+        // Same corrupt-projection loud failure as claims-zh (codex P2).
+        if let Some(e) = errors.iter().find(|e| e.contains(CORRUPT_PROJECTION_MARKER)) {
+            return Err(CliError::Io(format!("memory-zh: {e}")));
+        }
         for e in &errors {
             sayln!("  card FAIL {e}");
         }
@@ -298,6 +314,9 @@ pub fn memory_zh(args: MemoryZhArgs) -> Result<(), CliError> {
         );
         done += d;
         skipped += s;
+        if let Some(e) = errors.iter().find(|e| e.contains(CORRUPT_PROJECTION_MARKER)) {
+            return Err(CliError::Io(format!("memory-zh: {e}")));
+        }
         for e in &errors {
             sayln!("  theme FAIL {e}");
         }
@@ -422,5 +441,17 @@ mod tests {
             pairs,
             vec![("ck-a".to_string(), "Active claim.".to_string())]
         );
+    }
+
+    /// A malformed last line that IS newline-terminated is a complete bad
+    /// record, not a half-written append — it must stay a loud error (codex
+    /// P2), otherwise the latest write/retract would silently vanish.
+    #[test]
+    fn active_claim_pairs_rejects_terminated_malformed_last_line() {
+        let tmp = tempfile::tempdir().unwrap();
+        let good = serde_json::to_string(&write_event("ck-a", "Active claim.")).unwrap();
+        write_ledger(tmp.path(), &format!("{good}\n{{not json\n"));
+        let err = active_claim_pairs(tmp.path()).unwrap_err();
+        assert!(err.contains("ledger line 2"), "{err}");
     }
 }

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -693,15 +693,14 @@ fn enrich_missing_titles(vault_root: &Path, sources: &mut [SourceRow]) {
                 s.url = Some(doc.source_url);
             }
         }
-        if s.title.as_ref().is_none_or(|t| t.trim().is_empty()) {
-            if let Some(stem) = path
+        if s.title.as_ref().is_none_or(|t| t.trim().is_empty())
+            && let Some(stem) = path
                 .file_stem()
                 .and_then(|n| n.to_str())
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
-            {
-                s.title = Some(stem.to_string());
-            }
+        {
+            s.title = Some(stem.to_string());
         }
     }
 }

--- a/crates/ovp-memory/src/bilingual.rs
+++ b/crates/ovp-memory/src/bilingual.rs
@@ -13,9 +13,13 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
-use ovp_llm::{ModelClient, ModelMessage, ModelRequest};
+use ovp_llm::{ModelClient, ModelMessage, ModelRequest, StopReason};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+
+/// Cassette cache root for every bilingual-tail client (daily / crystal-synth /
+/// crystal-theme-pages / source-work) — one place to change the replay store.
+pub const CACHE_REL: &str = ".ovp/cassettes/bilingual";
 
 /// Shared vault glossary (merge of operator edits + LLM extractions).
 pub const GLOSSARY_REL: &str = ".ovp/crystal/glossary.json";
@@ -88,12 +92,7 @@ impl GlossaryFile {
     }
 
     pub fn save(&self, vault_root: &Path) -> Result<(), String> {
-        let path = vault_root.join(GLOSSARY_REL);
-        if let Some(p) = path.parent() {
-            fs::create_dir_all(p).map_err(|e| format!("mkdir: {e}"))?;
-        }
-        let raw = serde_json::to_string_pretty(self).map_err(|e| e.to_string())?;
-        fs::write(&path, raw).map_err(|e| format!("write glossary: {e}"))
+        save_json(vault_root, GLOSSARY_REL, self)
     }
 
     /// Render as bullet list for prompt injection.
@@ -325,11 +324,37 @@ fn llm_text(
         cache_namespace: Some("bilingual/v1".into()),
     };
     let reply = client.call(&req).map_err(|e| e.to_string())?;
+    // A truncated/refused reply must never be persisted: stored with a
+    // matching en_hash it would be treated as fresh forever. Error instead so
+    // the item is collected and retried next run.
+    if !reply.is_final_success() {
+        return Err(format!(
+            "model stopped early (stop_reason={}) — not storing truncated translation",
+            stop_reason_label(&reply.stop_reason, reply.raw_stop_reason.as_deref())
+        ));
+    }
     let text = reply.text.trim().to_string();
     if text.is_empty() {
         return Err("model returned empty text".into());
     }
     Ok(text)
+}
+
+/// snake_case stop reason for error messages, with the verbatim provider
+/// string appended when the reason was not recognized.
+fn stop_reason_label(reason: &StopReason, raw: Option<&str>) -> String {
+    let name = match reason {
+        StopReason::EndTurn => "end_turn",
+        StopReason::MaxTokens => "max_tokens",
+        StopReason::StopSequence => "stop_sequence",
+        StopReason::ToolUse => "tool_use",
+        StopReason::Refusal => "refusal",
+        StopReason::Unknown => "unknown",
+    };
+    match (reason, raw) {
+        (StopReason::Unknown, Some(raw)) => format!("{name} (raw: {raw})"),
+        _ => name.to_string(),
+    }
 }
 
 fn user_with_glossary(glossary: &GlossaryFile, kind: &str, body: &str) -> String {
@@ -375,6 +400,36 @@ pub fn translate_claim(
     Ok(zh)
 }
 
+/// Consecutive per-item failures tolerated before a batch helper aborts.
+/// During a provider outage every stale item would otherwise go through the
+/// retrying client's backoff — an unattended daily tail hammering the API.
+const MAX_CONSECUTIVE_ERRORS: usize = 3;
+
+/// Load a batch snapshot, distinguishing a MISSING projection (default, the
+/// steady state before the first run) from a CORRUPT one (exists but won't
+/// parse / schema-mismatched). Corrupt must fail once, loud and clear —
+/// defaulting to empty would turn every per-item `load()?` into N permanent
+/// errors that never heal.
+macro_rules! load_snapshot {
+    ($ty:ty, $vault_root:expr, $rel:expr) => {
+        match <$ty>::load($vault_root) {
+            Ok(f) => f,
+            Err(e) if $vault_root.join($rel).is_file() => {
+                return (
+                    0,
+                    0,
+                    vec![format!(
+                        "{}: projection corrupt ({e}) — delete the file to rebuild",
+                        $rel
+                    )],
+                );
+            }
+            // Vanished between the existence check and the read — treat as missing.
+            Err(_) => <$ty>::default(),
+        }
+    };
+}
+
 /// Batch-translate missing claims. Returns (done, skipped, errors).
 pub fn translate_claims_batch(
     vault_root: &Path,
@@ -387,18 +442,32 @@ pub fn translate_claims_batch(
     let mut done = 0usize;
     let mut skipped = 0usize;
     let mut errors = Vec::new();
-    let existing = ClaimsZhFile::load(vault_root).unwrap_or_default();
+    let mut consecutive_errors = 0usize;
+    let existing = load_snapshot!(ClaimsZhFile, vault_root, CLAIMS_ZH_REL);
     for (key, en) in claims {
         if max > 0 && done >= max {
             break;
         }
         if !force && existing.get_fresh(key, en).is_some() {
             skipped += 1;
+            consecutive_errors = 0;
             continue;
         }
         match translate_claim(vault_root, key, en, client, model, force) {
-            Ok(_) => done += 1,
-            Err(e) => errors.push(format!("{key}: {e}")),
+            Ok(_) => {
+                done += 1;
+                consecutive_errors = 0;
+            }
+            Err(e) => {
+                errors.push(format!("{key}: {e}"));
+                consecutive_errors += 1;
+                if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
+                    errors.push(format!(
+                        "aborting batch after {MAX_CONSECUTIVE_ERRORS} consecutive failures (provider outage?)"
+                    ));
+                    break;
+                }
+            }
         }
     }
     (done, skipped, errors)
@@ -454,18 +523,32 @@ pub fn topup_cards_zh(
     let mut done = 0usize;
     let mut skipped = 0usize;
     let mut errors = Vec::new();
-    let existing = CardsZhFile::load(vault_root).unwrap_or_default();
+    let mut consecutive_errors = 0usize;
+    let existing = load_snapshot!(CardsZhFile, vault_root, CARDS_ZH_REL);
     for (id, title, content) in cards {
         if max > 0 && done >= max {
             break;
         }
         if !force && existing.get_fresh(id, title, content).is_some() {
             skipped += 1;
+            consecutive_errors = 0;
             continue;
         }
         match translate_card(vault_root, id, title, content, client, model, force) {
-            Ok(_) => done += 1,
-            Err(e) => errors.push(format!("{id}: {e}")),
+            Ok(_) => {
+                done += 1;
+                consecutive_errors = 0;
+            }
+            Err(e) => {
+                errors.push(format!("{id}: {e}"));
+                consecutive_errors += 1;
+                if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
+                    errors.push(format!(
+                        "aborting batch after {MAX_CONSECUTIVE_ERRORS} consecutive failures (provider outage?)"
+                    ));
+                    break;
+                }
+            }
         }
     }
     (done, skipped, errors)
@@ -560,7 +643,8 @@ pub fn topup_theme_pages_zh(
     let mut done = 0usize;
     let mut skipped = 0usize;
     let mut errors = Vec::new();
-    let existing = ThemePagesZhFile::load(vault_root).unwrap_or_default();
+    let mut consecutive_errors = 0usize;
+    let existing = load_snapshot!(ThemePagesZhFile, vault_root, THEME_PAGES_ZH_REL);
     for (community_id, sections) in pages {
         if max > 0 && done >= max {
             break;
@@ -568,11 +652,24 @@ pub fn topup_theme_pages_zh(
         let en_hash = theme_page_en_hash(sections);
         if !force && existing.get_fresh(*community_id, &en_hash).is_some() {
             skipped += 1;
+            consecutive_errors = 0;
             continue;
         }
         match translate_theme_page(vault_root, *community_id, sections, client, model, force) {
-            Ok(_) => done += 1,
-            Err(e) => errors.push(format!("community {community_id}: {e}")),
+            Ok(_) => {
+                done += 1;
+                consecutive_errors = 0;
+            }
+            Err(e) => {
+                errors.push(format!("community {community_id}: {e}"));
+                consecutive_errors += 1;
+                if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
+                    errors.push(format!(
+                        "aborting batch after {MAX_CONSECUTIVE_ERRORS} consecutive failures (provider outage?)"
+                    ));
+                    break;
+                }
+            }
         }
     }
     (done, skipped, errors)
@@ -634,7 +731,17 @@ fn save_json<T: Serialize>(vault_root: &Path, rel: &str, value: &T) -> Result<()
         fs::create_dir_all(p).map_err(|e| format!("mkdir: {e}"))?;
     }
     let raw = serde_json::to_string_pretty(value).map_err(|e| e.to_string())?;
-    fs::write(&path, raw).map_err(|e| format!("write {rel}: {e}"))
+    // Atomic publish: tmp + rename in the same directory, so concurrent
+    // readers (the portal serve worker answering HTTP requests) never see a
+    // torn projection mid-write.
+    let mut tmp_os = path.clone().into_os_string();
+    tmp_os.push(".tmp");
+    let tmp = std::path::PathBuf::from(tmp_os);
+    if let Err(e) = fs::write(&tmp, raw) {
+        let _ = fs::remove_file(&tmp);
+        return Err(format!("write {rel}: {e}"));
+    }
+    fs::rename(&tmp, &path).map_err(|e| format!("rename {rel}: {e}"))
 }
 
 #[cfg(test)]
@@ -717,12 +824,35 @@ mod tests {
     }
 
     /// Client whose every call fails (transport-style outage).
-    struct AlwaysFailsClient;
+    #[derive(Default)]
+    struct AlwaysFailsClient {
+        calls: usize,
+    }
 
     impl ModelClient for AlwaysFailsClient {
         fn call(&mut self, _request: &ModelRequest) -> Result<ModelReply, CallError> {
+            self.calls += 1;
             Err(CallError::Transport {
                 detail: "simulated outage".into(),
+            })
+        }
+    }
+
+    /// Client whose replies are truncated at the token cap.
+    struct MaxTokensClient;
+
+    impl ModelClient for MaxTokensClient {
+        fn call(&mut self, _request: &ModelRequest) -> Result<ModelReply, CallError> {
+            Ok(ModelReply {
+                model: "truncated".into(),
+                text: "partial translation".into(),
+                stop_reason: StopReason::MaxTokens,
+                usage: Usage {
+                    input_tokens: 1,
+                    output_tokens: 1,
+                },
+                blocks: None,
+                raw_stop_reason: None,
             })
         }
     }
@@ -776,12 +906,160 @@ mod tests {
     fn topup_cards_zh_errors_are_collected_not_thrown() {
         let tmp = tempfile::tempdir().unwrap();
         let cards = vec![card("c1", "T", "B")];
-        let mut client = AlwaysFailsClient;
+        let mut client = AlwaysFailsClient::default();
         let (done, skipped, errors) =
             topup_cards_zh(tmp.path(), &cards, &mut client, "m", false, 0);
         assert_eq!((done, skipped), (0, 0));
         assert_eq!(errors.len(), 1);
         assert!(errors[0].contains("c1"), "{}", errors[0]);
+    }
+
+    /// Circuit breaker: 3 consecutive failures abort the batch instead of
+    /// attempting every stale item through the retrying client's backoff
+    /// (provider outage ⇒ a daily tail must not hammer the API).
+    #[test]
+    fn topup_cards_zh_aborts_after_three_consecutive_failures() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cards: Vec<_> = (0..5).map(|i| card(&format!("c{i}"), "T", "B")).collect();
+        let mut client = AlwaysFailsClient::default();
+        let (done, skipped, errors) =
+            topup_cards_zh(tmp.path(), &cards, &mut client, "m", false, 0);
+        assert_eq!((done, skipped), (0, 0));
+        assert_eq!(client.calls, 3, "abort after 3 consecutive failures");
+        assert_eq!(errors.len(), 4, "3 per-item errors + 1 summary");
+        assert!(errors[3].contains("provider outage"), "{}", errors[3]);
+    }
+
+    /// A MaxTokens reply is an error, never persisted — stored with a matching
+    /// en_hash, a truncated translation would be treated as fresh forever.
+    #[test]
+    fn max_tokens_reply_errors_and_persists_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cards = vec![card("c1", "T", "B")];
+        let mut client = MaxTokensClient;
+        let (done, skipped, errors) =
+            topup_cards_zh(tmp.path(), &cards, &mut client, "m", false, 0);
+        assert_eq!((done, skipped), (0, 0));
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("stop_reason=max_tokens"), "{}", errors[0]);
+        assert!(
+            !tmp.path().join(CARDS_ZH_REL).exists(),
+            "truncated translations must never be written"
+        );
+    }
+
+    /// Write unparseable bytes at a projection path; returns the bytes written
+    /// so the caller can assert the corrupt file survives the batch untouched.
+    fn write_corrupt(vault: &std::path::Path, rel: &str) -> String {
+        let path = vault.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let bytes = "{corrupt not json";
+        std::fs::write(&path, bytes).unwrap();
+        bytes.to_string()
+    }
+
+    #[test]
+    fn topup_cards_zh_corrupt_projection_fails_once_and_preserves_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let corrupt = write_corrupt(tmp.path(), CARDS_ZH_REL);
+        let cards = vec![card("c1", "T", "B")];
+        let mut client = CountingClient::new("# 标题\n\n正文");
+        let (done, skipped, errors) =
+            topup_cards_zh(tmp.path(), &cards, &mut client, "m", false, 0);
+        assert_eq!((done, skipped), (0, 0));
+        assert_eq!(errors.len(), 1, "one clear error, not N per-item errors");
+        assert!(errors[0].contains(CARDS_ZH_REL), "{}", errors[0]);
+        assert!(errors[0].contains("corrupt"), "{}", errors[0]);
+        assert_eq!(client.calls, 0, "no item attempted against a corrupt projection");
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join(CARDS_ZH_REL)).unwrap(),
+            corrupt,
+            "the corrupt file must NOT be overwritten"
+        );
+    }
+
+    #[test]
+    fn topup_theme_pages_zh_corrupt_projection_fails_once_and_preserves_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let corrupt = write_corrupt(tmp.path(), THEME_PAGES_ZH_REL);
+        let pages = vec![(7i64, vec![("Memory".to_string(), "Persists.".to_string())])];
+        let mut client = CountingClient::new("## 记忆\n\n持久化。");
+        let (done, skipped, errors) =
+            topup_theme_pages_zh(tmp.path(), &pages, &mut client, "m", false, 0);
+        assert_eq!((done, skipped), (0, 0));
+        assert_eq!(errors.len(), 1, "one clear error, not N per-item errors");
+        assert!(errors[0].contains(THEME_PAGES_ZH_REL), "{}", errors[0]);
+        assert!(errors[0].contains("corrupt"), "{}", errors[0]);
+        assert_eq!(client.calls, 0, "no item attempted against a corrupt projection");
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join(THEME_PAGES_ZH_REL)).unwrap(),
+            corrupt,
+            "the corrupt file must NOT be overwritten"
+        );
+    }
+
+    // ---- translate_claims_batch ----
+
+    fn claim(key: &str, text: &str) -> (String, String) {
+        (key.to_string(), text.to_string())
+    }
+
+    #[test]
+    fn translate_claims_batch_writes_delta_then_second_run_is_zero_call_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let claims = vec![
+            claim("ck-1", "Memory is a budget."),
+            claim("ck-2", "Context compounds."),
+        ];
+        let mut client = CountingClient::new("译文");
+        let (done, skipped, errors) =
+            translate_claims_batch(tmp.path(), &claims, &mut client, "m", false, 0);
+        assert_eq!((done, skipped), (2, 0));
+        assert!(errors.is_empty());
+        assert_eq!(client.calls, 2);
+        let file = ClaimsZhFile::load(tmp.path()).unwrap();
+        assert_eq!(file.entries.len(), 2);
+        assert!(file.entries.contains_key("ck-1"));
+
+        // Unchanged authority: a fresh client must NEVER be called.
+        let mut client2 = CountingClient::new("译文");
+        let (done, skipped, errors) =
+            translate_claims_batch(tmp.path(), &claims, &mut client2, "m", false, 0);
+        assert_eq!((done, skipped), (0, 2));
+        assert!(errors.is_empty());
+        assert_eq!(client2.calls, 0, "unchanged authority = 0 LLM calls");
+    }
+
+    #[test]
+    fn translate_claims_batch_errors_are_collected_not_thrown() {
+        let tmp = tempfile::tempdir().unwrap();
+        let claims = vec![claim("ck-1", "Claim one.")];
+        let mut client = AlwaysFailsClient::default();
+        let (done, skipped, errors) =
+            translate_claims_batch(tmp.path(), &claims, &mut client, "m", false, 0);
+        assert_eq!((done, skipped), (0, 0));
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("ck-1"), "{}", errors[0]);
+    }
+
+    #[test]
+    fn translate_claims_batch_corrupt_projection_fails_once_and_preserves_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let corrupt = write_corrupt(tmp.path(), CLAIMS_ZH_REL);
+        let claims = vec![claim("ck-1", "Claim one.")];
+        let mut client = CountingClient::new("译文");
+        let (done, skipped, errors) =
+            translate_claims_batch(tmp.path(), &claims, &mut client, "m", false, 0);
+        assert_eq!((done, skipped), (0, 0));
+        assert_eq!(errors.len(), 1, "one clear error, not N per-item errors");
+        assert!(errors[0].contains(CLAIMS_ZH_REL), "{}", errors[0]);
+        assert!(errors[0].contains("corrupt"), "{}", errors[0]);
+        assert_eq!(client.calls, 0, "no item attempted against a corrupt projection");
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join(CLAIMS_ZH_REL)).unwrap(),
+            corrupt,
+            "the corrupt file must NOT be overwritten"
+        );
     }
 
     #[test]

--- a/crates/ovp-memory/src/bilingual.rs
+++ b/crates/ovp-memory/src/bilingual.rs
@@ -405,6 +405,11 @@ pub fn translate_claim(
 /// retrying client's backoff — an unattended daily tail hammering the API.
 const MAX_CONSECUTIVE_ERRORS: usize = 3;
 
+/// Substring marking the single corrupt-projection error produced by
+/// `load_snapshot!` — the manual CLIs match on it to fail loud (nonzero)
+/// where the automatic tails only warn. (codex P2)
+pub const CORRUPT_PROJECTION_MARKER: &str = "projection corrupt";
+
 /// Load a batch snapshot, distinguishing a MISSING projection (default, the
 /// steady state before the first run) from a CORRUPT one (exists but won't
 /// parse / schema-mismatched). Corrupt must fail once, loud and clear —
@@ -419,8 +424,8 @@ macro_rules! load_snapshot {
                     0,
                     0,
                     vec![format!(
-                        "{}: projection corrupt ({e}) — delete the file to rebuild",
-                        $rel
+                        "{}: {} ({e}) — delete the file to rebuild",
+                        $rel, CORRUPT_PROJECTION_MARKER
                     )],
                 );
             }
@@ -449,8 +454,10 @@ pub fn translate_claims_batch(
             break;
         }
         if !force && existing.get_fresh(key, en).is_some() {
+            // A fresh skip makes no provider call, so it must NOT reset the
+            // outage breaker — interleaved cache hits would otherwise let an
+            // outage retry every stale item (codex P2).
             skipped += 1;
-            consecutive_errors = 0;
             continue;
         }
         match translate_claim(vault_root, key, en, client, model, force) {
@@ -530,8 +537,9 @@ pub fn topup_cards_zh(
             break;
         }
         if !force && existing.get_fresh(id, title, content).is_some() {
+            // Fresh skip = no provider call — must not reset the outage
+            // breaker (see translate_claims_batch).
             skipped += 1;
-            consecutive_errors = 0;
             continue;
         }
         match translate_card(vault_root, id, title, content, client, model, force) {
@@ -651,8 +659,9 @@ pub fn topup_theme_pages_zh(
         }
         let en_hash = theme_page_en_hash(sections);
         if !force && existing.get_fresh(*community_id, &en_hash).is_some() {
+            // Fresh skip = no provider call — must not reset the outage
+            // breaker (see translate_claims_batch).
             skipped += 1;
-            consecutive_errors = 0;
             continue;
         }
         match translate_theme_page(vault_root, *community_id, sections, client, model, force) {
@@ -912,6 +921,37 @@ mod tests {
         assert_eq!((done, skipped), (0, 0));
         assert_eq!(errors.len(), 1);
         assert!(errors[0].contains("c1"), "{}", errors[0]);
+    }
+
+    /// Interleaved fresh hits make no provider call, so they must not reset
+    /// the outage breaker — otherwise a half-populated projection would retry
+    /// every stale card through the backoff during an outage (codex P2).
+    #[test]
+    fn topup_cards_zh_breaker_ignores_fresh_skips() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Populate c1/c3/c5 as fresh entries.
+        let fresh = vec![
+            card("c1", "T", "B"),
+            card("c3", "T", "B"),
+            card("c5", "T", "B"),
+        ];
+        let mut seed = CountingClient::new("# 标题\n\n正文");
+        topup_cards_zh(tmp.path(), &fresh, &mut seed, "m", false, 0);
+        // Interleave fresh (skip) with stale (failing) cards.
+        let mixed = vec![
+            card("c1", "T", "B"),
+            card("c2", "T", "B"),
+            card("c3", "T", "B"),
+            card("c4", "T", "B"),
+            card("c5", "T", "B"),
+            card("c6", "T", "B"),
+        ];
+        let mut client = AlwaysFailsClient::default();
+        let (done, skipped, errors) =
+            topup_cards_zh(tmp.path(), &mixed, &mut client, "m", false, 0);
+        assert_eq!((done, skipped), (0, 3));
+        assert_eq!(client.calls, 3, "breaker trips on 3 failed CALLS despite interleaved fresh skips");
+        assert!(errors.iter().any(|e| e.contains("provider outage")));
     }
 
     /// Circuit breaker: 3 consecutive failures abort the batch instead of

--- a/crates/ovp-memory/src/bilingual.rs
+++ b/crates/ovp-memory/src/bilingual.rs
@@ -424,7 +424,7 @@ macro_rules! load_snapshot {
                     0,
                     0,
                     vec![format!(
-                        "{}: {} ({e}) — delete the file to rebuild",
+                        "{}: {} ({e}) — if the file is unparseable, delete it to rebuild",
                         $rel, CORRUPT_PROJECTION_MARKER
                     )],
                 );
@@ -448,9 +448,13 @@ pub fn translate_claims_batch(
     let mut skipped = 0usize;
     let mut errors = Vec::new();
     let mut consecutive_errors = 0usize;
+    // `max` caps provider ATTEMPTS, not successes: each failure is still a
+    // paid call, and alternating success/failure would otherwise blow the
+    // budget without ever tripping the breaker (CodeRabbit).
+    let mut attempts = 0usize;
     let existing = load_snapshot!(ClaimsZhFile, vault_root, CLAIMS_ZH_REL);
     for (key, en) in claims {
-        if max > 0 && done >= max {
+        if max > 0 && attempts >= max {
             break;
         }
         if !force && existing.get_fresh(key, en).is_some() {
@@ -460,6 +464,7 @@ pub fn translate_claims_batch(
             skipped += 1;
             continue;
         }
+        attempts += 1;
         match translate_claim(vault_root, key, en, client, model, force) {
             Ok(_) => {
                 done += 1;
@@ -531,9 +536,11 @@ pub fn topup_cards_zh(
     let mut skipped = 0usize;
     let mut errors = Vec::new();
     let mut consecutive_errors = 0usize;
+    // `max` caps provider attempts, not successes (see translate_claims_batch).
+    let mut attempts = 0usize;
     let existing = load_snapshot!(CardsZhFile, vault_root, CARDS_ZH_REL);
     for (id, title, content) in cards {
-        if max > 0 && done >= max {
+        if max > 0 && attempts >= max {
             break;
         }
         if !force && existing.get_fresh(id, title, content).is_some() {
@@ -542,6 +549,7 @@ pub fn topup_cards_zh(
             skipped += 1;
             continue;
         }
+        attempts += 1;
         match translate_card(vault_root, id, title, content, client, model, force) {
             Ok(_) => {
                 done += 1;
@@ -652,9 +660,11 @@ pub fn topup_theme_pages_zh(
     let mut skipped = 0usize;
     let mut errors = Vec::new();
     let mut consecutive_errors = 0usize;
+    // `max` caps provider attempts, not successes (see translate_claims_batch).
+    let mut attempts = 0usize;
     let existing = load_snapshot!(ThemePagesZhFile, vault_root, THEME_PAGES_ZH_REL);
     for (community_id, sections) in pages {
-        if max > 0 && done >= max {
+        if max > 0 && attempts >= max {
             break;
         }
         let en_hash = theme_page_en_hash(sections);
@@ -664,6 +674,7 @@ pub fn topup_theme_pages_zh(
             skipped += 1;
             continue;
         }
+        attempts += 1;
         match translate_theme_page(vault_root, *community_id, sections, client, model, force) {
             Ok(_) => {
                 done += 1;
@@ -742,9 +753,15 @@ fn save_json<T: Serialize>(vault_root: &Path, rel: &str, value: &T) -> Result<()
     let raw = serde_json::to_string_pretty(value).map_err(|e| e.to_string())?;
     // Atomic publish: tmp + rename in the same directory, so concurrent
     // readers (the portal serve worker answering HTTP requests) never see a
-    // torn projection mid-write.
+    // torn projection mid-write. The tmp name is unique per process+write —
+    // two writers sharing a fixed `<dest>.tmp` could rename each other's
+    // half-written file (CodeRabbit).
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
     let mut tmp_os = path.clone().into_os_string();
-    tmp_os.push(".tmp");
+    tmp_os.push(format!(".tmp.{}-{nanos}", std::process::id()));
     let tmp = std::path::PathBuf::from(tmp_os);
     if let Err(e) = fs::write(&tmp, raw) {
         let _ = fs::remove_file(&tmp);
@@ -968,6 +985,20 @@ mod tests {
         assert_eq!(client.calls, 3, "abort after 3 consecutive failures");
         assert_eq!(errors.len(), 4, "3 per-item errors + 1 summary");
         assert!(errors[3].contains("provider outage"), "{}", errors[3]);
+    }
+
+    /// `max` caps provider ATTEMPTS, not successes: with an always-failing
+    /// client and max=2, exactly 2 calls are made — old behavior would run
+    /// to the 3-failure breaker (CodeRabbit).
+    #[test]
+    fn topup_cards_zh_max_counts_attempts_not_successes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cards: Vec<_> = (0..5).map(|i| card(&format!("c{i}"), "T", "B")).collect();
+        let mut client = AlwaysFailsClient::default();
+        let (_done, _skipped, errors) =
+            topup_cards_zh(tmp.path(), &cards, &mut client, "m", false, 2);
+        assert_eq!(client.calls, 2, "max=2 attempts even when all fail");
+        assert_eq!(errors.len(), 2, "no breaker summary — cap hit first");
     }
 
     /// A MaxTokens reply is an error, never persisted — stored with a matching

--- a/crates/ovp-memory/src/bilingual.rs
+++ b/crates/ovp-memory/src/bilingual.rs
@@ -354,10 +354,10 @@ pub fn translate_claim(
     force: bool,
 ) -> Result<String, String> {
     let mut file = ClaimsZhFile::load(vault_root)?;
-    if !force {
-        if let Some(zh) = file.get_fresh(claim_key, claim_en) {
-            return Ok(zh.to_string());
-        }
+    if !force
+        && let Some(zh) = file.get_fresh(claim_key, claim_en)
+    {
+        return Ok(zh.to_string());
     }
     let glossary = GlossaryFile::load(vault_root).unwrap_or_default();
     let user = user_with_glossary(&glossary, "knowledge claim", claim_en);
@@ -415,10 +415,10 @@ pub fn translate_card(
     force: bool,
 ) -> Result<CardZhEntry, String> {
     let mut file = CardsZhFile::load(vault_root)?;
-    if !force {
-        if let Some(e) = file.get_fresh(card_id, title, content) {
-            return Ok(e.clone());
-        }
+    if !force
+        && let Some(e) = file.get_fresh(card_id, title, content)
+    {
+        return Ok(e.clone());
     }
     let glossary = GlossaryFile::load(vault_root).unwrap_or_default();
     let blob = format!("# {title}\n\n{content}");
@@ -438,6 +438,39 @@ pub fn translate_card(
     Ok(entry)
 }
 
+/// Top up the cards_zh projection for `cards` ((card_id, title, content)),
+/// translating only stale/missing entries through `get_fresh`. Shared by the
+/// manual `source-work memory-zh` CLI and the daily bilingual tail — an
+/// unchanged authority (`force = false`) costs zero LLM calls.
+/// Returns (done, skipped, errors).
+pub fn topup_cards_zh(
+    vault_root: &Path,
+    cards: &[(String, String, String)],
+    client: &mut dyn ModelClient,
+    model: &str,
+    force: bool,
+    max: usize,
+) -> (usize, usize, Vec<String>) {
+    let mut done = 0usize;
+    let mut skipped = 0usize;
+    let mut errors = Vec::new();
+    let existing = CardsZhFile::load(vault_root).unwrap_or_default();
+    for (id, title, content) in cards {
+        if max > 0 && done >= max {
+            break;
+        }
+        if !force && existing.get_fresh(id, title, content).is_some() {
+            skipped += 1;
+            continue;
+        }
+        match translate_card(vault_root, id, title, content, client, model, force) {
+            Ok(_) => done += 1,
+            Err(e) => errors.push(format!("{id}: {e}")),
+        }
+    }
+    (done, skipped, errors)
+}
+
 fn split_card_zh(zh: &str, fallback_title: &str) -> (String, String) {
     let t = zh.trim();
     if let Some(rest) = t.strip_prefix("# ") {
@@ -447,10 +480,10 @@ fn split_card_zh(zh: &str, fallback_title: &str) -> (String, String) {
         return (rest.trim().to_string(), String::new());
     }
     // No heading — use first line as title if short.
-    if let Some((first, body)) = t.split_once('\n') {
-        if first.chars().count() <= 80 {
-            return (first.trim().to_string(), body.trim().to_string());
-        }
+    if let Some((first, body)) = t.split_once('\n')
+        && first.chars().count() <= 80
+    {
+        return (first.trim().to_string(), body.trim().to_string());
     }
     (fallback_title.to_string(), t.to_string())
 }
@@ -477,10 +510,10 @@ pub fn translate_theme_page(
     let en_hash = theme_page_en_hash(sections);
     let mut file = ThemePagesZhFile::load(vault_root)?;
     let key = community_id.to_string();
-    if !force {
-        if let Some(e) = file.get_fresh(community_id, &en_hash) {
-            return Ok(e.clone());
-        }
+    if !force
+        && let Some(e) = file.get_fresh(community_id, &en_hash)
+    {
+        return Ok(e.clone());
     }
     let glossary = GlossaryFile::load(vault_root).unwrap_or_default();
     let mut out_sections = Vec::new();
@@ -511,6 +544,40 @@ pub fn translate_theme_page(
     Ok(entry)
 }
 
+/// Top up the theme_pages_zh projection for `pages`
+/// ((community_id, [(heading, body)])), translating only stale/missing
+/// entries through `get_fresh`. Shared by the manual `source-work memory-zh`
+/// CLI and the crystal-theme-pages bilingual tail — an unchanged authority
+/// (`force = false`) costs zero LLM calls. Returns (done, skipped, errors).
+pub fn topup_theme_pages_zh(
+    vault_root: &Path,
+    pages: &[(i64, Vec<(String, String)>)],
+    client: &mut dyn ModelClient,
+    model: &str,
+    force: bool,
+    max: usize,
+) -> (usize, usize, Vec<String>) {
+    let mut done = 0usize;
+    let mut skipped = 0usize;
+    let mut errors = Vec::new();
+    let existing = ThemePagesZhFile::load(vault_root).unwrap_or_default();
+    for (community_id, sections) in pages {
+        if max > 0 && done >= max {
+            break;
+        }
+        let en_hash = theme_page_en_hash(sections);
+        if !force && existing.get_fresh(*community_id, &en_hash).is_some() {
+            skipped += 1;
+            continue;
+        }
+        match translate_theme_page(vault_root, *community_id, sections, client, model, force) {
+            Ok(_) => done += 1,
+            Err(e) => errors.push(format!("community {community_id}: {e}")),
+        }
+    }
+    (done, skipped, errors)
+}
+
 fn split_section_zh(zh: &str, fallback_heading: &str) -> (String, String) {
     let t = zh.trim();
     for prefix in ["## ", "# "] {
@@ -526,14 +593,11 @@ fn split_section_zh(zh: &str, fallback_heading: &str) -> (String, String) {
 
 // ---- IO helpers ----
 
-fn load_map_file<T: for<'de> Deserialize<'de> + Default>(
+fn load_map_file<T: for<'de> Deserialize<'de> + Default + SchemaCheck>(
     vault_root: &Path,
     rel: &str,
     schema: &str,
-) -> Result<T, String>
-where
-    T: SchemaCheck,
-{
+) -> Result<T, String> {
     let path = vault_root.join(rel);
     if !path.is_file() {
         return Ok(T::default());
@@ -614,5 +678,157 @@ mod tests {
         let (t, b) = split_card_zh("# 标题\n\n正文段落", "Fallback");
         assert_eq!(t, "标题");
         assert!(b.contains("正文"));
+    }
+
+    // ---- topup helpers (shared by manual CLIs + bilingual tails) ----
+
+    use ovp_llm::{CallError, ModelReply, StopReason, Usage};
+
+    /// Scripted client: counts calls and replies with a fixed zh blob.
+    struct CountingClient {
+        calls: usize,
+        reply: String,
+    }
+
+    impl CountingClient {
+        fn new(reply: &str) -> Self {
+            Self {
+                calls: 0,
+                reply: reply.to_string(),
+            }
+        }
+    }
+
+    impl ModelClient for CountingClient {
+        fn call(&mut self, _request: &ModelRequest) -> Result<ModelReply, CallError> {
+            self.calls += 1;
+            Ok(ModelReply {
+                model: "counting".into(),
+                text: self.reply.clone(),
+                stop_reason: StopReason::EndTurn,
+                usage: Usage {
+                    input_tokens: 1,
+                    output_tokens: 1,
+                },
+                blocks: None,
+                raw_stop_reason: None,
+            })
+        }
+    }
+
+    /// Client whose every call fails (transport-style outage).
+    struct AlwaysFailsClient;
+
+    impl ModelClient for AlwaysFailsClient {
+        fn call(&mut self, _request: &ModelRequest) -> Result<ModelReply, CallError> {
+            Err(CallError::Transport {
+                detail: "simulated outage".into(),
+            })
+        }
+    }
+
+    fn card(id: &str, title: &str, content: &str) -> (String, String, String) {
+        (id.to_string(), title.to_string(), content.to_string())
+    }
+
+    #[test]
+    fn topup_cards_zh_writes_delta_then_second_run_is_zero_call_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cards = vec![
+            card("c1", "Memory budget", "Memory is a budget."),
+            card("c2", "Context", "Context compounds."),
+        ];
+        let mut client = CountingClient::new("# 标题\n\n正文");
+        let (done, skipped, errors) =
+            topup_cards_zh(tmp.path(), &cards, &mut client, "m", false, 0);
+        assert_eq!((done, skipped), (2, 0));
+        assert!(errors.is_empty());
+        assert_eq!(client.calls, 2);
+        // Projection file written, keyed by card id.
+        let file = CardsZhFile::load(tmp.path()).unwrap();
+        assert_eq!(file.entries.len(), 2);
+        assert!(file.entries.contains_key("c1"));
+
+        // Unchanged authority: a fresh client must NEVER be called.
+        let mut client2 = CountingClient::new("# 标题\n\n正文");
+        let (done, skipped, errors) =
+            topup_cards_zh(tmp.path(), &cards, &mut client2, "m", false, 0);
+        assert_eq!((done, skipped), (0, 2));
+        assert!(errors.is_empty());
+        assert_eq!(client2.calls, 0, "unchanged authority = 0 LLM calls");
+
+        // One changed card → exactly one call.
+        let cards2 = vec![
+            card("c1", "Memory budget", "Memory is a SCARCE budget."),
+            card("c2", "Context", "Context compounds."),
+        ];
+        let mut client3 = CountingClient::new("# 新标题\n\n新正文");
+        let (done, skipped, errors) =
+            topup_cards_zh(tmp.path(), &cards2, &mut client3, "m", false, 0);
+        assert_eq!((done, skipped), (1, 1));
+        assert!(errors.is_empty());
+        assert_eq!(client3.calls, 1);
+        let file = CardsZhFile::load(tmp.path()).unwrap();
+        assert_eq!(file.entries["c1"].title_zh, "新标题");
+    }
+
+    #[test]
+    fn topup_cards_zh_errors_are_collected_not_thrown() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cards = vec![card("c1", "T", "B")];
+        let mut client = AlwaysFailsClient;
+        let (done, skipped, errors) =
+            topup_cards_zh(tmp.path(), &cards, &mut client, "m", false, 0);
+        assert_eq!((done, skipped), (0, 0));
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("c1"), "{}", errors[0]);
+    }
+
+    #[test]
+    fn topup_theme_pages_zh_writes_delta_then_second_run_is_zero_call_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pages = vec![(
+            7i64,
+            vec![(
+                "Memory".to_string(),
+                "Persists [claim:ck-a].".to_string(),
+            )],
+        )];
+        let mut client = CountingClient::new("## 记忆\n\n持久化 [claim:ck-a]。");
+        let (done, skipped, errors) =
+            topup_theme_pages_zh(tmp.path(), &pages, &mut client, "m", false, 0);
+        assert_eq!((done, skipped), (1, 0));
+        assert!(errors.is_empty());
+        assert_eq!(client.calls, 1, "one section = one call");
+        let file = ThemePagesZhFile::load(tmp.path()).unwrap();
+        let entry = &file.pages["7"];
+        assert_eq!(entry.sections[0].heading, "记忆");
+        assert!(
+            entry.sections[0].body.contains("[claim:ck-a]"),
+            "citation tokens preserved"
+        );
+
+        // Unchanged authority: zero calls.
+        let mut client2 = CountingClient::new("## 记忆\n\n持久化 [claim:ck-a]。");
+        let (done, skipped, errors) =
+            topup_theme_pages_zh(tmp.path(), &pages, &mut client2, "m", false, 0);
+        assert_eq!((done, skipped), (0, 1));
+        assert!(errors.is_empty());
+        assert_eq!(client2.calls, 0, "unchanged authority = 0 LLM calls");
+
+        // Changed body → retranslated.
+        let pages2 = vec![(
+            7i64,
+            vec![(
+                "Memory".to_string(),
+                "Persists and compounds [claim:ck-a].".to_string(),
+            )],
+        )];
+        let mut client3 = CountingClient::new("## 记忆\n\n持久化并复利 [claim:ck-a]。");
+        let (done, skipped, errors) =
+            topup_theme_pages_zh(tmp.path(), &pages2, &mut client3, "m", false, 0);
+        assert_eq!((done, skipped), (1, 0));
+        assert!(errors.is_empty());
+        assert_eq!(client3.calls, 1);
     }
 }

--- a/evolution/candidates/bilingual_tail-v1.json
+++ b/evolution/candidates/bilingual_tail-v1.json
@@ -1,0 +1,28 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "bilingual_tail-v1",
+  "base_version": "none",
+  "target_version": "v1",
+  "surface": "runtime",
+  "component": "runtime.bilingual_tail",
+  "hypothesis": "RUNTIME surface: wire the EXISTING `auto_claim_zh` / `auto_memory_zh` flags (`.ovp/source-work.toml`, already parsed but today only biasing manual CLIs) as best-effort TAIL STAGES of the commands that mutate the English authority — `daily` (reader → cards_zh delta), `crystal-synth` (ledger → claims_zh delta), `crystal-theme-pages` (pages → theme_pages_zh delta). Each tail reuses the existing `ovp-memory::bilingual` translate functions and `get_fresh` content-hash skip, so an unchanged authority costs ZERO LLM calls and only the delta is translated. Predicted: after any live daily/crystal run, the portal's zh surfaces are fresh without a manual `source-work claims-zh|memory-zh` pass; flag-off and replay-mode runs are byte-identical to today (no LLM calls added); tail failures surface as warnings and never change the run's terminal status.",
+  "predicted_delta": {
+    "operational_reliability": "zh projections stop drifting behind the EN authority — today they only advance when an operator remembers the manual CLI (the 2026-08 dogfood gap: 994 claims + 15 theme pages + all cards untranslated for days); after wiring, every scheduled daily/crystal run self-heals the delta, and a network outage just defers zh to the next run instead of leaving a silent permanent hole",
+    "coverage": "portal zh coverage (claims / theme overview / reader cards) tracks the EN authority within one run instead of being weeks stale; `zh ready X/N` on the theme page converges to N without operator action"
+  },
+  "guardrails": {
+    "en_authority_untouched": "tails only WRITE the rebuildable projections `.ovp/crystal/claims_zh.json|cards_zh.json|theme_pages_zh.json`; the crystal ledger, reader packs, and theme_pages.json are never opened for write — a tail crash cannot corrupt the English authority it follows",
+    "flag_off_bytes_unchanged": "auto_claim_zh=false / auto_memory_zh=false (or an unparseable source-work.toml, which warns + skips the tail) reproduces today's behavior exactly; existing daily/crystal tests pass unmodified because the default test fixture path uses replay + no config file... with tails gated OFF for replay",
+    "replay_mode_no_calls": "tails run only when the parent command's client kind is LIVE; replay/offline runs skip the tail (NeverCallsClient must never be hit), so offline determinism and cassette-replay CI stay intact",
+    "failure_isolation": "any tail error (transport, decode, config, index build) is caught, printed as a warn line, and appended to the run report warnings where one exists; the parent command's exit code and terminal status are decided by the EN phases alone",
+    "incremental_only": "tails translate strictly through get_fresh (content-hash keyed) — re-running on an unchanged authority is a 0-call no-op; no --force semantics are exposed to the tail, so a wedged projection can only be rebuilt via the existing manual CLI",
+    "no_queue_interaction": "tails run inline after the parent phase and never touch `.ovp/source-work-queue.json` or the worker lock — the queue's single-writer and priority invariants are unaffected"
+  },
+  "eval_plan": {
+    "replay_set": "ovp-cli tests with a scripted/replay client on a temp vault: (1) daily with auto_memory_zh default + replay client → tail skipped, no cards_zh.json, run output/status identical to pre-change; (2) live-kind call sites factored so the tail body is unit-tested against a fake ModelClient — cards delta writes only changed cards, errors degrade to warnings, exit code stays 0; (3) crystal-theme-pages tail: pages_zh written for a fixture page, second run = 0 calls; (4) flag-off config → no projection files created; (5) malformed source-work.toml → warn + skip, parent run still succeeds",
+    "paired_sources": 0,
+    "soak": false
+  },
+  "rollback": "Set `auto_claim_zh = false` / `auto_memory_zh = false` in `.ovp/source-work.toml` — the flags pre-exist and gate the new code paths; the EN pipeline never moved. Code rollback is a single revert: tails are additive tail-phase blocks in three commands plus batch helpers in ovp-memory::bilingual.",
+  "ablation_required": false
+}

--- a/evolution/components.json
+++ b/evolution/components.json
@@ -196,6 +196,15 @@
     "operational_reliability",
     "crystal_provenance"
    ]
+  },
+  {
+   "id": "runtime.bilingual_tail",
+   "surface": "runtime",
+   "file": "crates/ovp-memory/src/bilingual.rs",
+   "quality_buckets": [
+    "coverage",
+    "operational_reliability"
+   ]
   }
  ]
 }


### PR DESCRIPTION
## Summary

Implements evolution candidate `bilingual_tail-v1` (spec: `evolution/candidates/bilingual_tail-v1.json`, validated via `ovp2 evolve validate`; component `runtime.bilingual_tail` registered in `evolution/components.json`).

Wires the **existing** `auto_claim_zh` / `auto_memory_zh` flags (`.ovp/source-work.toml`, previously only biasing manual CLIs) as best-effort **tail stages** of the three commands that mutate the English authority:

- `daily` → cards delta → `.ovp/crystal/cards_zh.json`
- `crystal-synth` → claims delta → `.ovp/crystal/claims_zh.json`
- `crystal-theme-pages` → pages delta → `.ovp/crystal/theme_pages_zh.json`

After any live daily/crystal run, the portal's zh surfaces self-heal without a manual `source-work claims-zh|memory-zh` pass (the 2026-08 dogfood gap: 994 claims + 15 theme pages + all cards stale for days).

## Guardrails (per spec, test-covered)

- Tails **only** write `.ovp/crystal/*_zh.json` projections; EN authority (ledger/packs/theme_pages.json) never opened for write.
- Tails run **only** when client kind is `Live` — replay/offline runs skip entirely (offline determinism / cassette CI intact).
- Flag-off or malformed `source-work.toml` → warn + skip; parent behavior byte-identical.
- Failure isolation: any tail error → warn line; parent exit code/terminal status unaffected.
- Incremental only via `get_fresh` (content-hash keyed); unchanged authority = 0 LLM calls.
- No interaction with `source-work-queue.json` / worker lock.

## Implementation notes

- New `topup_cards_zh` / `topup_theme_pages_zh` batch helpers in `ovp-memory::bilingual` (mirroring `translate_claims_batch`); manual CLIs in `source_work_cmd.rs` refactored to reuse them — no loop duplication.
- Tail gating order everywhere: `Live` check → config parse → flag → non-empty input → live client (`<vault>/.ovp/cassettes/bilingual`, `AskArgs::default().model_name`) → `get_fresh` topup.

## Tests

- `cargo test -p ovp-memory`: 127 passed (new: delta writes only changed entries, second run 0-call no-op, errors collected not thrown)
- `cargo test -p ovp-cli --bin ovp2`: 147 passed (12 new wiring tests: replay-skip / flag-off / malformed-config / empty-input per tail + replay daily e2e creates no `cards_zh.json`)
- `bash scripts/check_architecture.sh`: exit 0
- Known pre-existing at HEAD (verified on main, untouched by this PR): `m31_e2e::daily_and_pinboard_sync_inherit_first_sync_flood_guard` failure; workspace clippy under local stable 1.93.1 (~27 lints in unrelated files — recommend a separate chore branch)

## Rollback

Set `auto_claim_zh = false` / `auto_memory_zh = false` in `.ovp/source-work.toml`, or revert this branch — tails are additive blocks only.

🤖 Generated with Kimi Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional automatic Chinese translations for daily evidence cards, crystal claims, and theme pages.
  * Translations run incrementally during eligible live runs, updating only missing or outdated content.

* **Bug Fixes**
  * Translation and configuration issues no longer affect the primary English workflow.
  * Replay and offline runs safely skip automatic translation.
  * Improved handling of incomplete, corrupt, or truncated translation data, including safer atomic updates and failure limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->