### PR TITLE
docs: 刷新中英 README —— 补上 9 天的产品变化

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ A morning dashboard: captures, reads, new claims, and items that need attention.
 
 ### Library — everything you captured
 
-Browse by collection and month. Open any source for **memory cards**, the original markdown, and claims that cite it — with a neighborhood graph on the side.
+Browse by collection and month. Open any source for **memory cards**, the full original
+document, and claims that cite it — with a neighborhood graph on the side. Markdown renders
+properly, Mermaid diagrams included.
+
+Per source, on demand: a **deep summary**, a **中文 translation**, **companion links** to
+related sources, and **chat about this one** — enrichment you ask for, not a bill the daily
+loop runs up on everything you ever saved.
 
 <p align="center">
   <img src="docs/images/02-library.png" alt="Library list of processed sources with tags and status" width="900" />
@@ -55,6 +61,10 @@ Browse by collection and month. Open any source for **memory cards**, the origin
 ### Knowledge — themes & claims
 
 Durable vs caveated claims, grouped by theme. Switch **List / Graph / Terrain** when you want structure instead of a spreadsheet of notes.
+
+Each theme also gets a **topic page**: its durable claims woven into prose, where every
+sentence cites a claim key. A draft that cannot cite is repaired once, then rejected — the
+page never ships ungrounded.
 
 <p align="center">
   <img src="docs/images/04-knowledge.png" alt="Knowledge themes as cards with durable/caveated bars" width="900" />
@@ -74,13 +84,27 @@ Ask in natural language. The agent searches claims, sources, and evidence cards;
 
 ### Search — one box
 
-Sources, claims, packs, themes — `⌘K` / `Ctrl+K` from anywhere.
+Sources, claims, packs, themes — and the **full text of every source body**, not just
+titles. `⌘K` / `Ctrl+K` from anywhere.
 
 <p align="center">
   <img src="docs/images/08-search.png" alt="Search results for agent memory across claims" width="900" />
 </p>
 
-Also in the portal: **Tags**, **Entities**, **System** (runs, doctor, LLM settings, schedule). Light *Atelier* and dark *Vault* themes; English and 简体中文.
+### 中文 — the knowledge, not just the buttons
+
+The interface has always had a 中文 locale. Beyond that, OVP2 can carry a **Chinese
+projection of the knowledge itself**: claims, memory cards, and topic pages get zh versions
+alongside the English ones.
+
+It is a *projection*, deliberately — the ledger stays English and single-authority, and the
+zh layer is rebuildable from it, so a translation can never become a second source of truth
+that quietly disagrees. New material is queued as it arrives and old material backfills in
+the background, both inside the vault's own token budget.
+
+Also in the portal: **Tags**, **Entities**, **Work queue** (what enrichment is running, its
+pace and ETA), **System** (runs, doctor, LLM settings, schedule). Light *Atelier* and dark
+*Vault* themes.
 
 ---
 
@@ -88,14 +112,30 @@ Also in the portal: **Tags**, **Entities**, **System** (runs, doctor, LLM settin
 
 | You want… | Do this |
 |---|---|
-| Ingest bookmarks / clippings on a schedule | `ovp2 schedule install` then fill `<vault>/.ovp/daily.env` |
 | Process the vault once | `ovp2 daily --vault-root ~/path/to/vault --client live` |
 | Open the UI | `ovp2 serve --vault-root ~/path/to/vault` → open the printed URL |
-| Desktop app | [OVP2.app releases](https://github.com/fakechris/obsidian_vault_pipeline/releases) (macOS) |
+| Desktop app | [OVP2.app releases](https://github.com/fakechris/obsidian_vault_pipeline/releases) (macOS) — it carries its own clock, so `ovp2 schedule init` is enough; no OS unit needed |
+| Ingest on a schedule, no app running | `ovp2 schedule install` (launchd / systemd user timer) |
+| See what the LLM cost you | `ovp2 usage --vault-root …` — tokens by day × lane, against the soft budget |
 | Ask from the CLI | `ovp2 ask --vault-root … "your question"` |
+| Enrich sources (deep summary, 中文) | `ovp2 source-work --vault-root …` |
+| Publish durable knowledge as a public site | `ovp2 publish --vault-root … --out <dir>` |
 | Agent tools in an editor | `ovp2 mcp` (stdio MCP: find / search / ask / doctor …) |
 
 The daily loop: capture sweep → grounded read per new source → ledgers → rebuild the read model. Crystal synthesis turns reader packs into cross-source claims behind mechanical gates.
+
+### Bookmarks you never meant to read
+
+Some things you save are entry points, not articles — a brand homepage, a gallery, a docs
+index. Tag the capture `ovp_skip` and the pipeline drops it at intake, before it fetches or
+spends anything. Remove the tag later and it is picked up again on the next sweep; nothing
+is deleted. `ovp_force` is the other direction: read this one even though it is too short to
+clear the automatic gate.
+
+We tried to detect these pages automatically and **measured that it does not work** — on a
+real 1,448-source corpus the structural signals flagged a 73k-character engineering writeup
+and a 46k-character CUDA article next to the three genuine navigation pages. Whether a
+bookmark is worth reading is your call, so it stays a tag.
 
 ---
 
@@ -122,12 +162,21 @@ Full channels, desktop DMG, and rollback notes: [`docs/install.md`](docs/install
 
 ### Quick start
 
-1. **LLM credentials** (for live reads / Ask) — private shell env or vault-side provider config, never committed:
+1. **LLM credentials** (for live reads / Ask) — write `<vault>/.ovp/providers.toml`, which the
+   app reads itself. Shell env still wins when set, so one-off overrides keep working.
 
-   ```sh
-   export ANTHROPIC_API_KEY=sk-ant-...
-   export OVP_LLM_TIMEOUT_SECS=480
+   ```toml
+   [env]
+   ANTHROPIC_API_KEY = "sk-ant-..."
+   OVP_LLM_TIMEOUT_SECS = "480"
+
+   [budget]
+   daily_token_budget = 2000000   # optional; reported by `ovp2 usage`, not enforced
    ```
+
+   The portal's **System → LLM settings** page edits this file for you (keys masked once
+   saved). A scheduled job cannot reliably shell-source an env file — that is why this is a
+   config file and not `daily.env`.
 
 2. **One daily pass** (try `--dry-run` first):
 
@@ -162,6 +211,13 @@ Only leave the machine when **you** configure them:
 - **Pinboard** — only with `--live` and your token (never logged).
 - **Web / GitHub enrichment** — fetches bookmarked URLs (and repo metadata for GitHub links) when enabled.
 - **Manual diagnostic compare** — only if you run the compare command against an external service you choose; not part of `daily`.
+- **Publishing** — `ovp2 publish` is the only command that pushes anything outward, only to a
+  repo you name, and only durable claims.
+
+What it costs is visible too: every metered LLM call lands in `.ovp/usage/`, and
+`ovp2 usage` reports tokens by day and by lane against your budget line. The budget is
+**soft** — it reports, it does not cut you off mid-run. Per-run limits are the throttle
+(`--max-sources`, the enrichment queue's own cap).
 
 ---
 
@@ -183,7 +239,11 @@ Screenshots in [`docs/images/`](docs/images/) were taken from a local dogfood va
 
 ## Status
 
-Rust workspace (CLI + portal + optional desktop). The daily loop, crystal synthesis, Ask agent, and portal run on real vaults today. See [releases](https://github.com/fakechris/obsidian_vault_pipeline/releases) for the latest artifacts.
+Rust workspace (CLI + portal + optional desktop). The daily loop, crystal synthesis, topic
+pages, Ask agent, source enrichment, the 中文 projection, and the portal all run on a real
+dogfood vault daily — currently ~1,450 sources and ~1,500 durable + caveated claims. See
+[releases](https://github.com/fakechris/obsidian_vault_pipeline/releases) for the latest
+artifacts.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,7 +42,9 @@ OVP2 是面向 Obsidian vault 的本地优先应用：读取你捕获的内容�
 
 ### 资料 Library — 全部收藏
 
-按集合与月份浏览。打开任一来源，可见 **记忆卡片**、原文 markdown、引用该源的主张，以及邻域图谱。
+按集合与月份浏览。打开任一来源，可见 **记忆卡片**、**完整原文**、引用该源的主张，以及邻域图谱。Markdown 正常渲染，含 Mermaid 图。
+
+按需的逐源增强：**深度摘要**、**中文翻译**、**相关来源链接**、**就这一篇对话**——你点了才跑，而不是让日循环对你存过的每一篇都记一笔账。
 
 <p align="center">
   <img src="docs/images/02-library.png" alt="Library 来源列表" width="900" />
@@ -55,6 +57,8 @@ OVP2 是面向 Obsidian vault 的本地优先应用：读取你捕获的内容�
 ### 知识 Knowledge — 主题与主张
 
 durable / caveated 主张按主题分组。需要结构时切换 **列表 / 图谱 / 地形**。
+
+每个主题还有一页 **专题综述**：把该主题的 durable 主张织成正文，**每一句都必须引用一个 claim key**。引不上的草稿只修一次,修不好就丢弃——综述页永远不会带着无据的句子上线。
 
 <p align="center">
   <img src="docs/images/04-knowledge.png" alt="Knowledge 主题卡片" width="900" />
@@ -74,13 +78,19 @@ durable / caveated 主张按主题分组。需要结构时切换 **列表 / 图�
 
 ### 搜索 Search — 一个输入框
 
-源、主张、pack、主题——任意页面 `⌘K` / `Ctrl+K`。
+源、主张、pack、主题——以及**每一篇原文的全文**，不只是标题。任意页面 `⌘K` / `Ctrl+K`。
 
 <p align="center">
   <img src="docs/images/08-search.png" alt="搜索 agent memory 的主张结果" width="900" />
 </p>
 
-另有 **标签 Tags**、**实体 Entities**、**系统 System**（运行记录、doctor、LLM 设置、日程）。浅色 Atelier / 深色 Vault 两套主题；界面支持 English 与简体中文。
+### 中文 — 翻的是知识，不只是按钮
+
+界面一直有中文。在那之上，OVP2 还能给**知识本身**建一层中文投影：主张、记忆卡片、专题综述都有与英文并存的中文版。
+
+它**刻意只是投影**——账本保持英文、单一权威，中文层可从它重建。所以一份译文永远不会变成第二个真相来源，跟英文悄悄打架。新内容随到随排队，旧内容在后台回填，两者都受 vault 自己的 token 预算约束。
+
+另有 **标签 Tags**、**实体 Entities**、**工作队列**（正在跑什么增强、速率与预计完成）、**系统 System**（运行记录、doctor、LLM 设置、日程）。浅色 Atelier / 深色 Vault 两套主题。
 
 ---
 
@@ -88,14 +98,23 @@ durable / caveated 主张按主题分组。需要结构时切换 **列表 / 图�
 
 | 想做什么 | 怎么做 |
 |---|---|
-| 定时消化书签 / 剪藏 | `ovp2 schedule install`，再填写 `<vault>/.ovp/daily.env` |
 | 跑一遍日循环 | `ovp2 daily --vault-root ~/path/to/vault --client live` |
 | 打开界面 | `ovp2 serve --vault-root ~/path/to/vault` → 打开打印的 URL |
-| 桌面端 | [OVP2.app 发布页](https://github.com/fakechris/obsidian_vault_pipeline/releases)（macOS） |
+| 桌面端 | [OVP2.app 发布页](https://github.com/fakechris/obsidian_vault_pipeline/releases)（macOS）——它自带时钟，`ovp2 schedule init` 就够，不需要 OS 单元 |
+| 不开 app 也要定时跑 | `ovp2 schedule install`（launchd / systemd user timer） |
+| 看 LLM 花了多少 | `ovp2 usage --vault-root …`——按天 × 车道的 token 用量，对照预算线 |
 | 命令行提问 | `ovp2 ask --vault-root … "你的问题"` |
+| 增强来源（深度摘要、中文） | `ovp2 source-work --vault-root …` |
+| 把 durable 知识发成公开站点 | `ovp2 publish --vault-root … --out <dir>` |
 | 编辑器里当工具 | `ovp2 mcp`（stdio MCP） |
 
 日循环：捕获清扫 → 新源接地阅读 → 账本 → 重建读模型。结晶合成把 reader pack 变成跨源主张，并由机械 gate 把关。
+
+### 那些你本来就没打算读的书签
+
+有些东西你存下来是当入口，不是当文章——品牌首页、画廊站、文档索引。给这条捕获打上 `ovp_skip`，管线会在 intake 阶段就放手，**在抓取和花钱之前**。以后把标签去掉，下次清扫会重新拾起它；什么都不会被删。`ovp_force` 是反方向：这篇虽然短到过不了自动闸门，也照读。
+
+我们试过自动识别这类页面，并且**量化证明了它不成立**——在真实的 1,448 个源上，结构判据把一篇 73k 字的工程长文和一篇 46k 字的 CUDA 文章，和那三个真导航页一起标了出来。一个书签值不值得读是你的判断，所以它留作标签。
 
 ---
 
@@ -122,12 +141,18 @@ ovp2 --version
 
 ### 快速开始
 
-1. **LLM 凭证**（live 阅读 / 对话需要）——放在私有 shell 或 vault 侧配置，不要提交进仓库：
+1. **LLM 凭证**（live 阅读 / 对话需要）——写进 `<vault>/.ovp/providers.toml`，由 app 自己读。shell 环境变量优先级更高，临时覆盖照常可用。
 
-   ```sh
-   export ANTHROPIC_API_KEY=sk-ant-...
-   export OVP_LLM_TIMEOUT_SECS=480
+   ```toml
+   [env]
+   ANTHROPIC_API_KEY = "sk-ant-..."
+   OVP_LLM_TIMEOUT_SECS = "480"
+
+   [budget]
+   daily_token_budget = 2000000   # 可选；由 `ovp2 usage` 报告，不做拦截
    ```
+
+   门户的 **系统 → LLM 设置** 页可以直接编辑这个文件（保存后密钥打码）。定时任务无法可靠地 shell-source 一个 env 文件——这正是它是配置文件而不是 `daily.env` 的原因。
 
 2. **跑一次日循环**（可先 `--dry-run`）：
 
@@ -162,6 +187,9 @@ ovp2 --version
 - **Pinboard** — 仅 `--live` + 你的 token（不写日志）。
 - **网页 / GitHub  enrichment** — 在启用时抓取你书签的 URL（及 GitHub 元数据）。
 - **手动诊断对比** — 仅在你主动跑 compare 命令、并指向自选外部服务时；不是 `daily` 的一部分。
+- **发布** — `ovp2 publish` 是唯一会主动往外推的命令，只推到你指定的仓库，只推 durable 主张。
+
+花了多少也是看得见的:每一次计量到的 LLM 调用都落在 `.ovp/usage/`，`ovp2 usage` 按天、按车道报告 token 用量并对照预算线。预算是**软的**——它只报告，不会在运行中途把你掐断。真正的节流是每次运行的上限(`--max-sources`、增强队列自己的 cap)。
 
 ---
 
@@ -171,6 +199,7 @@ ovp2 --version
 |---|---|
 | [`docs/install.md`](docs/install.md) | 安装、桌面端、版本 |
 | [`docs/operator-runbook.md`](docs/operator-runbook.md) | 真实 vault 运维与恢复 |
+| [`CLAUDE.md`](CLAUDE.md) | **贡献者:改完之后该重建什么**——装了桌面端的机器上跑着四份互相独立的产物,更新错一份的现象就是"我的改动完全没生效" |
 | [`docs/ovp-to-ovp2.zh-CN.md`](docs/ovp-to-ovp2.zh-CN.md) | 重写叙事与迁移（[EN](docs/ovp-to-ovp2.md)） |
 | [`docs/architecture.md`](docs/architecture.md) | 架构（给工程师） |
 | [`docs/product-state-layout.md`](docs/product-state-layout.md) | 磁盘上的产品状态 |
@@ -182,7 +211,7 @@ ovp2 --version
 
 ## 状态
 
-Rust 工作区（CLI + 门户 + 可选桌面端）。日循环、结晶合成、Ask agent 与门户已在真实 vault 上使用。产物见 [releases](https://github.com/fakechris/obsidian_vault_pipeline/releases)。
+Rust 工作区（CLI + 门户 + 可选桌面端）。日循环、结晶合成、专题综述、Ask agent、来源增强、中文投影与门户,都在一个真实的 dogfood vault 上每天跑——目前约 1,450 个源、约 1,500 条 durable + caveated 主张。产物见 [releases](https://github.com/fakechris/obsidian_vault_pipeline/releases)。
 
 ---
 


### PR DESCRIPTION
## 为什么

README 上一次产品面向的更新是 **07-26**。之后 9 天里门户长出了来源增强、专题综述、全文搜索、工作队列、用量计量、发布路径,CLI 长出了 `usage` / `source-work` / `publish`——**从正门进来的人一个都看不到**。

## 最大的遗漏:中文层

原文只在一行末尾写了"界面支持 English 与简体中文",这**低估**了它:主张、记忆卡片、专题综述现在都有**知识本身**的中文投影。

两版都补上了"为什么它是投影而不是并行账本"——英文账本保持单一权威,中文层可重建,这样一份译文不会悄悄变成第二个真相来源。

## 纠正的是"过时",不只是"缺失"

| 原文 | 问题 |
|---|---|
| `<vault>/.ovp/daily.env` 填凭证 | `providers.toml` 已经取代它,原因正是**定时任务无法可靠 shell-source 一个 env 文件**(launchd EPERM 那次)。README 还在教那个坏掉的形态 |
| `ovp2 schedule install` 是唯一的定时方案 | 桌面端自带时钟,那边 `schedule init` 就够 |
| Status 说"已在真实 vault 上使用" | 没说规模。今天是 ~1,450 个源、~1,500 条 durable + caveated 主张 |

## 新增:`ovp_skip` / `ovp_force`

而且写了**为什么它是标签而不是自动识别**——结构判据在真实 1,448 个源上量过,把一篇 73k 字的工程长文和一篇 46k 字的 CUDA 文章,和那三个真导航页一起标了出来。

把这个诚实的否定结果写出来,比让读者以为"这功能只是还没做"有用。

## 中文版同步

中文 README 同样停在 07-26。一个**把双语知识当卖点**的项目,中文 README 落后说不过去,两版同步更新,章节数一致(16/16)。

## 核对

- 两版章节数一致
- 所有内链目标存在
- Status 里的数字取自 `.ovp/index/index.json`:`sources=1452`、`durable=1033`、`caveated=484`
- 1,448 那个数字是本次实测的语料规模

纯文档,无代码改动。