### PR TITLE
feat(intake): `ovp/skip` / `ovp/force` capture tags

### DIFF
--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -253,9 +253,17 @@ fn run_inner(
         let done = succeeded_hashes(&read_daily_ledger(&ledger_path).map_err(CliError::Io)?);
         let sweep = sweep_intake(&intake_cfg, &done, args.dry_run).map_err(CliError::Io)?;
         sayln!(
-            "  intake: {} ingested, {} duplicate(s), {} needs-content, {} unparseable{}{}",
+            "  intake: {} ingested, {} duplicate(s), {} needs-content, {} unparseable{}{}{}",
             sweep.ingested.len(), sweep.duplicates.len(), sweep.needs_content.len(),
             sweep.unparseable.len(),
+            // Surfaced, not silent: a capture the pipeline declined to read
+            // must show up in the run's own summary, or `ovp/skip` becomes a
+            // place where bookmarks quietly disappear.
+            if sweep.skipped.is_empty() {
+                String::new()
+            } else {
+                format!(", {} skipped by tag", sweep.skipped.len())
+            },
             if sweep.already_flagged > 0 {
                 format!(" ({} previously flagged)", sweep.already_flagged)
             } else {

--- a/crates/ovp-cli/src/commands/intake.rs
+++ b/crates/ovp-cli/src/commands/intake.rs
@@ -37,12 +37,14 @@ pub fn run(args: IntakeArgs) -> Result<(), CliError> {
         .chain(&sweep.duplicates)
         .chain(&sweep.needs_content)
         .chain(&sweep.unparseable)
+        .chain(&sweep.skipped)
     {
         let verb = match rec.action {
             IntakeAction::Ingested => "ingested",
             IntakeAction::Duplicate => "duplicate",
             IntakeAction::NeedsContent => "needs-content",
             IntakeAction::Unparseable => "unparseable",
+            IntakeAction::Skipped => "skipped",
         };
         match &rec.to {
             Some(to) => println!("  {verb:13} {} → {to}", rec.from),

--- a/crates/ovp-console/src/lib.rs
+++ b/crates/ovp-console/src/lib.rs
@@ -67,6 +67,7 @@ pub(crate) fn source_status_label(s: SourceStatus) -> (&'static str, &'static st
         SourceStatus::NeedsContent => ("needs content", "待补内容", "warn"),
         SourceStatus::Unparseable => ("unparseable", "无法解析", "warn"),
         SourceStatus::Duplicate => ("duplicate", "重复", "dim"),
+        SourceStatus::Skipped => ("skipped by tag", "已按标签跳过", "dim"),
     }
 }
 

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -215,6 +215,7 @@ fn build_sources(
             IntakeAction::Duplicate => SourceStatus::Duplicate,
             IntakeAction::NeedsContent => SourceStatus::NeedsContent,
             IntakeAction::Unparseable => SourceStatus::Unparseable,
+            IntakeAction::Skipped => SourceStatus::Skipped,
         };
         // Precedence: a later Duplicate record for the same hash means another
         // COPY was parked — it must not mask the canonical copy still queued

--- a/crates/ovp-index/src/model.rs
+++ b/crates/ovp-index/src/model.rs
@@ -25,6 +25,12 @@ pub enum SourceStatus {
     Processed,
     /// Parked as a duplicate of known content/URL.
     Duplicate,
+    /// Excluded by the operator's `ovp/skip` tag — a bookmark kept as a quick
+    /// entry point, not to be read. Its OWN status, deliberately: folding it
+    /// into `NeedsContent` would put it back in the enrichment queue, and
+    /// folding it into `Duplicate` would lie about why it is here. The
+    /// operator must be able to see, and undo, what they excluded.
+    Skipped,
 }
 
 /// Timeline axes for a source (do not collapse these into one field):

--- a/crates/ovp-index/src/query.rs
+++ b/crates/ovp-index/src/query.rs
@@ -420,6 +420,7 @@ pub fn source_status_str(s: SourceStatus) -> &'static str {
         SourceStatus::NeedsContent => "needs_content",
         SourceStatus::Unparseable => "unparseable",
         SourceStatus::Duplicate => "duplicate",
+        SourceStatus::Skipped => "skipped",
     }
 }
 

--- a/crates/ovp-intake/src/ledger.rs
+++ b/crates/ovp-intake/src/ledger.rs
@@ -25,6 +25,17 @@ pub enum IntakeAction {
     NeedsContent,
     /// Frontmatter does not parse; left in place for the operator to fix.
     Unparseable,
+    /// The capture carries the reserved skip tag: the operator bookmarked it as
+    /// a quick entry point, not as something to read. Terminal and hash-keyed —
+    /// removing the tag changes the hash and re-evaluates the file.
+    ///
+    /// This is INTENT, which no page heuristic can recover. A measurement over
+    /// the real 1448-source corpus found structural signals (sentence density,
+    /// separator density) could not separate brand/gallery pages from long
+    /// technical articles: a conservative threshold flagged a 73k-char
+    /// knowledge-base writeup and a 46k-char CUDA article alongside the three
+    /// real navigation pages. So the operator says so, and the pipeline obeys.
+    Skipped,
 }
 
 /// One capture-file disposition.
@@ -82,17 +93,36 @@ pub fn known_urls(records: &[IntakeRecord]) -> HashSet<String> {
         .collect()
 }
 
-/// Hashes previously flagged NeedsContent / Unparseable — skipped quietly on
-/// later sweeps (the record exists once; editing the file changes its hash
-/// and re-evaluates it).
+/// Hashes previously flagged NeedsContent / Unparseable / Skipped — skipped
+/// quietly on later sweeps (the record exists once; editing the file changes
+/// its hash and re-evaluates it).
+///
+/// The three are NOT equivalent downstream: NeedsContent/Unparseable are
+/// PENDING (enrichment retries them), while Skipped is TERMINAL by operator
+/// decision. Callers must branch on the returned action — see
+/// [`is_pending_flag`].
 pub fn flagged_hashes(records: &[IntakeRecord]) -> HashMap<String, IntakeAction> {
     records
         .iter()
         .filter(|r| {
-            matches!(r.action, IntakeAction::NeedsContent | IntakeAction::Unparseable)
+            matches!(
+                r.action,
+                IntakeAction::NeedsContent | IntakeAction::Unparseable | IntakeAction::Skipped
+            )
         })
         .map(|r| (r.sha256.clone(), r.action))
         .collect()
+}
+
+/// Whether a flagged capture is still WAITING on something (enrichment, an
+/// operator fix) rather than closed. `Skipped` is closed: re-fetching a page
+/// the operator has excluded is exactly the waste this tag exists to stop.
+pub fn is_pending_flag(action: IntakeAction) -> bool {
+    match action {
+        IntakeAction::NeedsContent | IntakeAction::Unparseable => true,
+        IntakeAction::Skipped => false,
+        IntakeAction::Ingested | IntakeAction::Duplicate => false,
+    }
 }
 
 #[cfg(test)]

--- a/crates/ovp-intake/src/sweep.rs
+++ b/crates/ovp-intake/src/sweep.rs
@@ -35,6 +35,54 @@ use crate::vaultops::{append_pipeline_event, hex_sha256, rel_to, safe_move, Pipe
 /// enrich (typical case: a bare pinboard bookmark with a one-line note).
 pub const MIN_READER_BODY_CHARS: usize = 200;
 
+/// Reserved capture tag: do not process this bookmark at all.
+pub const TAG_SKIP: &str = "ovp/skip";
+/// Reserved capture tag: process even when an automatic gate would hold it
+/// back (today: [`MIN_READER_BODY_CHARS`]).
+pub const TAG_FORCE: &str = "ovp/force";
+
+/// What the operator's reserved tags say about one capture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TagDirective {
+    /// No reserved tag — the automatic gates decide.
+    None,
+    /// `ovp/skip`: a bookmark kept as a quick entry point, not to be read.
+    Skip,
+    /// `ovp/force`: read it even if a gate would hold it back.
+    Force,
+}
+
+/// Read the reserved tags off a capture.
+///
+/// Forgiving about shape — `#ovp/skip`, `ovp-skip`, `OVP/Skip` and `ovp_skip`
+/// all count — because these are typed by hand into Pinboard and Obsidian,
+/// which disagree about leading `#` and about which separators are legal. The
+/// forgiveness is one normalization, not a list of accepted spellings.
+///
+/// `Skip` beats `Force` when both are present: the two are contradictory, and
+/// the safe reading of a contradiction is "leave it alone" — a wrongly skipped
+/// capture is one tag edit away from being read, while a wrongly read one has
+/// already spent the LLM call.
+pub fn tag_directive(tags: &[String]) -> TagDirective {
+    let norm = |t: &String| {
+        t.trim()
+            .trim_start_matches('#')
+            .to_ascii_lowercase()
+            .replace(['-', '_'], "/")
+    };
+    let mut force = false;
+    for t in tags {
+        let t = norm(t);
+        if t == TAG_SKIP {
+            return TagDirective::Skip;
+        }
+        if t == TAG_FORCE {
+            force = true;
+        }
+    }
+    if force { TagDirective::Force } else { TagDirective::None }
+}
+
 #[derive(Debug, Clone)]
 pub struct IntakeConfig {
     pub vault_root: PathBuf,
@@ -58,8 +106,10 @@ pub struct SweepOutcome {
     pub duplicates: Vec<IntakeRecord>,
     pub needs_content: Vec<IntakeRecord>,
     pub unparseable: Vec<IntakeRecord>,
-    /// Files whose hash was already flagged needs_content/unparseable on an
-    /// earlier sweep — still sitting in a capture dir, skipped quietly.
+    /// Captures the operator excluded with `ovp/skip`.
+    pub skipped: Vec<IntakeRecord>,
+    /// Files whose hash was already flagged needs_content/unparseable/skipped
+    /// on an earlier sweep — still sitting in a capture dir, skipped quietly.
     pub already_flagged: usize,
     /// The already-flagged files as `(from, url)` pairs, so the enrichment
     /// phases can RETRY them (a fetch that failed on an earlier run, or a
@@ -72,7 +122,7 @@ pub struct SweepOutcome {
 impl SweepOutcome {
     pub fn total_new_records(&self) -> usize {
         self.ingested.len() + self.duplicates.len() + self.needs_content.len()
-            + self.unparseable.len()
+            + self.unparseable.len() + self.skipped.len()
     }
 }
 
@@ -107,15 +157,21 @@ pub fn sweep_intake(
             let sha256 = hex_sha256(&bytes);
             let from = rel_to(&cfg.vault_root, &path);
 
-            if flagged.contains_key(&sha256) {
+            if let Some(prev) = flagged.get(&sha256) {
                 outcome.already_flagged += 1;
-                // Parse best-effort for the URL so enrichment can retry this
-                // previously-flagged capture (it is still pending, not done).
-                let url = read_source_from_path(&path)
-                    .ok()
-                    .filter(|s| !s.source_url.is_empty())
-                    .map(|s| s.source_url);
-                outcome.flagged_pending.push((from.clone(), url));
+                // Only PENDING flags go back to enrichment. A capture the
+                // operator skipped is closed: re-fetching it every run is the
+                // waste `ovp/skip` exists to stop, and at `every 4h` that waste
+                // is six times a day.
+                if crate::ledger::is_pending_flag(*prev) {
+                    // Parse best-effort for the URL so enrichment can retry this
+                    // previously-flagged capture (it is still pending, not done).
+                    let url = read_source_from_path(&path)
+                        .ok()
+                        .filter(|s| !s.source_url.is_empty())
+                        .map(|s| s.source_url);
+                    outcome.flagged_pending.push((from.clone(), url));
+                }
                 continue;
             }
             if known_hashes.contains(&sha256) {
@@ -153,8 +209,24 @@ pub fn sweep_intake(
                     continue;
                 }
 
+            // Operator intent first: `ovp/skip` closes the capture before any
+            // gate or fetch spends anything on it.
+            let directive = tag_directive(&source.tags);
+            if directive == TagDirective::Skip {
+                let rec = record(cfg, IntakeAction::Skipped, &from, None, url, &sha256,
+                    Some(source.title.clone()),
+                    Some(format!("tagged {TAG_SKIP}")));
+                if !dry_run {
+                    append_intake_record(&ledger_path, &rec)?;
+                }
+                outcome.skipped.push(rec);
+                continue;
+            }
+
             let body_chars = source.body_markdown.trim().chars().count();
-            if body_chars < cfg.min_reader_body_chars {
+            // `ovp/force` overrides the size gate — the escape hatch that keeps
+            // an automatic threshold from becoming a silent trap.
+            if body_chars < cfg.min_reader_body_chars && directive != TagDirective::Force {
                 let rec = record(cfg, IntakeAction::NeedsContent, &from, None, url, &sha256,
                     Some(source.title.clone()),
                     Some(format!("body {body_chars} chars < {}", cfg.min_reader_body_chars)));
@@ -359,5 +431,56 @@ mod tests {
         assert_eq!(pick_date(Some("2026-05-30T01:02:03Z"), "2026-06-09"), "2026-05-30");
         assert_eq!(pick_date(Some("not a date"), "2026-06-09"), "2026-06-09");
         assert_eq!(pick_date(None, "2026-06-09"), "2026-06-09");
+    }
+
+    fn tags(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn tag_directive_ignores_ordinary_tags() {
+        assert_eq!(tag_directive(&[]), TagDirective::None);
+        assert_eq!(
+            tag_directive(&tags(&["clippings", "pinboard", "design"])),
+            TagDirective::None
+        );
+        // Near-misses must NOT match: these are real tags someone could use.
+        assert_eq!(tag_directive(&tags(&["ovp"])), TagDirective::None);
+        assert_eq!(tag_directive(&tags(&["skip"])), TagDirective::None);
+        assert_eq!(tag_directive(&tags(&["ovp/skipped"])), TagDirective::None);
+        assert_eq!(tag_directive(&tags(&["not-ovp/skip"])), TagDirective::None);
+    }
+
+    #[test]
+    fn tag_directive_accepts_the_shapes_pinboard_and_obsidian_produce() {
+        // Leading `#`, case, and `-`/`_` separators all normalize.
+        for t in ["ovp/skip", "#ovp/skip", "OVP/Skip", "ovp-skip", "ovp_skip", "  #OVP-SKIP  "] {
+            assert_eq!(tag_directive(&tags(&[t])), TagDirective::Skip, "{t}");
+        }
+        for t in ["ovp/force", "#ovp/force", "OVP-Force", "ovp_force"] {
+            assert_eq!(tag_directive(&tags(&[t])), TagDirective::Force, "{t}");
+        }
+        assert_eq!(
+            tag_directive(&tags(&["clippings", "ovp/force", "ai"])),
+            TagDirective::Force
+        );
+    }
+
+    #[test]
+    fn skip_beats_force_when_the_operator_tagged_both() {
+        // Contradictory input; the safe reading is "leave it alone". A wrongly
+        // skipped capture costs one tag edit; a wrongly read one has already
+        // spent the call.
+        assert_eq!(tag_directive(&tags(&["ovp/force", "ovp/skip"])), TagDirective::Skip);
+        assert_eq!(tag_directive(&tags(&["ovp/skip", "ovp/force"])), TagDirective::Skip);
+    }
+
+    #[test]
+    fn skipped_is_terminal_but_pending_flags_still_retry() {
+        use crate::ledger::is_pending_flag;
+        assert!(is_pending_flag(IntakeAction::NeedsContent));
+        assert!(is_pending_flag(IntakeAction::Unparseable));
+        // The whole point: enrichment must never re-fetch a skipped capture.
+        assert!(!is_pending_flag(IntakeAction::Skipped));
     }
 }

--- a/crates/ovp-intake/tests/intake_e2e.rs
+++ b/crates/ovp-intake/tests/intake_e2e.rs
@@ -316,3 +316,70 @@ fn pinboard_first_sync_guard_exempts_dry_run_but_reports_it() {
     assert!(!root.join("50-Inbox/02-Pinboard").exists(), "dry run writes nothing");
     assert!(!root.join(".ovp/pinboard-sync.jsonl").exists());
 }
+
+/// `ovp/skip` is a TERMINAL disposition, and `ovp/force` overrides the size
+/// gate. Both are operator intent, which no page heuristic can recover: a
+/// measurement over the real 1448-source corpus found that structural signals
+/// flagged a 73k-char knowledge-base writeup and a 46k-char CUDA article
+/// alongside the three genuine navigation pages, so the operator says so.
+#[test]
+fn reserved_tags_skip_terminally_and_force_past_the_size_gate() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let clippings = root.join("Clippings");
+    std::fs::create_dir_all(&clippings).unwrap();
+
+    let tagged = |title: &str, url: &str, body: &str, tag: &str| {
+        format!(
+            "---\ntitle: \"{title}\"\nsource: \"{url}\"\npublished: 2026-06-01\n\
+             created: 2026-06-08\ntags:\n  - \"clippings\"\n  - \"{tag}\"\n---\n{body}\n"
+        )
+    };
+
+    // A brand homepage the operator keeps as a quick entry point. Body is LONG,
+    // so no automatic gate would have caught it — only the tag does.
+    std::fs::write(
+        clippings.join("Brand Home.md"),
+        tagged("Brand Home", "https://e.x/brand", LONG_BODY, "ovp/skip"),
+    )
+    .unwrap();
+    // A deliberately terse note the operator wants read anyway (below the
+    // 200-char gate, which would otherwise park it as needs-content).
+    std::fs::write(
+        clippings.join("Short But Wanted.md"),
+        tagged("Short But Wanted", "https://e.x/short", "Two sentences. That is all.", "ovp/force"),
+    )
+    .unwrap();
+
+    let sweep = sweep_intake(&cfg(root), &HashSet::new(), false).unwrap();
+    assert_eq!(sweep.skipped.len(), 1, "the tagged homepage is skipped");
+    assert_eq!(sweep.skipped[0].title.as_deref(), Some("Brand Home"));
+    assert_eq!(sweep.needs_content.len(), 0, "force beat the size gate");
+    assert_eq!(sweep.ingested.len(), 1, "only the forced note was ingested");
+    assert_eq!(sweep.ingested[0].title.as_deref(), Some("Short But Wanted"));
+
+    // Re-sweep: the skipped capture is recognised by hash and NOT re-recorded.
+    // Critically it must not land in `flagged_pending` either — that list is
+    // what enrichment re-fetches, and re-fetching a skipped page every run is
+    // exactly the waste this tag exists to stop (six times a day at `every 4h`).
+    let again = sweep_intake(&cfg(root), &HashSet::new(), false).unwrap();
+    assert_eq!(again.skipped.len(), 0, "no duplicate skip record");
+    assert_eq!(again.already_flagged, 1);
+    assert!(
+        again.flagged_pending.is_empty(),
+        "a skipped capture must never be handed back to enrichment: {:?}",
+        again.flagged_pending
+    );
+
+    // The ledger carries the reason, so the disposition is auditable.
+    let ledger = read_intake_ledger(&root.join(".ovp/intake.jsonl")).unwrap();
+    let skip_rec = ledger
+        .iter()
+        .find(|r| r.title.as_deref() == Some("Brand Home"))
+        .expect("skip record persisted");
+    assert!(
+        skip_rec.note.as_deref().unwrap_or("").contains("ovp/skip"),
+        "note names the tag: {:?}",
+        skip_rec.note
+    );
+}

--- a/crates/ovp-memory/src/source_work_auto.rs
+++ b/crates/ovp-memory/src/source_work_auto.rs
@@ -210,6 +210,9 @@ pub fn candidates_from_index(
             | SourceStatus::NeedsContent
             | SourceStatus::Queued
             | SourceStatus::Unparseable
+            // Operator-excluded: it never became a readable source, and
+            // queueing it here would spend on exactly what `ovp/skip` declined.
+            | SourceStatus::Skipped
             | SourceStatus::Failed => continue,
             SourceStatus::Processed | SourceStatus::Duplicate => {}
         }


### PR DESCRIPTION
## 问题

有些书签是**入口**,不是读物:品牌首页、画廊站、注册页。它们现在会跑完整的 grounded reader,要么硬失败(`0 units extracted`),要么**更糟——"成功"了**:3 个 unit、1 张什么都没说的卡,静默污染语料。

## 为什么不是启发式闸门

先试的是结构闸门,并且**用真实的 1448 个源量过**。结论是不成立:

保守阈值(>300 字符/句 或 >60 个 `·` 分隔符)命中 18 个,其中只有约 3 个是真导航页。同时命中的还有:

- `How we built our knowledge base`(73,877 字,真文章)
- `GPU 架构十年演化与 CUDA 编程模型的同步膨胀`(46,342 字,真技术长文)
- `benchflow-ai awesome-evals`(84,420 字)、多个真 README

中间带直接重叠:`Design Arena`(导航)85.8 字/句 ↔ `You're doing RAG wrong`(文章)83.2。**把阈值收紧到能抓住中间带,就开始删真文章。**

原因也清楚:web-fetch 把页面抹平成纯文本,链接全没了;真正的区别是"这些字是 UI chrome",而那从廉价结构特征里判不出来。

按仓库的 decidability rule,这件事属于**不可判定**分支——不该用代码规则硬做。

## 方案:意图来自操作者

两个保留标签,在 intake 阶段读取,**早于任何抓取和花费**:

| 标签 | 行为 |
|---|---|
| `ovp/skip` | 终态。哈希键控(和现有 flag 一致),**去掉标签即改变哈希 → 自动复评** |
| `ovp/force` | 越过 `MIN_READER_BODY_CHARS` 闸门 |

**`skip` 不会回到 enrichment**(`is_pending_flag`):重新抓一个已被排除的页面,正是这个标签要消灭的浪费——在 `every 4h` 下是每天 6 次。

**`ovp/force` 是关键的另一半**:没有覆盖手段的自动阈值就是个静默陷阱。

**两个都打时 `skip` 胜出**:它们互相矛盾,而误跳过只差一次标签编辑就能救回,误读则已经把钱花掉了。

## 细节

- 标签匹配归一化前导 `#`、大小写、`-`/`_` 分隔符(Pinboard 和 Obsidian 三件事都不一致)。是**一次归一化,不是一张拼写白名单**——`ovp/skipped`、`not-ovp/skip` 仍然不匹配,有测试锁死。
- `SourceStatus::Skipped` 是**独立状态**,没有并进 `NeedsContent`(会把它重新排进队列)或 `Duplicate`(会谎报原因)。
- daily 摘要打印 `N skipped by tag`,`source_work_auto` 排除它——**管线拒绝处理的东西不能悄悄消失**。

## Tests

ovp-intake lib 27 + 新增 4 个纯函数测试 + 1 个 e2e(验证终态、不回到 enrichment、force 越闸、ledger 记录原因)。workspace 其余全绿。

## 已知红

`m31_e2e::daily_and_pinboard_sync_inherit_first_sync_flood_guard` 在本分支是红的——**main 上已有的回归,与本 PR 无关**,修复在 #412。本分支基于 origin/main,#412 合了这个红就消失。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `ovp/skip` tags to exclude captures from processing.
  - Added `ovp/force` tags to bypass minimum-content requirements.
  - Skip and force tags support flexible formatting and clear precedence.

- **Improvements**
  - Intake results now show skipped records and totals.
  - Skipped captures are clearly labeled in English and Chinese.
  - Skipped items are not retried or selected for automatic backfill.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->