### PR TITLE
feat(scheduler): `every <N>h` interval cadence + repo CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# OVP2
+
+Rust workspace (`crates/`) + React portal (`console-ui/`) + Tauri desktop shell
+(`apps/desktop/`). Pipeline: capture → intake → reader packs → crystal claims →
+portal. The vault is data, not code — it lives outside this repo.
+
+Only gotchas below. Anything derivable by reading the code is deliberately absent.
+
+---
+
+## 定时任务跑的是 app sidecar,不是 `target/release/ovp2`
+
+Desktop 的 scheduler exec `resolve_ovp2_bin()`(`apps/desktop/src-tauri/src/lib.rs:309`):
+`OVP2_BIN` → app 内 sidecar → dev fallback。**`cargo build --release` 到不了定时任务。**
+
+```bash
+INSTALL_APP=/Applications/OVP2.app scripts/build-desktop-sidecar.sh
+```
+
+不用重启 app——每次 tick 都重新 spawn 进程。验收方式是比对 sidecar 的 mtime/哈希与目标提交,
+不是看 `cargo build` 成功。dev fallback 尤其危险:它会命中一个可能没编 live features 的
+`target/release/ovp2`,然后把 `--features web-fetch-live` 这种构建期错误抛给 GUI 用户。
+
+## cadence 语法比二进制新 = 整个 tick 停摆
+
+registry 在**加载期**校验 cadence,一个不认识的语法会让 `schedule list` / `tick` 直接
+非零退出——**注册表里的每个 job 都不跑**,不只是那一个。而 desktop 把子进程的 stderr 只写进
+`eprintln`(从 Finder 启动时被吞掉),所以在 GUI 里表现为"什么都没发生"。
+
+**改 `.ovp/schedule.json` 的 cadence 前,必须先装上认得新语法的 sidecar。**
+顺序反了 = 定时任务全停。(`plan_tick` 里还有一层 `skipped_not_due` 的防御分支,
+但那条路径正常走不到,别指望它。)
+
+## `is_due` 只看时间,不看上次成败
+
+`crates/ovp-scheduler/src/lib.rs:175` 只比较 `last_run` 与最近调度点。所以**失败或被 kill 的 job
+不会重试**,要空等一整个 cadence。一次 09:05 的失败会让 daily 静默停到次日 09:00。
+UI 上必须显式说明这一点,别让 "Next schedule window" 读起来像会自愈。
+
+## daily 的吞吐天花板是 `--max-sources × cadence`
+
+默认 `--max-sources 10`(`crates/ovp-daily/src/lib.rs:231`,`0`=无限)。进度条的分母也按它算,
+所以 "10/10" 是"本次打算处理的都做完了",不是"积压清空了"——差额在心跳的 `capped` / `queued_after`。
+`providers.toml` 的 `[budget] daily_token_budget` **不能当限流器**:它是 soft 的,只由
+`ovp2 usage` 打印一行,不拦截任何调用。
+
+## `run_id` 是按日期生成的
+
+`format!("daily-{date}")`(`crates/ovp-cli/src/main.rs:1556`)。同一天多次运行**共用一个 run_id**,
+`last-run.json` 会被覆盖。加高频 cadence 时要考虑这点。
+
+## console-ui:默认没有 node_modules,测试跑在 node env
+
+`npm ci` 后才有依赖。vitest 配的是 `environment: 'node'`——**没有 DOM,不能渲染组件**。
+所以组件里承载判断的逻辑必须抽成 `src/lib/derive.ts` 里的纯函数才测得了
+(例:`shouldClearRetry`)。i18n 模板的测试方式是自己 mirror `{name}` 插值,见
+`RunBanner.progress.test.ts`。
+
+## 落地流程
+
+feature 分支 → PR → coderabbitai + gemini 机器人评审(只在 PR 上,没有 push CI)→ 修 → 合。
+`codex` 是推送前的本地闸门(P1 = fail)。**不要 `git add -A`**——这个仓库经常有多个 agent
+同时在工作区里改东西,`-A` 会把别人的半成品一起提交。`IMPLEMENTATION_PLAN.md` 永不提交。

--- a/crates/ovp-scheduler/src/lib.rs
+++ b/crates/ovp-scheduler/src/lib.rs
@@ -46,6 +46,17 @@ pub enum Cadence {
         hour: u8,
         minute: u8,
     },
+    /// Every `hours` hours, ANCHORED AT LOCAL MIDNIGHT (`every 4h` → 00:00,
+    /// 04:00, …, 20:00). Anchoring — rather than stepping from `last_run` —
+    /// keeps occurrences drift-free: a late tick or a long run shifts nothing,
+    /// so `is_due` stays a pure function of the wall clock.
+    ///
+    /// `hours` that do not divide 24 leave a SHORT final slot before midnight
+    /// (`every 5h` → 00,05,10,15,20, then 00 four hours later). That is
+    /// accepted, not prevented: the alternative is drift.
+    EveryHours {
+        hours: u8,
+    },
 }
 
 fn parse_hm(s: &str) -> Result<(u8, u8), String> {
@@ -60,6 +71,23 @@ fn parse_hm(s: &str) -> Result<(u8, u8), String> {
         return Err(bad());
     }
     Ok((hour, minute))
+}
+
+/// Parse the `<N>h` of an `every <N>h` cadence. 1..=23 only: `24h` is `daily
+/// 00:00` (use that — it says what it means), and 0 would divide by zero.
+fn parse_every_hours(s: &str) -> Result<u8, String> {
+    let bad = || {
+        format!("invalid interval '{s}': expected <N>h with N in 1..=23, e.g. 4h (24h = 'daily 00:00')")
+    };
+    let n = s.strip_suffix('h').ok_or_else(bad)?;
+    if n.is_empty() || n.len() > 2 {
+        return Err(bad());
+    }
+    let hours: u8 = n.parse().map_err(|_| bad())?;
+    if !(1..=23).contains(&hours) {
+        return Err(bad());
+    }
+    Ok(hours)
 }
 
 fn parse_weekday(s: &str) -> Result<Weekday, String> {
@@ -90,7 +118,8 @@ fn weekday_abbr(wd: Weekday) -> &'static str {
 }
 
 impl Cadence {
-    /// Parse `"daily HH:MM"` or `"weekly <DOW> HH:MM"` (case-insensitive DOW).
+    /// Parse `"daily HH:MM"`, `"weekly <DOW> HH:MM"` (case-insensitive DOW), or
+    /// `"every <N>h"`.
     pub fn parse(s: &str) -> Result<Cadence, String> {
         let parts: Vec<&str> = s.split_whitespace().collect();
         match parts.as_slice() {
@@ -107,8 +136,12 @@ impl Cadence {
                     minute,
                 })
             }
+            ["every", spec] => {
+                let hours = parse_every_hours(spec)?;
+                Ok(Cadence::EveryHours { hours })
+            }
             _ => Err(format!(
-                "invalid cadence '{s}': expected 'daily HH:MM' or 'weekly <DOW> HH:MM'"
+                "invalid cadence '{s}': expected 'daily HH:MM', 'weekly <DOW> HH:MM', or 'every <N>h'"
             )),
         }
     }
@@ -121,6 +154,7 @@ impl Cadence {
                 hour,
                 minute,
             } => format!("weekly {} {hour:02}:{minute:02}", weekday_abbr(weekday)),
+            Cadence::EveryHours { hours } => format!("every {hours}h"),
         }
     }
 
@@ -156,17 +190,35 @@ impl Cadence {
                     cand - Duration::days(7)
                 }
             }
+            Cadence::EveryHours { hours } => {
+                // Anchor at LOCAL midnight and floor to the slot: the last
+                // occurrence is today's midnight + floor(elapsed_hours / N) * N.
+                // Sub-hour components are dropped, so 13:59 with `every 4h`
+                // resolves to 12:00, not 13:00.
+                let midnight = now.date().and_hms_opt(0, 0, 0).expect("midnight exists");
+                let slots = (now - midnight).num_hours() / hours as i64;
+                midnight + Duration::hours(slots * hours as i64)
+            }
         }
     }
 
     /// Next scheduled instant strictly after `now` (for status "next due").
     pub fn next_occurrence(self, now: NaiveDateTime) -> NaiveDateTime {
         let prev = self.most_recent_occurrence(now);
-        let step = match self {
-            Cadence::Daily { .. } => Duration::days(1),
-            Cadence::Weekly { .. } => Duration::days(7),
-        };
-        prev + step
+        match self {
+            Cadence::Daily { .. } => prev + Duration::days(1),
+            Cadence::Weekly { .. } => prev + Duration::days(7),
+            Cadence::EveryHours { hours } => {
+                // Midnight RE-ANCHORS the slot grid, so an interval that does
+                // not divide 24 must not step past it: `every 5h` goes
+                // 20:00 → 00:00 (the short final slot), never 01:00.
+                let stepped = prev + Duration::hours(hours as i64);
+                let next_midnight = (now.date() + Duration::days(1))
+                    .and_hms_opt(0, 0, 0)
+                    .expect("midnight exists");
+                stepped.min(next_midnight)
+            }
+        }
     }
 }
 
@@ -629,6 +681,95 @@ mod tests {
         ] {
             assert!(Cadence::parse(bad).is_err(), "{bad} should be rejected");
         }
+    }
+
+    // -- interval cadence (`every <N>h`) ------------------------------------
+
+    #[test]
+    fn interval_cadence_round_trips_and_rejects_garbage() {
+        for s in ["every 1h", "every 4h", "every 23h"] {
+            assert_eq!(Cadence::parse(s).unwrap().to_display(), s, "round-trip {s}");
+        }
+        for bad in [
+            "every 0h",   // would divide by zero
+            "every 24h",  // that is `daily 00:00` — say what you mean
+            "every 25h", "every 4", "every h", "every -4h", "every 4hh", "every 4h 00:00",
+        ] {
+            assert!(Cadence::parse(bad).is_err(), "{bad} should be rejected");
+        }
+    }
+
+    #[test]
+    fn interval_anchors_at_midnight_and_floors_to_the_slot() {
+        let c = Cadence::parse("every 4h").unwrap();
+        // Slots: 00 04 08 12 16 20. Sub-hour components are dropped.
+        for (now, want) in [
+            ("2026-07-12T00:00:00", "2026-07-12T00:00:00"),
+            ("2026-07-12T03:59:59", "2026-07-12T00:00:00"),
+            ("2026-07-12T04:00:00", "2026-07-12T04:00:00"),
+            ("2026-07-12T13:59:00", "2026-07-12T12:00:00"),
+            ("2026-07-12T23:59:59", "2026-07-12T20:00:00"),
+        ] {
+            assert_eq!(c.most_recent_occurrence(dt(now)), dt(want), "now={now}");
+        }
+    }
+
+    #[test]
+    fn interval_next_occurrence_never_steps_past_midnight() {
+        // 24 % 5 != 0, so the final slot is SHORT: 20:00 → 00:00, not 01:00.
+        // Stepping naively from `prev` would drift the whole next day's grid.
+        let c = Cadence::parse("every 5h").unwrap();
+        assert_eq!(
+            c.next_occurrence(dt("2026-07-12T21:30:00")),
+            dt("2026-07-13T00:00:00")
+        );
+        // A cadence that divides 24 is unaffected mid-day.
+        let c4 = Cadence::parse("every 4h").unwrap();
+        assert_eq!(
+            c4.next_occurrence(dt("2026-07-12T13:00:00")),
+            dt("2026-07-12T16:00:00")
+        );
+        assert_eq!(
+            c4.next_occurrence(dt("2026-07-12T21:00:00")),
+            dt("2026-07-13T00:00:00")
+        );
+    }
+
+    #[test]
+    fn interval_next_occurrence_is_strictly_after_now() {
+        for spec in ["every 1h", "every 4h", "every 5h", "every 7h", "every 23h"] {
+            let c = Cadence::parse(spec).unwrap();
+            for h in 0..24 {
+                for m in [0, 1, 30, 59] {
+                    let now = dt(&format!("2026-07-12T{h:02}:{m:02}:00"));
+                    let next = c.next_occurrence(now);
+                    assert!(next > now, "{spec} at {now}: next {next} must be > now");
+                    assert!(
+                        c.most_recent_occurrence(now) <= now,
+                        "{spec} at {now}: prev must be <= now"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn interval_is_due_once_per_slot() {
+        let c = Cadence::parse("every 4h").unwrap();
+        let now = dt("2026-07-12T13:00:00"); // slot 12:00
+        assert!(is_due(c, None, now), "never run → due");
+        assert!(
+            !is_due(c, Some(dt("2026-07-12T12:05:00")), now),
+            "already ran inside this slot → not due"
+        );
+        assert!(
+            is_due(c, Some(dt("2026-07-12T11:59:00")), now),
+            "ran in the PREVIOUS slot → due again"
+        );
+        // The is_due contract is status-blind (see `is_due` docs): a run that
+        // FAILED inside the slot still consumes it. With `every 4h` the wait is
+        // 4 hours, not the 24 a `daily` cadence would impose.
+        assert!(!is_due(c, Some(dt("2026-07-12T12:00:00")), now));
     }
 
     // -- most_recent_occurrence / is_due ------------------------------------


### PR DESCRIPTION
## Why

`daily` 的自动吞吐上限是 `--max-sources` × 每天一次。爆发日(07-13 的 177 篇、07-28 的 81 篇)只能靠手动跑清空——调度本身永远追不上。间隔 cadence 抬高天花板,同时不让任何单次运行变成无界。

配合把 vault 的 `--max-sources` 提到 20,吞吐从 10 篇/天 → 120 篇/天。

## `every <N>h`

- **锚定本地午夜**,不从 `last_run` 递推:一次晚 tick 或一次长运行不会推移后续槽位,`is_due` 保持为墙钟的纯函数。
- **`next_occurrence` 钳制到次日午夜**,因为午夜会重新锚定网格:`every 5h` 走 `20:00 → 00:00`(短槽),而不是 `01:00`——后者会让第二天整条网格漂移。
- 只接受 `1..=23`:`24h` 就是 `daily 00:00`(那个说人话),`0h` 会除零。

## ⚠️ 部署顺序

cadence 字符串**比运行中的二进制新**会导致 registry **加载期**失败,进而中止整个 tick ——**注册表里每个 job 都不跑**,不只是改的那个。desktop 只把子进程 stderr 写进 `eprintln`(Finder 启动时被吞),所以 GUI 里表现为"什么都没发生"。

**先装新 sidecar,再往 `.ovp/schedule.json` 写 `every <N>h`。** 已在本机按此顺序执行并验证(旧二进制吃到 `every 4h` 确实报 `invalid cadence` 并退出)。

## CLAUDE.md

这个仓库此前没有 CLAUDE.md。新增的只装**读代码目录看不出来**的 gotcha:sidecar 是定时任务实际执行的二进制、cadence 版本错配会停掉整个 tick、`is_due` 不看 `last_status`、daily 吞吐天花板(且 `daily_token_budget` 是纯报告不拦截)、`run_id` 按日期生成、console-ui 的 vitest 无 DOM。刻意不含目录导览、依赖清单、标准构建命令。

## Tests

`ovp-scheduler` 25 passed(新增 5)。含一个 480 组合的不变量测试:`prev <= now < next` 对 `{1,4,5,7,23}h` × 24 小时 × 4 分钟位恒成立。

## Note

`m31_e2e::daily_and_pinboard_sync_inherit_first_sync_flood_guard` 在本分支是红的——那是 main 上已有的回归,与本 PR 无关(stash 掉本 PR 改动后在 baseline 上复现过)。修复在 #412。