### PR TITLE
feat(ovp-memory): source-work queue fail-back lifecycle (candidate queue_failback-v1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2902,6 +2902,7 @@ dependencies = [
 name = "ovp-memory"
 version = "2.0.1"
 dependencies = [
+ "chrono",
  "ovp-domain",
  "ovp-embed",
  "ovp-index",

--- a/console-ui/src/components/RunBanner.retry.test.ts
+++ b/console-ui/src/components/RunBanner.retry.test.ts
@@ -1,0 +1,181 @@
+/** Regression tests for the failed-run recovery controls (OVP2 observability:
+ * a failed run must stay OBSERVABLE and CONTROLLABLE).
+ *
+ * The bug these lock down: the retry button tracked pending state by watching
+ * `banner.level !== 'failed'`. When a retry ALSO failed, the level kept the
+ * same VALUE, so a level-keyed effect never re-fired — the button sat on
+ * "Starting…" forever, disabled, with no error shown. The operator's only
+ * recovery control was dead and the UI said nothing about it.
+ *
+ * Same DOM-free approach as RunBanner.progress.test.ts: the load-bearing
+ * decisions are pure functions, and the bilingual templates are checked by
+ * mirroring the i18n provider's `{name}` interpolation. */
+import { describe, expect, it } from 'vitest';
+import { en } from '../i18n/en';
+import { zh } from '../i18n/zh';
+import {
+  RETRY_WATCHDOG_MS,
+  buildRunTimeline,
+  lastRunBanner,
+  runSignature,
+  shouldClearRetry,
+} from '../lib/derive';
+import type { IndexModel, LastRunModel } from '../lib/types';
+
+const NOW = Date.parse('2026-08-04T03:30:00Z');
+
+/** Mirror the i18n provider's interpolation (index.tsx): `{name}` → vars[name]. */
+function fill(msg: string, vars: Record<string, string | number>): string {
+  let out = msg;
+  for (const [k, v] of Object.entries(vars)) out = out.replaceAll(`{${k}}`, String(v));
+  return out;
+}
+
+function modelWith(lr: Partial<LastRunModel>): IndexModel {
+  const last_run: LastRunModel = {
+    run_id: 'daily-2026-08-03',
+    started_at: '2026-08-04T02:25:52Z',
+    status: 'failed',
+    ...lr,
+  };
+  return {
+    schema: 'ovp.index/v2',
+    date: '2026-08-03',
+    totals: {
+      sources: 0, queued: 0, processed: 0, failed: 0, blocked: 0,
+      needs_content: 0, unparseable: 0, duplicates: 0, packs: 0,
+      claims_durable: 0, claims_caveated: 0, runs: 0,
+    },
+    sources: [], packs: [], claims: [], runs: [],
+    ops: { blocked_sources: [], queue_depth: 0, last_run },
+  };
+}
+
+const FAILED = lastRunBanner(
+  modelWith({ ended_at: '2026-08-04T02:25:52Z', error: 'io: live web fetch requires a build' }),
+  NOW,
+);
+
+describe('retry pending state', () => {
+  it('does not clear when there is nothing pending', () => {
+    expect(shouldClearRetry(null, FAILED, NOW)).toBe(false);
+  });
+
+  it('holds while the same failed run is still the newest one', () => {
+    const pending = { from: runSignature(FAILED), atMs: NOW };
+    expect(shouldClearRetry(pending, FAILED, NOW + 5_000)).toBe(false);
+  });
+
+  it('REGRESSION: clears when the retry itself fails — a second failed run', () => {
+    // Same-day retries reuse run_id (`daily-2026-08-03`); only the start
+    // instant moves. Level stays 'failed' both times, which is exactly what
+    // used to strand the button.
+    const pending = { from: runSignature(FAILED), atMs: NOW };
+    const retriedAndFailedAgain = lastRunBanner(
+      modelWith({
+        started_at: '2026-08-04T03:27:10Z',
+        ended_at: '2026-08-04T03:27:11Z',
+        status: 'failed',
+        error: 'io: live web fetch requires a build',
+      }),
+      NOW + 60_000,
+    );
+    expect(retriedAndFailedAgain.level).toBe('failed');
+    expect(retriedAndFailedAgain.runId).toBe(FAILED.runId); // run_id did NOT move
+    expect(shouldClearRetry(pending, retriedAndFailedAgain, NOW + 60_000)).toBe(true);
+  });
+
+  it('clears once the retry actually starts running', () => {
+    const pending = { from: runSignature(FAILED), atMs: NOW };
+    const running = lastRunBanner(
+      modelWith({ started_at: '2026-08-04T03:27:10Z', status: 'running' }),
+      NOW + 60_000,
+    );
+    expect(running.level).not.toBe('failed');
+    expect(shouldClearRetry(pending, running, NOW + 60_000)).toBe(true);
+  });
+
+  it('watchdog re-arms the button when the child dies without any heartbeat', () => {
+    // Nothing moves at all: same run, same level. Without the watchdog the
+    // operator would be left with a permanently disabled control.
+    const pending = { from: runSignature(FAILED), atMs: NOW };
+    expect(shouldClearRetry(pending, FAILED, NOW + RETRY_WATCHDOG_MS - 1)).toBe(false);
+    expect(shouldClearRetry(pending, FAILED, NOW + RETRY_WATCHDOG_MS)).toBe(true);
+  });
+
+  it('signature distinguishes attempts that share a run id', () => {
+    const a = runSignature(FAILED);
+    const b = runSignature(
+      lastRunBanner(modelWith({ started_at: '2026-08-04T03:27:10Z' }), NOW),
+    );
+    expect(a).not.toEqual(b);
+  });
+});
+
+describe('failed run states that it will not self-heal', () => {
+  const failedLr: LastRunModel = {
+    run_id: 'daily-2026-08-03',
+    started_at: '2026-08-04T02:25:52Z',
+    ended_at: '2026-08-04T02:25:52Z',
+    status: 'failed',
+    error: 'io: live web fetch requires a build with `--features web-fetch-live`',
+  };
+
+  it('adds the no-auto-retry step when the failure consumed the window', () => {
+    // `is_due` compares last_run to the most recent occurrence and IGNORES
+    // last_status, so a failure stamped after 09:00 leaves due=false until
+    // tomorrow. The timeline has to say that.
+    const steps = buildRunTimeline(failedLr, {
+      last_run: '2026-08-03T19:25:52',
+      last_status: 'error',
+      next_run: '2026-08-04T09:00:00',
+      due: false,
+      cadence: 'daily 09:00',
+    });
+    const step = steps.find((s) => s.id === 'no-auto-retry');
+    expect(step).toBeDefined();
+    expect(step!.kind).toBe('skip');
+    expect(step!.vars!.next).toBe('2026-08-04 09:00:00');
+    // It must come BEFORE the "next schedule window" line it is qualifying.
+    expect(steps.findIndex((s) => s.id === 'no-auto-retry')).toBeLessThan(
+      steps.findIndex((s) => s.id === 'next'),
+    );
+  });
+
+  it('stays quiet when the job is due again (the tick WILL pick it up)', () => {
+    const steps = buildRunTimeline(failedLr, {
+      last_run: '2026-08-03T08:00:00',
+      last_status: 'error',
+      next_run: '2026-08-04T09:00:00',
+      due: true,
+      cadence: 'daily 09:00',
+    });
+    expect(steps.find((s) => s.id === 'no-auto-retry')).toBeUndefined();
+  });
+
+  it('stays quiet for a completed run', () => {
+    const steps = buildRunTimeline(
+      { ...failedLr, status: 'completed', error: undefined, processed: 10 },
+      { next_run: '2026-08-04T09:00:00', due: false, cadence: 'daily 09:00' },
+    );
+    expect(steps.find((s) => s.id === 'no-auto-retry')).toBeUndefined();
+  });
+
+  it('renders the bilingual copy with no leftover placeholders', () => {
+    for (const dict of [en, zh]) {
+      const text = fill(dict['timeline.noAutoRetry'], { next: '2026-08-04 09:00:00' });
+      expect(text).toContain('2026-08-04 09:00:00');
+      expect(text).not.toMatch(/\{[a-zA-Z]+\}/);
+    }
+  });
+
+  it('surfaces a rejected start instead of swallowing it', () => {
+    for (const dict of [en, zh]) {
+      const text = fill(dict['banner.retryFailed'], {
+        error: 'a pipeline run is already in progress',
+      });
+      expect(text).toContain('a pipeline run is already in progress');
+      expect(text).not.toMatch(/\{[a-zA-Z]+\}/);
+    }
+  });
+});

--- a/console-ui/src/components/RunBanner.tsx
+++ b/console-ui/src/components/RunBanner.tsx
@@ -13,11 +13,15 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useI18n } from '../i18n';
 import {
+  RETRY_WATCHDOG_MS,
   formatRunWhen,
   isRunningWithProgress,
   lastRunBanner,
   runActivity,
+  runSignature,
+  shouldClearRetry,
   type BannerLevel,
+  type RetryPending,
 } from '../lib/derive';
 import { STATIC_MODE, fetchSchedule, startRunNow, type ScheduleJob } from '../lib/api';
 import { useModel } from '../model';
@@ -48,16 +52,35 @@ export default function RunBanner() {
   const navigate = useNavigate();
   const now = useNowTick();
   const [expanded, setExpanded] = useState(false);
-  const [retrying, setRetrying] = useState(false);
+  const [retryPending, setRetryPending] = useState<RetryPending | null>(null);
+  const [retryError, setRetryError] = useState<string | null>(null);
   const [dailyJob, setDailyJob] = useState<ScheduleJob | null>(null);
 
   const banner = lastRunBanner(model, now);
   // Retry stays pending until the heartbeat actually moves the banner off
-  // `failed` — the 202 alone doesn't mean the model caught up yet.
+  // `failed` — the 202 alone doesn't mean the model caught up yet. Keyed on the
+  // run SIGNATURE, not just the level: a retry that fails again leaves the level
+  // at `failed` (same value → a level-keyed effect never re-fires), which used
+  // to strand the button on "Starting…" forever with no error shown.
   const bannerLevel = banner.level;
+  const signature = runSignature(banner);
+  const retrying = retryPending !== null;
   useEffect(() => {
-    if (bannerLevel !== 'failed') setRetrying(false);
-  }, [bannerLevel]);
+    if (!retryPending) return;
+    if (shouldClearRetry(retryPending, banner, Date.now())) {
+      setRetryPending(null);
+      return;
+    }
+    // Re-arm on a schedule of its own: a child that dies before writing any
+    // heartbeat moves neither the level nor the signature, and the operator
+    // must never be left without a working control.
+    const left = Math.max(0, RETRY_WATCHDOG_MS - (Date.now() - retryPending.atMs));
+    const id = window.setTimeout(() => setRetryPending(null), left);
+    return () => window.clearTimeout(id);
+    // `banner` is re-derived every render; the signature + level are the parts
+    // that actually decide, so they are the deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [retryPending, signature, bannerLevel]);
 
   // Schedule context for hover: next due / whether currently due. Soft-fail if
   // the endpoint is down so the banner still works offline/static.
@@ -206,7 +229,8 @@ export default function RunBanner() {
             className="run-banner-retry"
             disabled={retrying}
             onClick={() => {
-              setRetrying(true);
+              setRetryError(null);
+              setRetryPending({ from: signature, atMs: Date.now() });
               startRunNow('daily')
                 .then(() => {
                   // Revalidate soon so the banner flips to "running" via the
@@ -222,11 +246,22 @@ export default function RunBanner() {
                     5000,
                   );
                 })
-                .catch(() => setRetrying(false));
+                .catch((e: unknown) => {
+                  // A rejected start (409 overlap, 500, offline) used to be
+                  // swallowed — the operator saw the button flicker and nothing
+                  // else. Surface it next to the control that caused it.
+                  setRetryPending(null);
+                  setRetryError(e instanceof Error ? e.message : String(e));
+                });
             }}
           >
             {retrying ? t('banner.retrying') : t('banner.retry')}
           </button>
+        )}
+        {banner.level === 'failed' && retryError && (
+          <span className="run-banner-retry-error" title={retryError}>
+            {t('banner.retryFailed', { error: retryError })}
+          </span>
         )}
         {/* Expand the live per-source activity feed inline, without leaving the
             current page — the operator's tail -f, one click away everywhere. */}

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -3172,6 +3172,14 @@ body {
   opacity: 0.5;
   cursor: default;
 }
+.run-banner-retry-error {
+  color: var(--danger, var(--muted));
+  font-size: var(--ovp-text-sm);
+  max-width: 32ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .provider-form {
   display: grid;
   gap: 0.6rem;

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -95,6 +95,8 @@ export const en = {
   'timeline.failUnknown': 'FAILED. {error}',
   'timeline.skippedReader': 'Skipped: intake → reader → index (not reached)',
   'timeline.noSourceFeed': 'No per-source activity — failure was before any source was claimed',
+  'timeline.noAutoRetry':
+    'NOT retried automatically — this failure already used up the current schedule window. Nothing will run until {next}. Use Retry (or Run now) to start it immediately.',
   'timeline.nextDue': 'Next schedule window ({cadence})',
   'timeline.nextDueNow': 'Next schedule window ({cadence}) — DUE NOW (waiting for tick / Run now)',
 
@@ -695,6 +697,7 @@ export const en = {
   'attention.ackHint': 'Hide this item until its status changes',
   'banner.retry': 'Retry',
   'banner.retrying': 'Starting…',
+  'banner.retryFailed': 'Could not start: {error}',
   'run.title': 'Pipeline run',
   'run.help':
     'Force today\'s daily job to run right now. Protected: a second click while any run is in progress is rejected, and a completed manual run counts for the automatic schedule (no double run).',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -95,6 +95,8 @@ export const zh: Record<keyof typeof en, string> = {
   'timeline.failUnknown': '失败。{error}',
   'timeline.skippedReader': '未执行：intake → reader → index（未到达）',
   'timeline.noSourceFeed': '无逐条活动 — 失败发生在认领任何来源之前',
+  'timeline.noAutoRetry':
+    '不会自动重试 —— 这次失败已经占用掉了当前调度窗口。在 {next} 之前不会有任何运行。要立刻处理，请点「重试」或「立即运行」。',
   'timeline.nextDue': '下一次调度窗口（{cadence}）',
   'timeline.nextDueNow': '下一次调度窗口（{cadence}）— 已到点（等 tick / 点立即运行）',
 
@@ -661,6 +663,7 @@ export const zh: Record<keyof typeof en, string> = {
   'attention.ackHint': '隐藏此条，状态变化时会重新出现',
   'banner.retry': '重试',
   'banner.retrying': '启动中…',
+  'banner.retryFailed': '启动失败：{error}',
   'run.title': '管线运行',
   'run.help':
     '立即强制运行今天的 daily 任务。有保护：任何运行进行中时再次点击会被拒绝；手动运行完成后计入自动调度（当天不会重复跑）。',

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -226,6 +226,26 @@ export function buildRunTimeline(
     });
   }
 
+  // A failed run does NOT re-arm the schedule: `is_due` compares last_run to the
+  // most recent occurrence and ignores last_status (ovp-scheduler/src/lib.rs),
+  // so this failure already consumed the current window. "Next schedule window"
+  // on its own reads as "it will fix itself" — say the quiet part out loud.
+  if (
+    (lr.status === 'failed' || lr.status === 'aborted') &&
+    schedule &&
+    schedule.due === false
+  ) {
+    steps.push({
+      id: 'no-auto-retry',
+      when: null,
+      kind: 'skip',
+      labelKey: 'timeline.noAutoRetry',
+      vars: {
+        next: formatRunWhen(schedule.next_run, { withSeconds: true }) || '—',
+      },
+    });
+  }
+
   if (schedule?.next_run) {
     steps.push({
       id: 'next',
@@ -301,6 +321,46 @@ export function lastRunBanner(
     startedAt: lr.started_at ?? null,
     endedAt: lr.ended_at ?? null,
   };
+}
+
+// ------------------------------------------------------------ retry pending
+
+/** How long a pending manual retry may sit before the button re-arms itself.
+ * A retry whose child dies before it writes a heartbeat would otherwise strand
+ * the only recovery control the operator has. */
+export const RETRY_WATCHDOG_MS = 90_000;
+
+/** Identity of the run the banner is showing. Same-day retries REUSE `run_id`
+ * (`daily-2026-08-03`), so the start instant is the part that actually moves
+ * when a new attempt begins — both halves are required to spot a new run. */
+export function runSignature(banner: LastRunBanner): string {
+  return `${banner.runId ?? '-'}|${banner.startedAt ?? '-'}`;
+}
+
+export interface RetryPending {
+  /** The run signature the operator clicked Retry from. */
+  from: string;
+  /** When the click happened (ms since epoch), for the watchdog. */
+  atMs: number;
+}
+
+/** Should the pending "Starting…" state clear?
+ *
+ * Watching only `level !== 'failed'` strands the button forever when the retry
+ * ALSO fails: the level keeps the same VALUE, so a level-keyed effect never
+ * re-fires and the operator is left holding a dead control with no error. Clear
+ * on any of: the banner left `failed`, a NEW run appeared (signature moved), or
+ * the watchdog expired. */
+export function shouldClearRetry(
+  pending: RetryPending | null,
+  banner: LastRunBanner,
+  nowMs: number,
+  watchdogMs: number = RETRY_WATCHDOG_MS,
+): boolean {
+  if (!pending) return false;
+  if (banner.level !== 'failed') return true;
+  if (runSignature(banner) !== pending.from) return true;
+  return nowMs - pending.atMs >= watchdogMs;
 }
 
 /** True when the heartbeat is a live in-progress run WITH a progress fraction —

--- a/crates/ovp-memory/Cargo.toml
+++ b/crates/ovp-memory/Cargo.toml
@@ -16,6 +16,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 sha2 = { workspace = true }
+chrono = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ovp-memory/src/source_work_queue.rs
+++ b/crates/ovp-memory/src/source_work_queue.rs
@@ -56,6 +56,14 @@ pub struct TaskState {
     pub status: TaskStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Transient failures so far (fail-back lifecycle). Serde-additive:
+    /// pre-failback queue files deserialize as 0 = today's behavior.
+    #[serde(default)]
+    pub attempts: u32,
+    /// Earliest epoch-second this task may be claimed again (retry backoff /
+    /// budget defer). None = claimable as soon as queued.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub not_before: Option<u64>,
 }
 
 impl TaskState {
@@ -69,6 +77,8 @@ impl TaskState {
                 TaskStatus::Skipped
             },
             error: None,
+            attempts: 0,
+            not_before: None,
         }
     }
 }
@@ -149,6 +159,13 @@ pub struct EnqueueRequest {
 /// several minutes; 12m is a generous upper bound that still unblocks a stuck
 /// gate within a refresh cycle users notice.
 const STALE_RUNNING_SECS: u64 = 12 * 60;
+
+/// Total tries (initial attempt + automatic retries) before a transient
+/// task failure goes terminal `Failed`. Retry schedule: 1m, 2m after the
+/// first two transient failures; the third is terminal.
+const MAX_TASK_ATTEMPTS: u32 = 3;
+/// Backoff base in seconds: `not_before = now + BASE * 2^attempts_so_far`.
+const RETRY_BACKOFF_BASE_SECS: u64 = 60;
 
 /// Process-local queue + wake for the background worker.
 pub struct SourceWorkQueue {
@@ -249,7 +266,10 @@ impl SourceWorkQueue {
         // promote to Done.
         let n = recover_interrupted(&self.vault_root, g);
         // Force any remaining long-running items (no artifacts) back to queued
-        // even if started_at was just cleared.
+        // even if started_at was just cleared. Preserve `attempts`/`not_before`
+        // on the requeued tasks: resetting them here would hand every stuck
+        // task a free retry budget (and pull its backoff earlier) every 12
+        // minutes — an infinite stale-recovery retry loop.
         for item in g.items.iter_mut() {
             if stale_ids.contains(&item.id) && item.status == ItemStatus::Running {
                 item.status = ItemStatus::Queued;
@@ -398,8 +418,13 @@ impl SourceWorkQueue {
                     item.translate.status,
                     TaskStatus::Skipped | TaskStatus::Cancelled | TaskStatus::Failed
                 ) {
+                    // Re-arm also resets the fail-back lifecycle: a manual
+                    // backfill re-run must not inherit attempts=3 (retry dead
+                    // for the item) or a stale not_before blocking the claim.
                     item.translate.status = TaskStatus::Queued;
                     item.translate.error = None;
+                    item.translate.attempts = 0;
+                    item.translate.not_before = None;
                 }
             }
             if req.summarize {
@@ -411,6 +436,8 @@ impl SourceWorkQueue {
                 ) {
                     item.summarize.status = TaskStatus::Queued;
                     item.summarize.error = None;
+                    item.summarize.attempts = 0;
+                    item.summarize.not_before = None;
                 }
             }
             if let Some(t) = req.title.filter(|s| !s.trim().is_empty()) {
@@ -564,7 +591,7 @@ impl SourceWorkQueue {
         if g.items.iter().any(|i| i.status == ItemStatus::Running) {
             return Ok(None); // one article at a time
         }
-        let Some(idx) = pick_next_queued_index(&g.items) else {
+        let Some(idx) = pick_next_queued_index(&g.items, now_secs()) else {
             return Ok(None);
         };
         let item = &mut g.items[idx];
@@ -603,19 +630,60 @@ impl SourceWorkQueue {
             TaskKind::Translate => &mut item.translate,
             TaskKind::Summarize => &mut item.summarize,
         };
+        let mut retried = false;
         match &result {
             Ok(()) => {
                 task.status = TaskStatus::Done;
                 task.error = None;
             }
-            Err(e) => {
-                task.status = TaskStatus::Failed;
-                task.error = Some(e.clone());
-            }
+            Err(e) => match classify_task_error(e) {
+                FailureClass::BudgetDefer => {
+                    // Reserved mechanism (nothing produces this class today):
+                    // defer to next local midnight; does not burn retry attempts.
+                    task.status = TaskStatus::Queued;
+                    task.error = Some(e.clone());
+                    task.not_before = Some(next_local_midnight(now_secs()));
+                    retried = true;
+                }
+                FailureClass::Transient
+                    if task.attempts.saturating_add(1) < MAX_TASK_ATTEMPTS =>
+                {
+                    // Backoff 1m/2m; the (MAX)th transient failure is terminal.
+                    task.not_before =
+                        Some(now_secs() + RETRY_BACKOFF_BASE_SECS * (1u64 << task.attempts));
+                    task.attempts = task.attempts.saturating_add(1);
+                    task.status = TaskStatus::Queued;
+                    // Keep the error text for visibility while backing off.
+                    task.error = Some(e.clone());
+                    retried = true;
+                }
+                _ => {
+                    task.status = TaskStatus::Failed;
+                    task.error = Some(e.clone());
+                }
+            },
         }
         // If cancelled mid-run, keep cancelled item status but record task results.
-        if item.status != ItemStatus::Cancelled {
-            recompute_item_status(item);
+        if retried {
+            // NEVER route the retry through `recompute_item_status`: with the
+            // sibling task still Running it would leave the item `Running`,
+            // and claim_next's one-item-running gate would jam the WHOLE
+            // queue behind this item's backoff until `recover_stale_running`
+            // (12 min). Re-queue the item explicitly instead.
+            if item.status != ItemStatus::Cancelled {
+                item.status = ItemStatus::Queued;
+                item.started_at = None;
+            }
+        } else if item.status != ItemStatus::Cancelled {
+            if item_tasks_terminal(item) {
+                recompute_item_status(item);
+            }
+            // Non-terminal: leave the item status alone. It is Running in the
+            // normal mid-flight case; but it may already be Queued because a
+            // sibling task failed back for retry while this one was still
+            // running — flipping it back to Running here would jam
+            // claim_next's one-item-running gate behind the sibling's
+            // backoff window (the same stall the retry branch avoids).
         } else if item_tasks_terminal(item) {
             item.finished_at = item.finished_at.or_else(|| Some(now_secs()));
         }
@@ -661,7 +729,15 @@ impl SourceWorkQueue {
             if !item.summarize.wanted {
                 item.summarize.status = TaskStatus::Skipped;
             }
-            recompute_item_status(item);
+            // A re-queued (retry-backoff) item must not be flipped back to
+            // Running here — that would jam claim_next's one-item-running
+            // gate behind the backoff window. Every other state keeps
+            // today's recompute semantics.
+            if item.status == ItemStatus::Queued && !item_tasks_terminal(item) {
+                // leave as Queued
+            } else {
+                recompute_item_status(item);
+            }
             let _ = self.persist_tracked(&g);
         }
     }
@@ -702,12 +778,86 @@ fn recompute_item_status(item: &mut QueueItem) {
     item.finished_at = Some(now_secs());
 }
 
+/// Failure classification for the fail-back lifecycle.
+///
+/// Mirrors the rules of `ovp_llm::client::is_transient`, but on the
+/// *stringified* error: by the time the source-work worker calls
+/// `finish_task`, the typed `CallError` has been flattened through its
+/// `Display` impl (`transport: …`, `provider error <code>: …`, `decode: …`,
+/// `budget exhausted: …`, …) inside `source_work`'s `llm_text`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FailureClass {
+    /// Transport / 429 / 5xx / rate_limit / overloaded / unavailable:
+    /// worth an automatic retry with backoff.
+    Transient,
+    /// Daily token budget exhausted: defer until next local midnight.
+    /// RESERVED — nothing produces this class today (meter-don't-enforce).
+    /// Deliberately distinct from `CallError::BudgetExhausted`
+    /// ("budget exhausted: …", a reasoning-token overflow), which stays
+    /// `Permanent`.
+    BudgetDefer,
+    /// 4xx, decode, protocol, cache miss, local/worker errors: terminal
+    /// `Failed`, exactly as today.
+    Permanent,
+}
+
+/// Prefix a future daily-budget producer will use; nothing emits it today.
+const BUDGET_DEFER_PREFIX: &str = "daily budget exhausted:";
+
+fn classify_task_error(msg: &str) -> FailureClass {
+    if msg.starts_with(BUDGET_DEFER_PREFIX) {
+        return FailureClass::BudgetDefer;
+    }
+    if msg.starts_with("transport:") {
+        return FailureClass::Transient;
+    }
+    if let Some(rest) = msg.strip_prefix("provider error ") {
+        let code = rest.split(':').next().unwrap_or("").trim();
+        if let Ok(n) = code.parse::<u16>() {
+            if n == 429 || (500..=599).contains(&n) {
+                return FailureClass::Transient;
+            }
+        } else {
+            let c = code.to_ascii_lowercase();
+            if c.contains("rate_limit") || c.contains("overloaded") || c.contains("unavailable") {
+                return FailureClass::Transient;
+            }
+        }
+    }
+    FailureClass::Permanent
+}
+
+/// Next local midnight as epoch seconds (budget-defer target). Falls back to
+/// `now + 24h` when the local timeline has no representable midnight.
+fn next_local_midnight(now: u64) -> u64 {
+    use chrono::{Local, TimeZone};
+    let dt = Local
+        .timestamp_opt(now.min(i64::MAX as u64) as i64, 0)
+        .latest()
+        .unwrap_or_else(Local::now);
+    let tomorrow = dt.date_naive() + chrono::Duration::days(1);
+    let Some(naive) = tomorrow.and_hms_opt(0, 0, 0) else {
+        return now + 24 * 3600;
+    };
+    let ts = match Local.from_local_datetime(&naive) {
+        chrono::LocalResult::Single(t) => t.timestamp(),
+        chrono::LocalResult::Ambiguous(a, _) => a.timestamp(),
+        chrono::LocalResult::None => return now + 24 * 3600,
+    };
+    ts.max(0) as u64
+}
+
 /// Index of the next queued item: highest priority, then oldest created_at.
-fn pick_next_queued_index(items: &[QueueItem]) -> Option<usize> {
+///
+/// Item-level claim gate: an item is claimable only when EVERY wanted+Queued
+/// task is past its `not_before` — `claim_next` flips both tasks to Running
+/// at once, so one backing-off task holds its own item back (but never
+/// other items).
+fn pick_next_queued_index(items: &[QueueItem], now: u64) -> Option<usize> {
     items
         .iter()
         .enumerate()
-        .filter(|(_, i)| i.status == ItemStatus::Queued)
+        .filter(|(_, i)| i.status == ItemStatus::Queued && item_claimable(i, now))
         .min_by(|(_, a), (_, b)| {
             // Prefer higher priority (so reverse cmp), then older created_at.
             b.priority
@@ -715,6 +865,15 @@ fn pick_next_queued_index(items: &[QueueItem]) -> Option<usize> {
                 .then_with(|| a.created_at.cmp(&b.created_at))
         })
         .map(|(idx, _)| idx)
+}
+
+fn item_claimable(item: &QueueItem, now: u64) -> bool {
+    fn task_ready(t: &TaskState, now: u64) -> bool {
+        // Only wanted+Queued tasks gate; not_before in the past is ready.
+        !(t.wanted && t.status == TaskStatus::Queued)
+            || t.not_before.is_none_or(|nb| nb <= now)
+    }
+    task_ready(&item.translate, now) && task_ready(&item.summarize, now)
 }
 
 /// Stable visual order for the portal: running first, then queued by
@@ -1057,12 +1216,16 @@ mod tests {
                     force: false,
                     status: TaskStatus::Running,
                     error: None,
+                    attempts: 0,
+                    not_before: None,
                 },
                 summarize: TaskState {
                     wanted: true,
                     force: false,
                     status: TaskStatus::Running,
                     error: None,
+                    attempts: 0,
+                    not_before: None,
                 },
                 status: ItemStatus::Running,
                 created_at: 1,
@@ -1110,12 +1273,16 @@ mod tests {
                     force: false,
                     status: TaskStatus::Running,
                     error: None,
+                    attempts: 0,
+                    not_before: None,
                 },
                 summarize: TaskState {
                     wanted: true,
                     force: false,
                     status: TaskStatus::Running,
                     error: None,
+                    attempts: 0,
+                    not_before: None,
                 },
                 status: ItemStatus::Running,
                 created_at: 1,
@@ -1167,6 +1334,379 @@ mod tests {
         let snap = q.snapshot();
         assert_eq!(snap.items[0].sha256, "bbbbbbbb");
         assert_eq!(snap.items[1].sha256, "aaaaaaaa");
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    // ---- fail-back lifecycle (queue_failback-v1) ----
+
+    fn enq(sha: &str, summarize: bool) -> EnqueueRequest {
+        EnqueueRequest {
+            sha256: sha.into(),
+            title: None,
+            translate: true,
+            summarize,
+            force: false,
+            notify: false,
+            priority: PRIORITY_NORMAL,
+        }
+    }
+
+    /// Force a task's backoff window into the past, as if time had passed.
+    fn expire_backoff(q: &SourceWorkQueue, id: &str, kind: TaskKind) {
+        let mut g = q.state.lock().unwrap_or_else(|p| p.into_inner());
+        let it = g.items.iter_mut().find(|i| i.id == id).unwrap();
+        let task = match kind {
+            TaskKind::Translate => &mut it.translate,
+            TaskKind::Summarize => &mut it.summarize,
+        };
+        task.not_before = Some(now_secs().saturating_sub(1));
+        q.persist_tracked(&g).unwrap();
+    }
+
+    #[test]
+    fn classify_task_error_rules() {
+        // Transient: transport, 429, 5xx, rate_limit/overloaded/unavailable —
+        // same rules as ovp_llm::client::is_transient, on stringified errors.
+        assert_eq!(
+            classify_task_error("transport: connection reset"),
+            FailureClass::Transient
+        );
+        assert_eq!(
+            classify_task_error("provider error 429: slow down"),
+            FailureClass::Transient
+        );
+        assert_eq!(
+            classify_task_error("provider error 503: service unavailable"),
+            FailureClass::Transient
+        );
+        assert_eq!(
+            classify_task_error("provider error rate_limit_error: x"),
+            FailureClass::Transient
+        );
+        assert_eq!(
+            classify_task_error("provider error overloaded_error: x"),
+            FailureClass::Transient
+        );
+        // Permanent: 4xx, decode, protocol, reasoning-budget, cache miss,
+        // local/worker errors.
+        assert_eq!(
+            classify_task_error("provider error 400: invalid request"),
+            FailureClass::Permanent
+        );
+        assert_eq!(
+            classify_task_error("provider error 401: auth"),
+            FailureClass::Permanent
+        );
+        assert_eq!(
+            classify_task_error("decode: no text block"),
+            FailureClass::Permanent
+        );
+        assert_eq!(
+            classify_task_error("tool protocol violation: adjacency"),
+            FailureClass::Permanent
+        );
+        assert_eq!(
+            classify_task_error("budget exhausted: thinking used all tokens"),
+            FailureClass::Permanent
+        );
+        assert_eq!(
+            classify_task_error("cache miss for key abcd"),
+            FailureClass::Permanent
+        );
+        assert_eq!(
+            classify_task_error("llm not configured"),
+            FailureClass::Permanent
+        );
+        assert_eq!(
+            classify_task_error("translate task panicked"),
+            FailureClass::Permanent
+        );
+        // Reserved budget-defer class (no producer today).
+        assert_eq!(
+            classify_task_error("daily budget exhausted: 1000000 tokens"),
+            FailureClass::BudgetDefer
+        );
+    }
+
+    /// CORE REGRESSION: an item backing off must never stall the queue.
+    #[test]
+    fn transient_retry_does_not_stall_other_items() {
+        let vault = tmp();
+        let q = SourceWorkQueue::open(&vault);
+        let a = q.enqueue(enq("sha-a-transient", true)).unwrap();
+        let b = q.enqueue(enq("sha-b-waits", true)).unwrap();
+        let claimed = q.claim_next().unwrap();
+        assert_eq!(claimed.id, a.id);
+        // Both of A's tasks transient-fail → A re-queued with backoff.
+        q.finish_task(&a.id, TaskKind::Translate, Err("transport: reset".into()))
+            .unwrap();
+        q.finish_task(
+            &a.id,
+            TaskKind::Summarize,
+            Err("provider error 429: slow down".into()),
+        )
+        .unwrap();
+        let snap = q.snapshot();
+        let a_now = snap.items.iter().find(|i| i.id == a.id).unwrap();
+        assert_eq!(a_now.status, ItemStatus::Queued);
+        assert_eq!(a_now.started_at, None);
+        assert!(a_now.translate.not_before.is_some());
+        // B is IMMEDIATELY claimable — the one-item-running gate is free.
+        let next = q.claim_next().unwrap();
+        assert_eq!(next.id, b.id);
+        q.finish_task(&b.id, TaskKind::Translate, Ok(())).unwrap();
+        q.finish_task(&b.id, TaskKind::Summarize, Ok(())).unwrap();
+        // A still inside its backoff window: nothing to claim.
+        assert!(q.claim_next().is_none());
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    #[test]
+    fn transient_retry_backoff_then_terminal() {
+        let vault = tmp();
+        let q = SourceWorkQueue::open(&vault);
+        let a = q.enqueue(enq("sha-retry", false)).unwrap();
+
+        // 1st transient failure: re-queued, attempts=1, not_before≈now+60s.
+        q.claim_next().unwrap();
+        let before = now_secs();
+        let item = q
+            .finish_task(&a.id, TaskKind::Translate, Err("transport: reset".into()))
+            .unwrap();
+        assert_eq!(item.translate.status, TaskStatus::Queued);
+        assert_eq!(item.translate.attempts, 1);
+        assert_eq!(item.translate.error.as_deref(), Some("transport: reset"));
+        let nb = item.translate.not_before.unwrap();
+        assert!(
+            (before + RETRY_BACKOFF_BASE_SECS..=before + RETRY_BACKOFF_BASE_SECS + 30)
+                .contains(&nb),
+            "not_before {nb} not ≈ +60s from {before}"
+        );
+        // Item explicitly re-queued (never left Running), so the gate is free.
+        assert_eq!(item.status, ItemStatus::Queued);
+        assert_eq!(item.started_at, None);
+        // Not claimable before the window.
+        assert!(q.claim_next().is_none());
+
+        // After the window: claimable again.
+        expire_backoff(&q, &a.id, TaskKind::Translate);
+        let c = q.claim_next().unwrap();
+        assert_eq!(c.id, a.id);
+
+        // 2nd transient failure: attempts=2, not_before≈now+120s.
+        let before = now_secs();
+        let item = q
+            .finish_task(&a.id, TaskKind::Translate, Err("transport: reset".into()))
+            .unwrap();
+        assert_eq!(item.translate.attempts, 2);
+        let nb = item.translate.not_before.unwrap();
+        assert!(
+            (before + 2 * RETRY_BACKOFF_BASE_SECS..=before + 2 * RETRY_BACKOFF_BASE_SECS + 30)
+                .contains(&nb),
+            "not_before {nb} not ≈ +120s from {before}"
+        );
+        expire_backoff(&q, &a.id, TaskKind::Translate);
+        q.claim_next().unwrap();
+
+        // 3rd transient failure: terminal Failed, retry budget spent.
+        let item = q
+            .finish_task(&a.id, TaskKind::Translate, Err("transport: reset".into()))
+            .unwrap();
+        assert_eq!(item.translate.status, TaskStatus::Failed);
+        assert_eq!(item.translate.attempts, 2);
+        assert_eq!(item.status, ItemStatus::Failed);
+        assert!(item.finished_at.is_some());
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    /// Item-level gate: translate backing off + summarize ready ⇒ NOT claimable
+    /// (claim_next flips both tasks to Running at once).
+    #[test]
+    fn item_not_claimable_while_any_task_backs_off() {
+        let vault = tmp();
+        let q = SourceWorkQueue::open(&vault);
+        let a = q.enqueue(enq("sha-gated", true)).unwrap();
+        q.claim_next().unwrap();
+        // translate transient-fails into backoff; summarize succeeds.
+        q.finish_task(&a.id, TaskKind::Translate, Err("transport: reset".into()))
+            .unwrap();
+        q.finish_task(&a.id, TaskKind::Summarize, Ok(())).unwrap();
+        let snap = q.snapshot();
+        let it = &snap.items[0];
+        assert_eq!(it.translate.status, TaskStatus::Queued);
+        assert_eq!(it.summarize.status, TaskStatus::Done);
+        assert_eq!(it.status, ItemStatus::Queued);
+        // One wanted+Queued task still in backoff ⇒ item not claimable.
+        assert!(q.claim_next().is_none());
+        // Window over ⇒ claimable; the Done sibling is left alone.
+        expire_backoff(&q, &a.id, TaskKind::Translate);
+        let c = q.claim_next().unwrap();
+        assert_eq!(c.translate.status, TaskStatus::Running);
+        assert_eq!(c.summarize.status, TaskStatus::Done);
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    #[test]
+    fn stale_recovery_preserves_attempts_and_not_before() {
+        let vault = tmp();
+        let q = SourceWorkQueue::open(&vault);
+        let a = q.enqueue(enq("sha-stale", false)).unwrap();
+        q.claim_next().unwrap();
+        // Simulate: retried twice already (attempts=2 + future backoff), then
+        // the process lost track — item went stale while Running.
+        let future = now_secs() + 3600;
+        {
+            let mut g = q.state.lock().unwrap_or_else(|p| p.into_inner());
+            let it = g.items.iter_mut().find(|i| i.id == a.id).unwrap();
+            it.started_at = Some(now_secs() - STALE_RUNNING_SECS - 60);
+            it.translate.attempts = 2;
+            it.translate.not_before = Some(future);
+            q.persist_tracked(&g).unwrap();
+        }
+        let snap = q.snapshot(); // triggers recover_stale_running
+        let it = &snap.items[0];
+        assert_eq!(it.status, ItemStatus::Queued);
+        assert_eq!(it.translate.status, TaskStatus::Queued);
+        // Retry budget and backoff survive stale recovery — no infinite
+        // 12-minute retry loop, no pulled-forward not_before.
+        assert_eq!(it.translate.attempts, 2);
+        assert_eq!(it.translate.not_before, Some(future));
+        assert!(q.claim_next().is_none());
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    #[test]
+    fn permanent_error_fails_terminally_on_first_failure() {
+        for err in [
+            "provider error 400: invalid request",
+            "decode: no text block",
+            "budget exhausted: thinking used all tokens",
+            "llm not configured",
+        ] {
+            let vault = tmp();
+            let q = SourceWorkQueue::open(&vault);
+            let a = q.enqueue(enq("sha-perm", false)).unwrap();
+            q.claim_next().unwrap();
+            let item = q
+                .finish_task(&a.id, TaskKind::Translate, Err(err.into()))
+                .unwrap();
+            assert_eq!(item.translate.status, TaskStatus::Failed, "{err}");
+            assert_eq!(item.translate.attempts, 0, "{err}");
+            assert_eq!(item.translate.not_before, None, "{err}");
+            assert_eq!(item.translate.error.as_deref(), Some(err));
+            assert_eq!(item.status, ItemStatus::Failed, "{err}");
+            let _ = std::fs::remove_dir_all(&vault);
+        }
+    }
+
+    /// Manual backfill re-run (today's only recovery tool) must re-arm with a
+    /// fresh retry budget — never inherit attempts=3 / a stale not_before.
+    #[test]
+    fn enqueue_rearm_resets_failback_state() {
+        let vault = tmp();
+        let q = SourceWorkQueue::open(&vault);
+        let a = q.enqueue(enq("sha-rearm", false)).unwrap();
+        // Simulate an item whose task exhausted retries: terminally Failed
+        // with attempts spent and a stale backoff timestamp left behind.
+        {
+            let mut g = q.state.lock().unwrap_or_else(|p| p.into_inner());
+            let it = g.items.iter_mut().find(|i| i.id == a.id).unwrap();
+            it.translate.status = TaskStatus::Failed;
+            it.translate.error = Some("provider error 500: boom".into());
+            it.translate.attempts = 3;
+            it.translate.not_before = Some(now_secs() + 3600);
+            q.persist_tracked(&g).unwrap();
+        }
+        let b = q.enqueue(enq("sha-rearm", false)).unwrap();
+        assert_eq!(b.id, a.id, "merged into the queued item, not a new one");
+        assert_eq!(b.translate.status, TaskStatus::Queued);
+        assert_eq!(b.translate.error, None);
+        assert_eq!(b.translate.attempts, 0);
+        assert_eq!(b.translate.not_before, None);
+        // Retry mechanism fully alive again for this item.
+        q.claim_next().unwrap();
+        let item = q
+            .finish_task(&a.id, TaskKind::Translate, Err("transport: reset".into()))
+            .unwrap();
+        assert_eq!(item.translate.status, TaskStatus::Queued);
+        assert_eq!(item.translate.attempts, 1);
+        assert!(item.translate.not_before.is_some());
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    /// Reserved budget-defer mechanism: deferred to next local midnight,
+    /// retry attempts untouched, item explicitly re-queued. (No producer today.)
+    #[test]
+    fn budget_defer_defers_to_next_local_midnight() {
+        let vault = tmp();
+        let q = SourceWorkQueue::open(&vault);
+        let a = q.enqueue(enq("sha-budget", false)).unwrap();
+        q.claim_next().unwrap();
+        let before = now_secs();
+        let item = q
+            .finish_task(
+                &a.id,
+                TaskKind::Translate,
+                Err("daily budget exhausted: 1000000 tokens".into()),
+            )
+            .unwrap();
+        assert_eq!(item.translate.status, TaskStatus::Queued);
+        assert_eq!(item.translate.attempts, 0, "defer must not burn retries");
+        assert_eq!(item.status, ItemStatus::Queued);
+        assert_eq!(item.started_at, None);
+        let nb = item.translate.not_before.unwrap();
+        assert!(nb > before && nb <= before + 36 * 3600, "nb={nb} before={before}");
+        use chrono::TimeZone;
+        let local = chrono::Local.timestamp_opt(nb as i64, 0).latest().unwrap();
+        assert_eq!(
+            local.time(),
+            chrono::NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
+            "not_before must be local midnight"
+        );
+        assert!(q.claim_next().is_none());
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    /// Pre-failback queue files (no attempts/not_before) load with defaults
+    /// and behave exactly as a fresh item.
+    #[test]
+    fn legacy_queue_json_without_failback_fields_loads() {
+        let vault = tmp();
+        let path = vault.join(QUEUE_REL);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let raw = r#"{
+          "schema": "ovp.source-work-queue/v1",
+          "items": [
+            {
+              "id": "swq-legacy",
+              "sha256": "legacysha",
+              "translate": { "wanted": true, "force": false, "status": "queued" },
+              "summarize": { "wanted": false, "status": "skipped" },
+              "status": "queued",
+              "created_at": 1
+            }
+          ]
+        }"#;
+        std::fs::write(&path, raw).unwrap();
+        let q = SourceWorkQueue::open(&vault);
+        let snap = q.snapshot();
+        assert_eq!(snap.items.len(), 1);
+        assert_eq!(snap.items[0].translate.attempts, 0);
+        assert_eq!(snap.items[0].translate.not_before, None);
+        // Claimable like any fresh item; a transient failure starts the retry
+        // budget from zero.
+        let c = q.claim_next().unwrap();
+        assert_eq!(c.id, "swq-legacy");
+        let item = q
+            .finish_task(
+                "swq-legacy",
+                TaskKind::Translate,
+                Err("provider error 429: slow down".into()),
+            )
+            .unwrap();
+        assert_eq!(item.translate.status, TaskStatus::Queued);
+        assert_eq!(item.translate.attempts, 1);
+        assert!(item.translate.not_before.is_some());
         let _ = std::fs::remove_dir_all(&vault);
     }
 }

--- a/crates/ovp-memory/src/source_work_queue.rs
+++ b/crates/ovp-memory/src/source_work_queue.rs
@@ -626,6 +626,7 @@ impl SourceWorkQueue {
             .iter_mut()
             .find(|i| i.id == id)
             .ok_or_else(|| format!("queue item not found: {id}"))?;
+        let cancelled = item.status == ItemStatus::Cancelled;
         let task = match kind {
             TaskKind::Translate => &mut item.translate,
             TaskKind::Summarize => &mut item.summarize,
@@ -635,6 +636,14 @@ impl SourceWorkQueue {
             Ok(()) => {
                 task.status = TaskStatus::Done;
                 task.error = None;
+            }
+            Err(e) if cancelled => {
+                // A cancelled item takes TERMINAL task results only:
+                // re-queueing a task under a Cancelled item strands it
+                // forever (claim_next only selects Queued items) and blocks
+                // the cancellation notification (CodeRabbit on PR #411).
+                task.status = TaskStatus::Failed;
+                task.error = Some(e.clone());
             }
             Err(e) => match classify_task_error(e) {
                 FailureClass::BudgetDefer => {
@@ -869,9 +878,17 @@ fn pick_next_queued_index(items: &[QueueItem], now: u64) -> Option<usize> {
 
 fn item_claimable(item: &QueueItem, now: u64) -> bool {
     fn task_ready(t: &TaskState, now: u64) -> bool {
+        // A wanted task still RUNNING gates the claim: finish_task can
+        // re-queue the item for a sibling's retry while this task's thread
+        // is still in flight, and claim_next's one-item gate keys on ITEM
+        // status (Queued in that case), not task status — without this a
+        // second thread would start the same task and the late finisher
+        // would overwrite the newer state (CodeRabbit on PR #411).
+        if t.wanted && t.status == TaskStatus::Running {
+            return false;
+        }
         // Only wanted+Queued tasks gate; not_before in the past is ready.
-        !(t.wanted && t.status == TaskStatus::Queued)
-            || t.not_before.is_none_or(|nb| nb <= now)
+        !(t.wanted && t.status == TaskStatus::Queued) || t.not_before.is_none_or(|nb| nb <= now)
     }
     task_ready(&item.translate, now) && task_ready(&item.summarize, now)
 }
@@ -1543,6 +1560,53 @@ mod tests {
         let c = q.claim_next().unwrap();
         assert_eq!(c.translate.status, TaskStatus::Running);
         assert_eq!(c.summarize.status, TaskStatus::Done);
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    /// A sibling task still in flight gates the claim: translate backed off
+    /// and its window expired, but summarize is still Running — claiming now
+    /// would start a second summarize thread whose late finish would
+    /// overwrite the newer state (CodeRabbit on PR #411).
+    #[test]
+    fn running_sibling_gates_claim_after_backoff() {
+        let vault = tmp();
+        let q = SourceWorkQueue::open(&vault);
+        let a = q.enqueue(enq("sha-inflight", true)).unwrap();
+        q.claim_next().unwrap();
+        // translate transient-fails into backoff; summarize is STILL Running.
+        q.finish_task(&a.id, TaskKind::Translate, Err("transport: reset".into()))
+            .unwrap();
+        let snap = q.snapshot();
+        let it = &snap.items[0];
+        assert_eq!(it.status, ItemStatus::Queued);
+        assert_eq!(it.summarize.status, TaskStatus::Running);
+        // Even with translate's backoff expired, the in-flight sibling gates.
+        expire_backoff(&q, &a.id, TaskKind::Translate);
+        assert!(q.claim_next().is_none());
+        // Once summarize finishes, the item is claimable again.
+        q.finish_task(&a.id, TaskKind::Summarize, Ok(())).unwrap();
+        let c = q.claim_next().unwrap();
+        assert_eq!(c.translate.status, TaskStatus::Running);
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    /// A task that fails after the item was CANCELLED takes a terminal
+    /// result — re-queueing it under a Cancelled item would strand it
+    /// forever and block the cancellation notification (CodeRabbit on #411).
+    #[test]
+    fn cancelled_item_takes_terminal_task_results() {
+        let vault = tmp();
+        let q = SourceWorkQueue::open(&vault);
+        let a = q.enqueue(enq("sha-cancelled", false)).unwrap();
+        q.claim_next().unwrap();
+        q.cancel(&a.id).unwrap();
+        let item = q
+            .finish_task(&a.id, TaskKind::Translate, Err("transport: reset".into()))
+            .unwrap();
+        assert_eq!(item.status, ItemStatus::Cancelled);
+        assert_eq!(item.translate.status, TaskStatus::Failed);
+        assert_eq!(item.translate.attempts, 0);
+        assert_eq!(item.translate.not_before, None);
         let _ = std::fs::remove_dir_all(&vault);
     }
 

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -2886,7 +2886,7 @@ fn handle_source_work_queue_delete(
 
 /// Background loop: claim one article, run its wanted tasks (parallel), finish.
 fn source_work_queue_worker(state: Arc<AppState>) {
-    use ovp_memory::source_work_queue::TaskKind;
+    use ovp_memory::source_work_queue::{TaskKind, TaskStatus};
     loop {
         state
             .source_work_queue
@@ -2957,8 +2957,13 @@ fn source_work_queue_worker(state: Arc<AppState>) {
         let url_s = url;
         let force_t = item.translate.force;
         let force_s = item.summarize.force;
-        let do_t = item.translate.wanted;
-        let do_s = item.summarize.wanted;
+        // Run ONLY the tasks claim_next armed (Running): after a partial
+        // retry the terminal sibling (Done / permanently Failed) must not
+        // execute again — with force=true that would repeat a paid LLM call,
+        // and a permanent sibling would be retried despite first-failure
+        // terminal semantics (codex P2 on PR #411).
+        let do_t = item.translate.wanted && item.translate.status == TaskStatus::Running;
+        let do_s = item.summarize.wanted && item.summarize.status == TaskStatus::Running;
         let factory_t = factory.clone();
         let factory_s = factory;
 

--- a/evolution/candidates/queue_failback-v1.json
+++ b/evolution/candidates/queue_failback-v1.json
@@ -1,0 +1,28 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "queue_failback-v1",
+  "base_version": "none",
+  "target_version": "v1",
+  "surface": "runtime",
+  "component": "runtime.queue_failback",
+  "hypothesis": "RUNTIME surface: give source-work queue tasks a fail-back lifecycle instead of terminal-failed-forever. TaskState gains serde-default additive `attempts` + `not_before` (schema stays ovp.source-work-queue/v1). On task failure: TRANSIENT errors (transport/429/5xx/rate-limit/overloaded — same rules as ovp-llm is_transient) with attempts < 3 are re-queued with exponential backoff (60s x 2^attempts); permanent errors (4xx/decode/content) or exhausted attempts stay terminal Failed exactly as today. Claiming is gated at ITEM level: an item is claimable only when ALL wanted+queued tasks are past their not_before (claim_next flips both tasks at once). The retry branch sets item.status=Queued + started_at=None EXPLICITLY (never via recompute_item_status, which would leave the item Running and jam the one-at-a-time claim gate for STALE_RUNNING_SECS). enqueue's re-arm of Failed/Skipped/Cancelled tasks resets attempts=0 and not_before=None so a manual backfill re-run stays a working painkiller. Predicted: the 2026-08 network-outage class of incident (hundreds of transient task failures requiring manual re-enqueue) self-recovers within minutes with zero operator action, while permanent failures surface exactly as before.",
+  "predicted_delta": {
+    "transient_recovery": "100% of transient task failures (transport/429/5xx/rate-limit) are retried automatically up to 3 attempts with backoff; 0 operator re-enqueues needed for the outage class; permanent failures still reach terminal Failed on the first failure (no retry storm)",
+    "queue_liveness": "an item in backoff never blocks other items: cross-item claim continues immediately (pinned by the cross-item gate regression test); 0 queue stalls longer than the 1-4 minute backoff windows",
+    "operational_reliability": "the manual 're-run backfill after a network blip' runbook step disappears for the transient class"
+  },
+  "guardrails": {
+    "schema_backward_compatible": "new TaskState fields are #[serde(default)]: old queue files load with attempts=0/not_before=None (identical-to-today behavior); reverted code reads new files fine (unknown fields dropped on rewrite)",
+    "no_queue_stall": "the retry path NEVER goes through recompute_item_status: it explicitly sets item.status=Queued and started_at=None, so claim_next's one-item-running gate is not held by a backing-off item; recover_stale_running preserves attempts and not_before (no infinite 12-minute retry loop)",
+    "permanent_failures_unchanged": "4xx/decode/content errors and attempt-exhausted items reach terminal Failed with the same error text and operator surfaces as today; history pruning (40 terminal) unchanged",
+    "manual_reenqueue_still_works": "enqueue re-arm resets attempts/not_before — a manual backfill (today's only recovery tool) keeps full retry semantics and is never blocked by a stale not_before",
+    "budget_defer_reserved": "a budget-exhausted class maps to not_before=next local midnight; nothing produces it today (meter-don't-enforce per operator decision) — mechanism + tests only"
+  },
+  "eval_plan": {
+    "replay_set": "unit tests over source_work_queue.rs, no LLM calls: (1) CROSS-ITEM GATE (core regression): item A transient-fails back to Queued, item B is immediately claimable; (2) transient failure → attempts=1, not_before≈now+60s, claimable after the window; 3rd transient failure → terminal Failed; (3) item-level gate: translate backing off + summarize ready → item NOT claimable; (4) recover_stale_running preserves attempts and not_before; (5) permanent error → terminal Failed on first failure; (6) enqueue re-arm resets attempts/not_before; (7) legacy queue JSON without the new fields loads and behaves identically to today",
+    "paired_sources": 0,
+    "soak": false
+  },
+  "rollback": "Single revert: with attempts=0/not_before=None everywhere the code paths collapse to today's behavior; queue files written by the new code load fine in old code (serde ignores unknown fields on read, drops on rewrite — no operator action).",
+  "ablation_required": false
+}

--- a/evolution/components.json
+++ b/evolution/components.json
@@ -213,6 +213,14 @@
    "quality_buckets": [
     "operational_reliability"
    ]
+  },
+  {
+   "id": "runtime.queue_failback",
+   "surface": "runtime",
+   "file": "crates/ovp-memory/src/source_work_queue.rs",
+   "quality_buckets": [
+    "operational_reliability"
+   ]
   }
  ]
 }


### PR DESCRIPTION
## Summary

Implements evolution candidate `queue_failback-v1` (spec validated; component `runtime.queue_failback` registered). Second half of the operator-approved "task planning / usage estimation / budget visibility / failure fail-back" initiative — the **fail-back** half.

Source-work queue tasks get a failure lifecycle instead of terminal-failed-forever (the 2026-08 network outage left hundreds of tasks terminally failed, requiring manual re-enqueue):

- `TaskState` gains serde-default `attempts` + `not_before` (schema stays `ovp.source-work-queue/v1`; legacy files load unchanged, new files read fine in old binaries).
- **Transient** failures (transport/429/5xx/rate-limit — `ovp-llm::is_transient` rules, classified on the worker's stringified error) retry automatically: ≤3 attempts, 1m/2m exponential backoff via `not_before`.
- **Permanent** failures (4xx/decode/content) reach terminal `Failed` on first failure, exactly as today.
- **Budget-defer (reserved)**: a `"daily budget exhausted:"` error class maps to `not_before` = next local midnight; no producer today (meter-don't-enforce), mechanism + tests only.

## Load-bearing invariants (from 3 rounds of plan review — each test-pinned)

- Retry branch **never** routes through `recompute_item_status` (it leaves the item `Running` and jams `claim_next`'s one-item gate for 12 min) — sets `item.status=Queued` + `started_at=None` explicitly. Two adjacent leaks of the same class (non-retry finish path, `mark_task_skipped_if_not_wanted`) fixed the same way.
- Claiming is **item-level**: every wanted+Queued task must be past `not_before` (claim flips both tasks at once).
- `recover_stale_running` preserves `attempts`/`not_before` (no infinite 12-min retry loop).
- `enqueue` re-arm resets `attempts=0`/`not_before=None` — a manual backfill re-run keeps working as the painkiller of last resort.

## Semantics note

"Up to 3 attempts" = initial try + 2 retries; the 3rd failure is terminal (matches the candidate's predicted_delta and B4 test).

## Tests

`cargo test -p ovp-memory`: **146 passed** (+9: classifier rules, cross-item gate core regression, backoff schedule + terminal-at-3rd, item-level gate, stale-recovery preservation, permanent-first-failure, enqueue re-arm reset, budget-defer-midnight, legacy-JSON load). `ovp-server` 70 passed. `check_architecture.sh` pass. No new clippy hits.

## Rollback

Single revert — `attempts=0`/`not_before=None` collapses to today's behavior; queue files are forward/backward compatible.

🤖 Generated with Kimi Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic retries for temporary task failures, with increasing delays and a maximum of three attempts.
  * Added scheduling for budget-related delays until the next local day.
  * Improved queue processing so blocked tasks do not prevent other work from continuing.
  * Added manual re-enqueue support that resets retry status.

* **Bug Fixes**
  * Preserved retry information during recovery from interrupted tasks.
  * Maintained compatibility with existing queue data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->