### PR TITLE
docs: 改完之后要重建什么(动作对照表)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,18 +8,72 @@ Only gotchas below. Anything derivable by reading the code is deliberately absen
 
 ---
 
+# 改完之后要做什么
+
+**先查这张表,再去测。** 装了 OVP2.app 的机器上跑着四份互相独立的产物,改了 A 却
+只更新了 B,现象是"改动完全没生效",而代码、测试、构建全是绿的——这是本仓库最贵的
+时间浪费来源。
+
+| 你改了什么 | 要做的动作 | 重启 app? |
+|---|---|---|
+| `crates/*`(**除** `ovp-server`)<br>daily / intake / scheduler / reader / CLI | `INSTALL_APP=/Applications/OVP2.app scripts/build-desktop-sidecar.sh` | 否 |
+| `crates/ovp-server` | 重建整个 desktop app(见下) | **是** |
+| `apps/desktop/src-tauri/*`<br>scheduler 间隔 / boot / 窗口 / 菜单 | 重建整个 desktop app | **是** |
+| `console-ui/*` | `npm run build` + 同步 dist(见下) | 否,刷新页面 |
+| `.ovp/schedule.json` | 无——下次 tick 自动读 | 否 |
+| `.ovp/providers.toml` | 无——每次调用重读 | 否 |
+
+## 为什么 `ovp-server` 不在 sidecar 那一行
+
+`apps/desktop/src-tauri/Cargo.toml` **直接依赖 `ovp-server`**,它被编译进 `ovp2-desktop`
+并在进程内运行。改了 server 去重建 sidecar 是**完全无效**的——sidecar 是 CLI(`ovp2 serve`
+才用它那份),和门户 API 走的不是同一份代码。
+
 ## 定时任务跑的是 app sidecar,不是 `target/release/ovp2`
 
 Desktop 的 scheduler exec `resolve_ovp2_bin()`(`apps/desktop/src-tauri/src/lib.rs:309`):
 `OVP2_BIN` → app 内 sidecar → dev fallback。**`cargo build --release` 到不了定时任务。**
 
+不用重启 app——每次 tick 都重新 spawn 进程,读的是磁盘上当前那个文件。验收方式是比对
+sidecar 的 mtime/哈希与目标提交,**不是看 `cargo build` 成功**。dev fallback 尤其危险:
+它会命中一个可能没编 live features 的 `target/release/ovp2`,然后把
+`--features web-fetch-live` 这种构建期错误抛给 GUI 用户。
+
+## 前端:vault 里那份副本会遮蔽一切
+
+`resolve_static` 的优先级是 **`<vault>/.ovp/console/app/` 先,`--viz-dir` 后**,而且是
+**逐文件**的(`ovp-server/src/lib.rs:4557`)。vault 里只要有这个目录,app 包里新的
+`console-ui/dist` 就永远不生效——`/` 命中旧的 `index.html`,它引用旧的 asset 哈希,
+那些 asset 也在 vault 副本里,于是整页都是旧构建。
+
+代码里**没有任何地方写** `.ovp/console/app/`,它是历史上手工拷进去的(`serve --viz-dir`
+overlay 本来就是为了取代这个手工步骤)。所以两条路选一条:
+
 ```bash
-INSTALL_APP=/Applications/OVP2.app scripts/build-desktop-sidecar.sh
+# A. 让 app 自带的构建生效(推荐):删掉 vault 里的遮蔽副本
+rm -rf <vault>/.ovp/console/app
+
+# B. 不重新打包 app 就想看到新前端:直接覆盖 vault 那份
+npm --prefix console-ui run build
+rsync -a --delete console-ui/dist/ <vault>/.ovp/console/app/
 ```
 
-不用重启 app——每次 tick 都重新 spawn 进程。验收方式是比对 sidecar 的 mtime/哈希与目标提交,
-不是看 `cargo build` 成功。dev fallback 尤其危险:它会命中一个可能没编 live features 的
-`target/release/ovp2`,然后把 `--features web-fetch-live` 这种构建期错误抛给 GUI 用户。
+两种都不用重启进程,刷新页面即可。**验收方式是比对页面实际引用的 asset 哈希**:
+
+```bash
+curl -s http://127.0.0.1:<port>/ | grep -o 'assets/[^"]*\.js'
+```
+
+端口在 `<vault>/.ovp/desktop-portal.log` 里(每次启动一个随机端口)。
+
+## 重建整个 desktop app
+
+```bash
+npm --prefix apps/desktop run tauri build
+```
+
+产物要装回 `/Applications/OVP2.app` 才算数,并且**必须退出再重开**——`ovp2-desktop` 是
+常驻进程,替换磁盘上的文件不影响已经跑着的那个。
 
 ## cadence 语法比二进制新 = 整个 tick 停摆
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,15 +39,24 @@ sidecar 的 mtime/哈希与目标提交,**不是看 `cargo build` 成功**。dev
 它会命中一个可能没编 live features 的 `target/release/ovp2`,然后把
 `--features web-fetch-live` 这种构建期错误抛给 GUI 用户。
 
-## 前端住在 vault 里,不在 app 包里
+## 前端有两份,vault 那份优先
 
-`read_app_file`(`ovp-server/src/lib.rs:4557`)**逐文件**地先查
-`<vault>/.ovp/console/app/`,再退到 `--viz-dir` / app 包自带的 dist。这是 `2987cebb`
-定下的:**已部署副本是权威,overlay 只是 dev checkout 服务任意 vault 时的兜底。**
+两份都能独立工作,`read_app_file`(`ovp-server/src/lib.rs:4557`)**逐文件**决定用哪份:
 
-后果是新人最容易踩的一脚:**重新打包 desktop app 不会改变门户显示的东西。** vault 里那份
+| 位置 | 角色 | 什么时候更新 |
+|---|---|---|
+| `<vault>/.ovp/console/app/` | **优先**。存在就赢 | 手动部署(`deploy-portal.sh`) |
+| app 包 `Contents/Resources/console-ui/dist` | 兜底(经 `--viz-dir`) | 重新打包 app 时 |
+
+最终用户的 vault 里**没有**第一份,门户就吃 app 包那份——这是正常路径。第一份是给
+"不重新打包就要看到前端改动"用的,也就是开发迭代。
+
+这个优先级是 `2987cebb` 有意定的:已部署副本让 vault 自成一体(`ovp2 serve` 时代的需求),
+`--viz-dir` 让 dev checkout 能服务任意 vault。**两者是不同场景,不是替代关系。**
+
+坑在于开发机上两份都在:**重新打包 desktop app 不会改变门户显示的东西。** vault 那份
 `index.html` 赢,它引用旧的 asset 哈希,那些 asset 也从同一份旧副本解析出来——整页都是旧
-构建,而构建日志全绿。
+构建,而构建日志全绿。不想要这个优先级就删掉 vault 那份,门户立刻回到 app 包那份。
 
 所以改完前端要跑:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Only gotchas below. Anything derivable by reading the code is deliberately absen
 | `crates/*`(**除** `ovp-server`)<br>daily / intake / scheduler / reader / CLI | `INSTALL_APP=/Applications/OVP2.app scripts/build-desktop-sidecar.sh` | 否 |
 | `crates/ovp-server` | 重建整个 desktop app(见下) | **是** |
 | `apps/desktop/src-tauri/*`<br>scheduler 间隔 / boot / 窗口 / 菜单 | 重建整个 desktop app | **是** |
-| `console-ui/*` | `npm run build` + 同步 dist(见下) | 否,刷新页面 |
+| `console-ui/*` | `scripts/deploy-portal.sh <vault>`(见下) | 否,硬刷新页面 |
 | `.ovp/schedule.json` | 无——下次 tick 自动读 | 否 |
 | `.ovp/providers.toml` | 无——每次调用重读 | 否 |
 
@@ -39,32 +39,26 @@ sidecar 的 mtime/哈希与目标提交,**不是看 `cargo build` 成功**。dev
 它会命中一个可能没编 live features 的 `target/release/ovp2`,然后把
 `--features web-fetch-live` 这种构建期错误抛给 GUI 用户。
 
-## 前端:vault 里那份副本会遮蔽一切
+## 前端住在 vault 里,不在 app 包里
 
-`resolve_static` 的优先级是 **`<vault>/.ovp/console/app/` 先,`--viz-dir` 后**,而且是
-**逐文件**的(`ovp-server/src/lib.rs:4557`)。vault 里只要有这个目录,app 包里新的
-`console-ui/dist` 就永远不生效——`/` 命中旧的 `index.html`,它引用旧的 asset 哈希,
-那些 asset 也在 vault 副本里,于是整页都是旧构建。
+`read_app_file`(`ovp-server/src/lib.rs:4557`)**逐文件**地先查
+`<vault>/.ovp/console/app/`,再退到 `--viz-dir` / app 包自带的 dist。这是 `2987cebb`
+定下的:**已部署副本是权威,overlay 只是 dev checkout 服务任意 vault 时的兜底。**
 
-代码里**没有任何地方写** `.ovp/console/app/`,它是历史上手工拷进去的(`serve --viz-dir`
-overlay 本来就是为了取代这个手工步骤)。所以两条路选一条:
+后果是新人最容易踩的一脚:**重新打包 desktop app 不会改变门户显示的东西。** vault 里那份
+`index.html` 赢,它引用旧的 asset 哈希,那些 asset 也从同一份旧副本解析出来——整页都是旧
+构建,而构建日志全绿。
 
-```bash
-# A. 让 app 自带的构建生效(推荐):删掉 vault 里的遮蔽副本
-rm -rf <vault>/.ovp/console/app
-
-# B. 不重新打包 app 就想看到新前端:直接覆盖 vault 那份
-npm --prefix console-ui run build
-rsync -a --delete console-ui/dist/ <vault>/.ovp/console/app/
-```
-
-两种都不用重启进程,刷新页面即可。**验收方式是比对页面实际引用的 asset 哈希**:
+所以改完前端要跑:
 
 ```bash
-curl -s http://127.0.0.1:<port>/ | grep -o 'assets/[^"]*\.js'
+scripts/deploy-portal.sh <vault-root>
 ```
 
-端口在 `<vault>/.ovp/desktop-portal.log` 里(每次启动一个随机端口)。
+它构建、部署、然后**去跑着的门户上取实际 asset 哈希做比对**。验收看的是这个比对,
+**不是 `npm run build` 的退出码**——后者正是让这个错误活过一整轮调试的东西。
+
+完整背景和手工步骤见 `docs/operator-runbook.md` 的 "Portal SPA deploy"。
 
 ## 重建整个 desktop app
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Only leave the machine when **you** configure them:
 |---|---|
 | [`docs/install.md`](docs/install.md) | Installers, desktop, versions |
 | [`docs/operator-runbook.md`](docs/operator-runbook.md) | Real-vault operation, failures, recovery |
+| [`CLAUDE.md`](CLAUDE.md) | **Contributors: what to rebuild after which change** — a machine with the desktop app installed runs four independent artifacts, and updating the wrong one looks exactly like "my change did nothing" |
 | [`docs/ovp-to-ovp2.md`](docs/ovp-to-ovp2.md) | Story of the rewrite & migration ([中文](docs/ovp-to-ovp2.zh-CN.md)) |
 | [`docs/architecture.md`](docs/architecture.md) | Crate map & dataflow (engineers) |
 | [`docs/product-state-layout.md`](docs/product-state-layout.md) | Where state lives on disk |

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -88,6 +88,39 @@ The old generated console stays reachable at `/legacy-index.html`
 portal's System page). After a `daily` run while the server is up, hit
 `/api/refresh` (or restart) to reload the index.
 
+#### Portal SPA deploy — after ANY `console-ui/` change
+
+```bash
+scripts/deploy-portal.sh "$VAULT"
+```
+
+Builds, deploys into `$VAULT/.ovp/console/app/`, then reads the asset hash a
+running portal actually serves and compares it against the one just built.
+Hard-refresh the browser afterwards (Cmd+Shift+R) if a tab was already open.
+
+**Read this part even if you never touch the frontend**, because the failure
+mode looks like a backend bug: file resolution checks the vault's deployed
+`.ovp/console/app/` BEFORE the `--viz-dir` overlay and before the desktop
+app's bundled `console-ui/dist`, per file (`read_app_file` in
+`crates/ovp-server/src/lib.rs`). While that directory exists it is
+authoritative — so **rebuilding the binary, or repackaging the whole desktop
+app, changes nothing about what the portal shows.** `/` resolves to the
+deployed `index.html`, which names the old asset hashes, which resolve from
+the same deployed copy. Every layer is internally consistent and every build
+log is green; the page is simply the old build.
+
+That is why the script verifies instead of just copying: a successful
+`npm run build` is the evidence that keeps this mistake alive.
+
+The precedence is deliberate (`2987cebb`): a deployed copy makes a vault
+self-contained, and `--viz-dir` exists so a dev checkout can serve ANY vault
+without deploying first — the two are different jobs, not alternatives. To
+hand the vault back to the app's bundled build, delete the deployed copy:
+
+```bash
+rm -rf "$VAULT/.ovp/console/app"      # then the app bundle / --viz-dir serves
+```
+
 Useful variants:
 
 ```bash

--- a/scripts/deploy-portal.sh
+++ b/scripts/deploy-portal.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Build the portal SPA and deploy it into a vault, then PROVE it took effect.
+#
+# Why this exists: `serve` resolves each file from the vault's deployed
+# `.ovp/console/app/` BEFORE the `--viz-dir` overlay / app bundle
+# (`read_app_file`, ovp-server/src/lib.rs). So while that directory exists,
+# rebuilding the binary — or repackaging the desktop app — changes nothing
+# about what the portal serves. The stale `index.html` wins, it names stale
+# asset hashes, and those resolve from the same stale copy: the whole page is
+# the old build, with a green build log to match.
+#
+# The verify step is the point. "npm run build succeeded" is exactly the
+# evidence that lets this mistake survive a debugging session.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VAULT="${1:-${OVP2_VAULT:-}}"
+if [[ -z "$VAULT" ]]; then
+  echo "usage: $0 <vault-root>    (or set OVP2_VAULT)" >&2
+  exit 2
+fi
+if [[ ! -d "$VAULT/.ovp" ]]; then
+  echo "not a vault (no .ovp/): $VAULT" >&2
+  exit 2
+fi
+
+APP_DIR="$VAULT/.ovp/console/app"
+DIST="$ROOT/console-ui/dist"
+
+echo "==> building console-ui"
+npm --prefix "$ROOT/console-ui" run build
+
+echo "==> deploying to $APP_DIR"
+# Replace wholesale: a merge would leave orphaned old asset hashes behind, and
+# those are exactly what a stale index.html would keep pointing at.
+rm -rf "$APP_DIR"
+mkdir -p "$APP_DIR"
+cp -R "$DIST"/. "$APP_DIR"/
+
+BUILT_HASH="$(grep -o 'assets/[A-Za-z0-9._-]*\.js' "$DIST/index.html" | head -1)"
+echo "==> built entry: $BUILT_HASH"
+
+# Verify against a RUNNING portal when we can find one. The desktop app picks a
+# fresh random port each launch and records it here; `ovp2 serve` defaults to
+# 3141. A miss is not an error — the deploy is still done.
+PORT="$(grep -o '127\.0\.0\.1:[0-9]*' "$VAULT/.ovp/desktop-portal.log" 2>/dev/null | tail -1 | cut -d: -f2 || true)"
+PORT="${PORT:-3141}"
+SERVED="$(curl -fsS --max-time 3 "http://127.0.0.1:$PORT/" 2>/dev/null \
+  | grep -o 'assets/[A-Za-z0-9._-]*\.js' | head -1 || true)"
+
+if [[ -z "$SERVED" ]]; then
+  echo "==> no portal answering on 127.0.0.1:$PORT — deployed, not verified live"
+  echo "    start one, then: curl -s http://127.0.0.1:<port>/ | grep -o 'assets/[^\"]*\.js'"
+  exit 0
+fi
+
+if [[ "$SERVED" == "$BUILT_HASH" ]]; then
+  echo "==> verified: portal on :$PORT serves $SERVED"
+  echo "    hard-refresh the browser (Cmd+Shift+R) if the tab was already open"
+else
+  echo "!!! MISMATCH: portal on :$PORT serves $SERVED, expected $BUILT_HASH" >&2
+  echo "    the running server is reading a different copy — check for another" >&2
+  echo "    vault, or an OVP2_VIZ_DIR override on the running process." >&2
+  exit 1
+fi


### PR DESCRIPTION
## 问题

装了 `OVP2.app` 的机器上跑着**四份互相独立的产物**:

1. app 内的 `ovp2` sidecar(定时任务用)
2. `ovp2-desktop` 外壳(常驻进程,**门户 server 在它进程内**)
3. app 包里的 `console-ui/dist`
4. **vault 里的 `.ovp/console/app/`**

改了 1 却只刷新了 3,现象是"改动完全没生效",而代码、测试、构建**全是绿的**。这个类别的错误今晚就撞了两次。

## 两条真正反直觉的边界

**`crates/ovp-server` 不在 sidecar 那条线上。** `apps/desktop/src-tauri/Cargo.toml:36` 直接依赖 `ovp-server`,它被编译进 `ovp2-desktop` 进程内运行。改了 server 去重建 sidecar 是**完全无效**的——门户 API 和 CLI 不是同一份代码。必须重建 app **并重启**。

**`<vault>/.ovp/console/app/` 逐文件遮蔽 app 自带的 dist**(`read_app_file`,`ovp-server/src/lib.rs:4557`)。只要这个目录在,**重新打包多少次都没用**:`/` 命中旧的 `index.html` → 它引用旧 asset 哈希 → 那些 asset 也在 vault 副本里 → 整页都是旧构建。

代码里**没有任何地方写**这个目录,它是 `--viz-dir` overlay 出现之前手工拷进去的遗留物。当前这个 vault 里就有一份 08-02 的。

## 内容

一张 6 行的对照表(改什么 → 做什么 → 要不要重启),外加每条的**验收方式**。

验收那部分是刻意加的:"构建成功了"正是让这类错误活下来的原因。所以表里写的是——比对已安装 sidecar 的 mtime 与目标提交、比对页面**实际引用**的 asset 哈希与刚构建出来的,而不是看 `cargo build` / `npm run build` 的退出码。

## Note

纯文档,无代码改动。