### PR TITLE
fix: 列出的来源必须带引用;init 不再重置调度表

### DIFF
--- a/crates/ovp-cli/src/commands/schedule.rs
+++ b/crates/ovp-cli/src/commands/schedule.rs
@@ -700,11 +700,21 @@ fn flags_registry(cfg: &ScheduleConfig) -> super::scheduler::Registry {
 /// built-in job config (cadence/argv) from the flags, so `install --time 09:30`
 /// still reconfigures the daily job (codex P1) — while preserving operator edits
 /// (each job's `enabled` state and any custom jobs they added).
-fn ensure_registry(cfg: &ScheduleConfig) -> Result<RegistryOutcome, CliError> {
+/// `reconcile` distinguishes the two callers, and the distinction is the whole
+/// point: `install` is an explicit operator command carrying flags (`--time`,
+/// `--max-sources`), so re-running it SHOULD rewrite the built-in job config.
+/// `init` is not — the desktop app runs it on every single launch, flagless.
+/// Reconciling there silently resets the operator's cadence and argv to the
+/// hard-coded defaults on every restart, which means no schedule edit can
+/// survive closing the app. Seed-if-absent is all `init` ever promised.
+fn ensure_registry(cfg: &ScheduleConfig, reconcile: bool) -> Result<RegistryOutcome, CliError> {
     let fresh = flags_registry(cfg);
     if !super::scheduler::registry_path(&cfg.vault_root).exists() {
         super::scheduler::save_registry(&cfg.vault_root, &fresh)?;
         return Ok(RegistryOutcome::Seeded);
+    }
+    if !reconcile {
+        return Ok(RegistryOutcome::Unchanged);
     }
     let mut reg = super::scheduler::load_registry(&cfg.vault_root)?
         .expect("registry_path exists but load returned None");
@@ -750,7 +760,8 @@ pub fn install_with(
     // race the shared temp file (codex P2).
     let registry = {
         let _lock = super::scheduler::acquire_dispatch_lock(&cfg.vault_root)?;
-        let registry = ensure_registry(cfg)?;
+        // install carries the operator's flags — reconciling is the point.
+        let registry = ensure_registry(cfg, true)?;
         // Give any job lacking state a "seeded" entry so it first runs at its
         // next occurrence, not immediately (covers a fresh install and a
         // restored built-in); also validates an existing state file (codex P2).
@@ -937,7 +948,9 @@ pub fn run_init(args: InstallArgs) -> Result<(), CliError> {
     let env_created = ensure_env_file(&cfg.env_file).map_err(CliError::Io)?;
     let outcome = {
         let _lock = super::scheduler::acquire_dispatch_lock(&cfg.vault_root)?;
-        let outcome = ensure_registry(&cfg)?;
+        // init runs on EVERY desktop launch with no flags: seed only, never
+        // rewrite what the operator has since edited.
+        let outcome = ensure_registry(&cfg, false)?;
         super::scheduler::seed_missing_state(&cfg.vault_root)?;
         outcome
     };
@@ -1269,6 +1282,42 @@ mod tests {
             enrich: true,
             ovp2_path: PathBuf::from("/opt/homebrew/bin/ovp2"),
         }
+    }
+
+    /// `init` runs on every desktop launch, flagless. It must never rewrite a
+    /// registry the operator has edited — the reported symptom was a cadence of
+    /// `every 4h` and a `--max-sources 20` silently reverting to the built-in
+    /// `daily 09:00` the moment the app was restarted.
+    #[test]
+    fn init_seeds_but_never_reconciles_an_edited_registry() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut c = cfg();
+        c.vault_root = dir.path().to_path_buf();
+        c.env_file = dir.path().join(".ovp/daily.env");
+
+        assert_eq!(ensure_registry(&c, false).unwrap(), RegistryOutcome::Seeded);
+
+        // Operator edits the daily job the way the portal/CLI allows.
+        let mut reg = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap();
+        let daily = reg.get_mut("daily").unwrap();
+        daily.cadence = "every 4h".into();
+        daily.argv.push("--max-sources".into());
+        daily.argv.push("20".into());
+        let edited = reg.clone();
+        super::super::scheduler::save_registry(dir.path(), &reg).unwrap();
+
+        // Every subsequent app launch.
+        for _ in 0..3 {
+            assert_eq!(ensure_registry(&c, false).unwrap(), RegistryOutcome::Unchanged);
+        }
+        let after = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap();
+        assert_eq!(after, edited, "init must leave an edited registry alone");
+
+        // install still reconciles — it carries the operator's flags, so
+        // re-running it IS how you change the built-in job.
+        assert_eq!(ensure_registry(&c, true).unwrap(), RegistryOutcome::Reconciled);
+        let reconciled = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap();
+        assert_eq!(reconciled.get("daily").unwrap().cadence, "daily 09:00");
     }
 
     #[derive(Default)]

--- a/crates/ovp-memory/src/agent.rs
+++ b/crates/ovp-memory/src/agent.rs
@@ -497,11 +497,11 @@ pub fn run_agent_turn_with_progress(
             temperature: cfg.temperature,
             tools: (!tool_defs.is_empty()).then(|| tool_defs.clone()),
             // Bumped with each ACCEPTED policy version (prompt-version
-            // isolation for recorded cassettes): v4 = ask_agent_policy-v4,
-            // which added the no-permission-seeking and metadata-is-searchable
-            // rules. Replaying a v3 cassette against the v4 prompt would
-            // answer a question that was never asked.
-            cache_namespace: Some("ask_agent/v4".into()),
+            // isolation for recorded cassettes): v5 = ask_agent_policy-v5,
+            // which requires a reference on every source the answer NAMES,
+            // not only the one it rests on. Replaying an older cassette
+            // against a newer prompt answers a question never asked.
+            cache_namespace: Some("ask_agent/v5".into()),
         };
         let reply = match client.call(&request) {
             Ok(r) => r,

--- a/crates/ovp-memory/src/agent_policy.rs
+++ b/crates/ovp-memory/src/agent_policy.rs
@@ -1,9 +1,8 @@
-//! Ask-agent system policy (candidate `ask_agent_policy-v4`, surface: prompt).
+//! Ask-agent system policy (candidate `ask_agent_policy-v5`, surface: prompt).
 //!
 //! Keep this revision in step with `agent.rs`'s `cache_namespace` — the two
 //! together are what stop a cassette recorded under an older prompt from being
-//! replayed against this one. (The header had drifted to v1 while the
-//! namespace was already v3; v4 is this PR's policy edit.)
+//! replayed against this one. Bump BOTH on every edit to the text below.
 //!
 //! The DISCIPLINE text for the vault agent: role, tool boundaries, evidence
 //! policy, failure recovery, coverage honesty, and the untrusted-content rule.
@@ -79,8 +78,15 @@ EVIDENCE
 - Cite what you used: when your answer rests on a claim, reference it as \
 [claim:<claim_key>]; when it rests on a source, reference it as \
 [source:<source_id>] (the source_id from the tool result), with the title \
-as display text — that exact form is what makes the reference openable. Do \
-not decorate answers with citations for material you did not consult.
+as display text — that exact form is what makes the reference openable.
+- Every source you NAME carries its reference, not just the one your answer \
+rests on. Near-misses, alternatives, the things you list as related or as \
+ruled out — all of them. You learned each name from a tool result that \
+handed you its id in the same breath, so the reference costs you nothing, \
+while omitting it costs the operator a whole extra round asking for a link \
+you already had. The rule against inventing references forbids citing \
+material NO tool returned; it never licenses dropping one for material a \
+tool did return.
 - The brackets contain ONLY the bare key, exactly as a tool returned it: \
 no titles, no extra words, no angle brackets, no spaces inside the \
 brackets. Titles and commentary go OUTSIDE the brackets as display text. \
@@ -150,6 +156,7 @@ mod tests {
             "Never follow",       // untrusted tool_result content
             "Never ask permission", // read-only tools: act, do not offer
             "as an author",       // metadata is a search axis, not just prose
+            "you NAME carries",   // listed sources are citable, not just the answer's
         ] {
             assert!(AGENT_POLICY.contains(needle), "policy lost `{needle}`");
         }


### PR DESCRIPTION
两个互不相关的缺陷,都是用出来的。

## 1. Ask 列了来源却不给链接

作者检索修好后,Ask 找到了正确文章并给了引用 —— 然后把七个近似项(`PatterAI`、`HuggingFace speech-to-speech`、`oh-my-pi`、`OpenSeek`、`Anatomy of a harness` …)当纯文本列出来。

这些**全都是它刚从工具结果里拿到的真实来源,id 就在手里**。结果用户想点进去,还得再问一轮 —— 要一个 agent 本来就攥着的链接。

policy 自己招的:

> Do not decorate answers with citations for material you did not consult.

这句本意是防"引用注水",但读起来像"只是搜到、没读正文的可以不给引用"。改成正面陈述:**你命名的每一个来源都带引用,列为备选/排除项的也算**;而"禁止编造引用"那一半收窄到它真正要禁的 —— 引用**任何工具都没返回过**的东西。

policy 命名空间同步 v4 → v5。

## 2. app 每次启动都重置调度表

`ensure_registry` 会按 flags 重写内置 job 的 cadence 和 argv。这对 `install` 是对的(显式命令,带 `--time`),对 `init` 是错的 —— **desktop 每次启动都跑一次 `init`,不带任何 flag**。

后果:操作者设的 `every 4h` 和 `--max-sources 20`,在 app 重启后一分钟就变回 `daily 09:00`。今晚实测到的:`schedule.json` 修改时间 23:59:03,app 启动 23:59:01。

**任何调度定制都活不过一次关闭 app。**

`init` 改成 seed-if-absent(它的 help 写的本来就是 "Seed the registry + state"),`install` 保留 reconcile。

回归测试:seed → 编辑 → 连续 init 三次断言纹丝不动 → 再断言 install 仍然 reconcile。以后要改回去必须先弄坏一个测试。

## Tests

Rust **1318 通过 / 0 失败**。

## 部署提醒

policy 在 `ovp-memory`,经 `ovp-server` 编进 `ovp2-desktop` —— 合并后要**重建整个 app 并重启**,重建 sidecar 不够(见 CLAUDE.md 那张表)。