### PR TITLE
feat(index): stage-3a SQLite shadow read-model in machine-local cache, verify-then-promote parity gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,6 +1047,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastembed"
 version = "5.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,6 +1571,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -2113,6 +2134,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2840,6 +2872,7 @@ dependencies = [
  "ovp-daily",
  "ovp-domain",
  "ovp-intake",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
@@ -3666,6 +3699,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -5206,6 +5253,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/crates/ovp-cli/src/commands/console_cmd.rs
+++ b/crates/ovp-cli/src/commands/console_cmd.rs
@@ -24,6 +24,7 @@ pub fn run(args: ConsoleArgs) -> Result<(), CliError> {
     let index_rel = write_index(&args.vault_root, &model).map_err(CliError::Io)?;
     let evidence = build_evidence(&args.vault_root, &args.date, &model).map_err(CliError::Io)?;
     let evidence_rel = write_evidence(&args.vault_root, &evidence).map_err(CliError::Io)?;
+    crate::commands::index_cmd::shadow_sqlite(&args.vault_root, &model, &evidence);
     let console_rel = write_console(&args.vault_root, &model).map_err(CliError::Io)?;
     let ops_pages = write_ops_pages(&args.vault_root, &model).map_err(CliError::Io)?;
     println!(

--- a/crates/ovp-cli/src/commands/crystal_review_session.rs
+++ b/crates/ovp-cli/src/commands/crystal_review_session.rs
@@ -1248,6 +1248,12 @@ mod tests {
 
     #[test]
     fn legacy_crystal_review_rejects_queue_state_actions() {
+        // This test drives the product `run()`, which (via run_index) builds
+        // the sqlite shadow — keep it out of the developer's REAL platform
+        // cache. Constant value: benign if a parallel test sets it too.
+        unsafe {
+            std::env::set_var("OVP_CACHE_DIR", std::env::temp_dir().join("ovp-test-cache"));
+        }
         let tmp = tempfile::tempdir().unwrap();
         let cand = tmp.path().join("candidate.json");
         fs::write(

--- a/crates/ovp-cli/src/commands/crystal_review_session.rs
+++ b/crates/ovp-cli/src/commands/crystal_review_session.rs
@@ -1250,10 +1250,12 @@ mod tests {
     fn legacy_crystal_review_rejects_queue_state_actions() {
         // This test drives the product `run()`, which (via run_index) builds
         // the sqlite shadow — keep it out of the developer's REAL platform
-        // cache. Constant value: benign if a parallel test sets it too.
-        unsafe {
-            std::env::set_var("OVP_CACHE_DIR", std::env::temp_dir().join("ovp-test-cache"));
-        }
+        // cache without touching the process environment (set_var races
+        // parallel test threads). Gitignored target/ path; OnceLock is
+        // first-call-wins so concurrent setters are benign.
+        ovp_index::sqlite::override_cache_base(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/tmp/ovp-test-cache"),
+        );
         let tmp = tempfile::tempdir().unwrap();
         let cand = tmp.path().join("candidate.json");
         fs::write(

--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -704,6 +704,7 @@ fn run_inner(
     let index_rel = write_index(&args.vault_root, &model).map_err(CliError::Io)?;
     let evidence = build_evidence(&args.vault_root, &args.date, &model).map_err(CliError::Io)?;
     let evidence_rel = write_evidence(&args.vault_root, &evidence).map_err(CliError::Io)?;
+    crate::commands::index_cmd::shadow_sqlite(&args.vault_root, &model, &evidence);
     let console_rel = write_console(&args.vault_root, &model).map_err(CliError::Io)?;
     let _ops_pages = write_ops_pages(&args.vault_root, &model).map_err(CliError::Io)?;
 

--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -880,6 +880,10 @@ fn rebuild_projection(
     write_index(vault_root, &model).map_err(CliError::Io)?;
     let evidence = build_evidence(vault_root, date, &model).map_err(CliError::Io)?;
     write_evidence(vault_root, &evidence).map_err(CliError::Io)?;
+    // The shadow follows EVERY projection write (incl. this refresh and the
+    // post-tags-bootstrap rebuild) — a JSON-only refresh would leave the
+    // sqlite generation stale for the rest of the run.
+    crate::commands::index_cmd::shadow_sqlite(vault_root, &model, &evidence);
     write_console(vault_root, &model).map_err(CliError::Io)?;
     write_ops_pages(vault_root, &model).map_err(CliError::Io)?;
     Ok(())

--- a/crates/ovp-cli/src/commands/index_cmd.rs
+++ b/crates/ovp-cli/src/commands/index_cmd.rs
@@ -18,6 +18,32 @@ pub struct IndexArgs {
     pub date: String,
 }
 
+/// Shadow-build the SQLite read-model and verify parity against the JSON
+/// projections it was built from (stage 3 of storage-read-model.md). Never
+/// fails the pipeline: the JSON files remain the serving projection during
+/// the shadow soak — a shadow failure is a LOUD warning to investigate, not
+/// a reason to lose a daily run. Skipped for mid-run refreshes (transient
+/// projections; the terminal write always shadows).
+pub(crate) fn shadow_sqlite(
+    vault_root: &std::path::Path,
+    model: &ovp_index::IndexModel,
+    evidence: &ovp_index::EvidenceModel,
+) {
+    let outcome = ovp_index::sqlite::write_shadow(vault_root, model, Some(evidence)).and_then(
+        |rel| {
+            ovp_index::sqlite::verify_shadow(vault_root, model, Some(evidence))
+                .map(|parity| (rel, parity))
+        },
+    );
+    match outcome {
+        Ok((rel, p)) => println!(
+            "  sqlite shadow: {rel} (sources={} packs={} claims={} cards={} units={} sampled={})",
+            p.sources, p.packs, p.claims, p.cards, p.units, p.sampled
+        ),
+        Err(e) => eprintln!("warning: sqlite shadow projection FAILED PARITY OR BUILD: {e}"),
+    }
+}
+
 pub fn run_index(args: IndexArgs) -> Result<(), CliError> {
     // Coarse phase lines (flushed) so a large-vault rebuild shows the
     // scan/hash/fold boundaries instead of one silent pause under nohup.
@@ -27,6 +53,7 @@ pub fn run_index(args: IndexArgs) -> Result<(), CliError> {
     let rel = write_index(&args.vault_root, &model).map_err(CliError::Io)?;
     let evidence = build_evidence(&args.vault_root, &args.date, &model).map_err(CliError::Io)?;
     let evidence_rel = write_evidence(&args.vault_root, &evidence).map_err(CliError::Io)?;
+    shadow_sqlite(&args.vault_root, &model, &evidence);
     let t = &model.totals;
     println!("index [{}]: {rel}", args.date);
     println!(

--- a/crates/ovp-cli/src/commands/index_cmd.rs
+++ b/crates/ovp-cli/src/commands/index_cmd.rs
@@ -18,27 +18,28 @@ pub struct IndexArgs {
     pub date: String,
 }
 
-/// Shadow-build the SQLite read-model and verify parity against the JSON
-/// projections it was built from (stage 3 of storage-read-model.md). Never
-/// fails the pipeline: the JSON files remain the serving projection during
-/// the shadow soak — a shadow failure is a LOUD warning to investigate, not
-/// a reason to lose a daily run. Skipped for mid-run refreshes (transient
-/// projections; the terminal write always shadows).
+/// Shadow-build the SQLite read-model (stage 3 of storage-read-model.md).
+/// `write_shadow` verifies the CANDIDATE and promotes only on parity, so the
+/// last-good generation survives any failure. Never fails the pipeline: the
+/// JSON files remain the serving projection during the shadow soak — a
+/// shadow failure is a LOUD warning to investigate, not a reason to lose a
+/// daily run. Every projection write shadows, including mid-run refreshes —
+/// a JSON-only refresh would leave the shadow stale for the rest of the run.
 pub(crate) fn shadow_sqlite(
     vault_root: &std::path::Path,
     model: &ovp_index::IndexModel,
     evidence: &ovp_index::EvidenceModel,
 ) {
-    let outcome = ovp_index::sqlite::write_shadow(vault_root, model, Some(evidence)).and_then(
-        |rel| {
-            ovp_index::sqlite::verify_shadow(vault_root, model, Some(evidence))
-                .map(|parity| (rel, parity))
-        },
-    );
-    match outcome {
-        Ok((rel, p)) => println!(
-            "  sqlite shadow: {rel} (sources={} packs={} claims={} cards={} units={} sampled={})",
-            p.sources, p.packs, p.claims, p.cards, p.units, p.sampled
+    match ovp_index::sqlite::write_shadow(vault_root, model, Some(evidence)) {
+        Ok((path, p)) => println!(
+            "  sqlite shadow: {} (sources={} packs={} claims={} cards={} units={} sampled={})",
+            path.display(),
+            p.sources,
+            p.packs,
+            p.claims,
+            p.cards,
+            p.units,
+            p.sampled
         ),
         Err(e) => eprintln!("warning: sqlite shadow projection FAILED PARITY OR BUILD: {e}"),
     }

--- a/crates/ovp-cli/tests/m31_e2e.rs
+++ b/crates/ovp-cli/tests/m31_e2e.rs
@@ -306,6 +306,7 @@ fn full_daily_workflow_capture_to_console_with_crystal_and_retry() {
     for state in [
         ".ovp/daily-runs.jsonl", ".ovp/intake.jsonl", ".ovp/pinboard-sync.jsonl",
         ".ovp/reports/daily-e2e.json", ".ovp/index/index.json", ".ovp/index/evidence.json",
+        ".ovp/index/read-model.sqlite", // stage-3 shadow, built beside the JSON projections
         ".ovp/console/index.html", "60-Logs/pipeline.jsonl",
     ] {
         assert!(vault.join(state).exists(), "missing {state}");

--- a/crates/ovp-cli/tests/m31_e2e.rs
+++ b/crates/ovp-cli/tests/m31_e2e.rs
@@ -86,12 +86,26 @@ fn seed_cassettes(cache_dir: &Path, source: &SourceDoc, quote: &str, text: &str)
     rec.call(&card_model_request(&accepted)).unwrap();
 }
 
+thread_local! {
+    /// Per-test cache root for the sqlite shadow (each #[test] runs on its
+    /// own thread). Set from the test's OWN tempdir so the cache self-cleans
+    /// on drop — never the developer's real platform cache, never an
+    /// accumulating fixed path in the system temp dir, and no process-env
+    /// mutation (unsafe under parallel test threads).
+    static TEST_CACHE: std::cell::RefCell<Option<std::path::PathBuf>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+fn set_test_cache(dir: &std::path::Path) {
+    TEST_CACHE.with(|c| *c.borrow_mut() = Some(dir.to_path_buf()));
+}
+
 fn bin() -> Command {
+    let cache = TEST_CACHE
+        .with(|c| c.borrow().clone())
+        .expect("test must call set_test_cache(tempdir) before bin()");
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_ovp2"));
-    // Derived-database cache must never land in the developer's real
-    // platform cache dir during tests — point it into the system temp dir
-    // (per-vault fingerprint subdirs keep parallel tests apart).
-    cmd.env("OVP_CACHE_DIR", std::env::temp_dir().join("ovp-e2e-cache"));
+    cmd.env("OVP_CACHE_DIR", &cache);
     cmd
 }
 
@@ -148,6 +162,8 @@ fn md_files(dir: &Path) -> Vec<PathBuf> {
 /// runs report instead of aborting.
 #[test]
 fn daily_and_pinboard_sync_inherit_first_sync_flood_guard() {
+    let cache = tempfile::tempdir().unwrap();
+    set_test_cache(cache.path());
     let tmp = tempfile::tempdir().unwrap();
     let vault = tmp.path().join("vault");
     // A real vault always has the raw inbox; the plan phase requires it.
@@ -255,6 +271,8 @@ fn daily_and_pinboard_sync_inherit_first_sync_flood_guard() {
 
 #[test]
 fn full_daily_workflow_capture_to_console_with_crystal_and_retry() {
+    let cache = tempfile::tempdir().unwrap();
+    set_test_cache(cache.path());
     let tmp = tempfile::tempdir().unwrap();
     let vault = tmp.path().join("vault");
     let cache_dir = tmp.path().join("cassettes");
@@ -316,13 +334,10 @@ fn full_daily_workflow_capture_to_console_with_crystal_and_retry() {
         assert!(vault.join(state).exists(), "missing {state}");
     }
     // Stage-3 shadow: in the MACHINE-LOCAL cache (never inside the synced
-    // vault), resolved through the same library path the binary uses.
-    let shadow = {
-        // SAFETY-of-parity: set the same override the child process ran with
-        // so sqlite_path resolves identically. Test-process-local.
-        unsafe { std::env::set_var("OVP_CACHE_DIR", std::env::temp_dir().join("ovp-e2e-cache")) };
-        ovp_index::sqlite::sqlite_path(&vault).expect("cache path resolves")
-    };
+    // vault), located through the same library helper the binary's env
+    // resolution feeds into — no process-env mutation needed.
+    let cache_root = TEST_CACHE.with(|c| c.borrow().clone()).expect("cache set");
+    let shadow = ovp_index::sqlite::sqlite_path_in(&cache_root, &vault);
     assert!(shadow.exists(), "missing sqlite shadow at {}", shadow.display());
     assert!(
         !vault.join(".ovp/index/read-model.sqlite").exists(),
@@ -546,6 +561,8 @@ fn full_daily_workflow_capture_to_console_with_crystal_and_retry() {
 /// duration. `--refresh-every 0` preserves the old behavior: no mid-run rebuild.
 #[test]
 fn daily_periodic_refresh_rebuilds_projection_mid_run() {
+    let cache = tempfile::tempdir().unwrap();
+    set_test_cache(cache.path());
     let tmp = tempfile::tempdir().unwrap();
     let cache_dir = tmp.path().join("cassettes");
 

--- a/crates/ovp-cli/tests/m31_e2e.rs
+++ b/crates/ovp-cli/tests/m31_e2e.rs
@@ -87,7 +87,12 @@ fn seed_cassettes(cache_dir: &Path, source: &SourceDoc, quote: &str, text: &str)
 }
 
 fn bin() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_ovp2"))
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_ovp2"));
+    // Derived-database cache must never land in the developer's real
+    // platform cache dir during tests — point it into the system temp dir
+    // (per-vault fingerprint subdirs keep parallel tests apart).
+    cmd.env("OVP_CACHE_DIR", std::env::temp_dir().join("ovp-e2e-cache"));
+    cmd
 }
 
 fn run_ok(cmd: &mut Command) -> String {
@@ -306,11 +311,23 @@ fn full_daily_workflow_capture_to_console_with_crystal_and_retry() {
     for state in [
         ".ovp/daily-runs.jsonl", ".ovp/intake.jsonl", ".ovp/pinboard-sync.jsonl",
         ".ovp/reports/daily-e2e.json", ".ovp/index/index.json", ".ovp/index/evidence.json",
-        ".ovp/index/read-model.sqlite", // stage-3 shadow, built beside the JSON projections
         ".ovp/console/index.html", "60-Logs/pipeline.jsonl",
     ] {
         assert!(vault.join(state).exists(), "missing {state}");
     }
+    // Stage-3 shadow: in the MACHINE-LOCAL cache (never inside the synced
+    // vault), resolved through the same library path the binary uses.
+    let shadow = {
+        // SAFETY-of-parity: set the same override the child process ran with
+        // so sqlite_path resolves identically. Test-process-local.
+        unsafe { std::env::set_var("OVP_CACHE_DIR", std::env::temp_dir().join("ovp-e2e-cache")) };
+        ovp_index::sqlite::sqlite_path(&vault).expect("cache path resolves")
+    };
+    assert!(shadow.exists(), "missing sqlite shadow at {}", shadow.display());
+    assert!(
+        !vault.join(".ovp/index/read-model.sqlite").exists(),
+        "shadow must NOT be written inside the synced vault"
+    );
     let console = std::fs::read_to_string(vault.join(".ovp/console/index.html")).unwrap();
     assert!(console.contains("The Chunk Problem"), "console shows sources");
     assert!(console.contains("Benchmark Maxxing"));

--- a/crates/ovp-index/Cargo.toml
+++ b/crates/ovp-index/Cargo.toml
@@ -14,6 +14,7 @@ ovp-intake = { path = "../ovp-intake" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
+rusqlite = { version = "0.37", features = ["bundled"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ovp-index/src/lib.rs
+++ b/crates/ovp-index/src/lib.rs
@@ -22,6 +22,7 @@ pub mod evidence;
 pub mod model;
 pub mod query;
 pub mod score;
+pub mod sqlite;
 
 pub use build::{
     build_index, build_index_at, build_index_with_progress, failed_reader_attempt,

--- a/crates/ovp-index/src/sqlite.rs
+++ b/crates/ovp-index/src/sqlite.rs
@@ -31,9 +31,23 @@ use crate::model::IndexModel;
 const SQLITE_FILE: &str = "read-model.sqlite";
 const SCHEMA_VERSION: &str = "1";
 
-/// The machine-local cache root: `OVP_CACHE_DIR` when set (tests, portable
-/// setups), else the platform cache directory.
+/// Process-wide cache-base override, first call wins. For EMBEDDERS and
+/// in-process tests: mutating `OVP_CACHE_DIR` via `set_var` is unsafe under
+/// parallel test threads (the race is on the environment block itself), and
+/// the env var only reliably covers child processes.
+static CACHE_BASE_OVERRIDE: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+
+pub fn override_cache_base(path: PathBuf) {
+    let _ = CACHE_BASE_OVERRIDE.set(path);
+}
+
+/// The machine-local cache root: the in-process override, else
+/// `OVP_CACHE_DIR` (child processes, portable setups), else the platform
+/// cache directory.
 fn cache_base() -> Result<PathBuf, String> {
+    if let Some(dir) = CACHE_BASE_OVERRIDE.get() {
+        return Ok(dir.clone());
+    }
     if let Some(dir) = std::env::var_os("OVP_CACHE_DIR") {
         return Ok(PathBuf::from(dir));
     }
@@ -68,10 +82,17 @@ fn vault_fingerprint(vault_root: &Path) -> String {
 
 /// Where this vault's shadow database lives on THIS machine.
 pub fn sqlite_path(vault_root: &Path) -> Result<PathBuf, String> {
-    Ok(cache_base()?
+    Ok(sqlite_path_in(&cache_base()?, vault_root))
+}
+
+/// [`sqlite_path`] under an EXPLICIT cache base — no env/override resolution.
+/// Lets a test that handed `OVP_CACHE_DIR` to a child process locate the
+/// promoted database without mutating its own environment.
+pub fn sqlite_path_in(cache_base: &Path, vault_root: &Path) -> PathBuf {
+    cache_base
         .join("ovp")
         .join(vault_fingerprint(vault_root))
-        .join(SQLITE_FILE))
+        .join(SQLITE_FILE)
 }
 
 /// serde's snake_case string for a status enum — the SAME strings the JSON
@@ -153,19 +174,31 @@ pub fn write_shadow(
         .ok_or_else(|| format!("{} has no parent directory", target.display()))?;
     std::fs::create_dir_all(parent)
         .map_err(|e| format!("creating {}: {e}", parent.display()))?;
-    // Sweep stale tmp generations from crashed builds before making a new one.
+    // Sweep stale tmp generations from crashed builds. Scoped: only OUR
+    // pid's leftover (a same-pid concurrent build cannot exist) plus foreign
+    // tmps old enough to be certainly dead — `index`/`console` do not hold
+    // daily's RunLock, so a blanket sweep could unlink a live concurrent
+    // candidate mid-build and fail its verify for no reason.
+    const FOREIGN_TMP_MAX_AGE: std::time::Duration = std::time::Duration::from_secs(24 * 3600);
+    let own_tmp_name = format!("read-model.sqlite.tmp.{}", std::process::id());
     if let Ok(entries) = std::fs::read_dir(parent) {
         for entry in entries.flatten() {
-            if entry
-                .file_name()
-                .to_string_lossy()
-                .starts_with("read-model.sqlite.tmp.")
-            {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if !name.starts_with("read-model.sqlite.tmp.") {
+                continue;
+            }
+            let dead_foreign = entry
+                .metadata()
+                .and_then(|m| m.modified())
+                .ok()
+                .and_then(|m| m.elapsed().ok())
+                .is_some_and(|age| age > FOREIGN_TMP_MAX_AGE);
+            if name == own_tmp_name || dead_foreign {
                 let _ = std::fs::remove_file(entry.path());
             }
         }
     }
-    let tmp = parent.join(format!("read-model.sqlite.tmp.{}", std::process::id()));
+    let tmp = parent.join(own_tmp_name);
 
     let outcome = build_into(&tmp, model, evidence)
         // Flush the candidate BEFORE validating/promoting: the build runs
@@ -503,6 +536,27 @@ fn verify_at(
     expect("pack_card_titles", count("pack_card_titles")?, want_card_titles)?;
     let want_claim_sources: usize = model.claims.iter().map(|c| c.sources.len()).sum();
     expect("claim_sources", count("claim_sources")?, want_claim_sources)?;
+
+    // meta scalars: built_at exists precisely so a stale projection cannot
+    // render like a fresh one — the verifier must not skip the one surface
+    // it writes but never reads.
+    let mut got_meta: Vec<(String, String)> = conn
+        .prepare("SELECT key, value FROM meta ORDER BY key")
+        .and_then(|mut st| {
+            st.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|e| format!("reading meta: {e}"))?;
+    got_meta.sort();
+    let mut want_meta = vec![
+        ("schema_version".to_string(), SCHEMA_VERSION.to_string()),
+        ("index_schema".to_string(), model.schema.clone()),
+        ("date".to_string(), model.date.clone()),
+        ("built_at".to_string(), model.built_at.clone().unwrap_or_default()),
+        ("run_id".to_string(), model.run_id.clone().unwrap_or_default()),
+    ];
+    want_meta.sort();
+    expect_row("meta", "scalars", &json!(got_meta), &json!(want_meta))?;
 
     let mut sampled = 0usize;
 

--- a/crates/ovp-index/src/sqlite.rs
+++ b/crates/ovp-index/src/sqlite.rs
@@ -1,11 +1,20 @@
 //! SQLite shadow read-model (stage 3 of `docs/design/storage-read-model.md`).
 //!
 //! Same philosophy as the JSON projection: derived, rebuildable state — every
-//! build produces a FRESH database file that atomically replaces the previous
-//! generation, so there is no migration story (`ovp2 index` IS the
-//! migration). The JSON files remain the serving projection; this shadow
-//! exists to be diffed against them (`verify_shadow`) until parity has soaked
-//! long enough to switch endpoints over (stage 4).
+//! build produces a FRESH database file. There is no migration story (`ovp2
+//! index` IS the migration). The JSON files remain the serving projection;
+//! this shadow exists to be diffed against them until parity has soaked long
+//! enough to switch endpoints over (stage 4).
+//!
+//! Placement: the database lives in a MACHINE-LOCAL cache directory, never
+//! inside the vault — the vault syncs (Obsidian/iCloud/Dropbox), and a
+//! rewritten multi-MB binary per run would thrash sync and conflict across
+//! machines. `OVP_CACHE_DIR` overrides the platform default.
+//!
+//! Promotion contract: build into a unique tmp → fsync the file → verify
+//! parity against the in-memory projections → only THEN atomically rename
+//! over the previous generation (+ directory fsync). Any build/verify/sync
+//! failure leaves the last-good generation untouched.
 //!
 //! Deliberately NOT here yet: incremental cursors (full rebuild is minutes at
 //! 100x scale, measured), FTS tables (stage 3c), vector columns (stage 5).
@@ -14,15 +23,55 @@ use std::path::{Path, PathBuf};
 
 use rusqlite::Connection;
 use serde::Serialize;
+use serde_json::{Value, json};
 
 use crate::evidence::EvidenceModel;
 use crate::model::IndexModel;
 
-pub const SQLITE_FILE: &str = ".ovp/index/read-model.sqlite";
+const SQLITE_FILE: &str = "read-model.sqlite";
 const SCHEMA_VERSION: &str = "1";
 
-pub fn sqlite_path(vault_root: &Path) -> PathBuf {
-    vault_root.join(SQLITE_FILE)
+/// The machine-local cache root: `OVP_CACHE_DIR` when set (tests, portable
+/// setups), else the platform cache directory.
+fn cache_base() -> Result<PathBuf, String> {
+    if let Some(dir) = std::env::var_os("OVP_CACHE_DIR") {
+        return Ok(PathBuf::from(dir));
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let home = std::env::var_os("HOME").ok_or("HOME is not set")?;
+        Ok(PathBuf::from(home).join("Library/Caches"))
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let local = std::env::var_os("LOCALAPPDATA").ok_or("LOCALAPPDATA is not set")?;
+        Ok(PathBuf::from(local))
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        if let Some(xdg) = std::env::var_os("XDG_CACHE_HOME") {
+            return Ok(PathBuf::from(xdg));
+        }
+        let home = std::env::var_os("HOME").ok_or("HOME is not set")?;
+        Ok(PathBuf::from(home).join(".cache"))
+    }
+}
+
+/// Stable per-vault fingerprint: hash of the canonicalized root. Needs no
+/// state file inside the vault; moving the vault just cold-starts a new
+/// cache entry (the shadow is rebuildable by definition).
+fn vault_fingerprint(vault_root: &Path) -> String {
+    let canon = std::fs::canonicalize(vault_root).unwrap_or_else(|_| vault_root.to_path_buf());
+    let hex = ovp_intake::vaultops::hex_sha256(canon.to_string_lossy().as_bytes());
+    hex[..16].to_string()
+}
+
+/// Where this vault's shadow database lives on THIS machine.
+pub fn sqlite_path(vault_root: &Path) -> Result<PathBuf, String> {
+    Ok(cache_base()?
+        .join("ovp")
+        .join(vault_fingerprint(vault_root))
+        .join(SQLITE_FILE))
 }
 
 /// serde's snake_case string for a status enum — the SAME strings the JSON
@@ -46,8 +95,10 @@ CREATE INDEX idx_sources_status ON sources(status);
 CREATE INDEX idx_sources_date ON sources(date);
 CREATE TABLE source_tags(sha256 TEXT NOT NULL, tag TEXT NOT NULL, kind TEXT NOT NULL);
 CREATE INDEX idx_source_tags ON source_tags(tag, sha256);
+CREATE INDEX idx_source_tags_sha ON source_tags(sha256);
 CREATE TABLE source_entities(sha256 TEXT NOT NULL, entity TEXT NOT NULL);
 CREATE INDEX idx_source_entities ON source_entities(entity, sha256);
+CREATE INDEX idx_source_entities_sha ON source_entities(sha256);
 CREATE TABLE packs(
   pack_dir TEXT NOT NULL, title TEXT NOT NULL, date TEXT,
   units INTEGER NOT NULL, cards INTEGER NOT NULL,
@@ -86,18 +137,17 @@ CREATE INDEX idx_units_pack ON units(pack_dir);
 CREATE INDEX idx_units_source ON units(source_sha256);
 ";
 
-/// Build the shadow database into a unique temp file and atomically rename it
-/// over the previous generation. A crash mid-build leaves only a stale tmp
-/// (removed on the next build) — the previous generation stays intact, never
-/// a torn database. Plain (non-unique) indexes throughout: this is a
-/// projection, and a constraint abort on quirky data would kill the whole
-/// index build; uniqueness is the parity checker's job.
+/// Build a fresh shadow, verify it, and promote it — see the module docs for
+/// the promotion contract. Returns the database path and the parity report.
+/// Plain (non-unique) indexes throughout: this is a projection, and a
+/// constraint abort on quirky data would kill the whole index build;
+/// uniqueness is the parity checker's job.
 pub fn write_shadow(
     vault_root: &Path,
     model: &IndexModel,
     evidence: Option<&EvidenceModel>,
-) -> Result<String, String> {
-    let target = sqlite_path(vault_root);
+) -> Result<(PathBuf, ShadowParity), String> {
+    let target = sqlite_path(vault_root)?;
     let parent = target
         .parent()
         .ok_or_else(|| format!("{} has no parent directory", target.display()))?;
@@ -117,17 +167,42 @@ pub fn write_shadow(
     }
     let tmp = parent.join(format!("read-model.sqlite.tmp.{}", std::process::id()));
 
-    let built = build_into(&tmp, model, evidence);
-    if let Err(e) = built {
-        let _ = std::fs::remove_file(&tmp);
-        return Err(e);
-    }
+    let outcome = build_into(&tmp, model, evidence)
+        // Flush the candidate BEFORE validating/promoting: the build runs
+        // with synchronous=OFF, so without this a post-rename power loss
+        // could expose torn pages behind a rename that itself survived.
+        .and_then(|_| {
+            std::fs::File::open(&tmp)
+                .and_then(|f| f.sync_all())
+                .map_err(|e| format!("syncing {}: {e}", tmp.display()))
+        })
+        // Verify the CANDIDATE — promotion only happens on parity, so a
+        // failed build can never replace the last-good generation.
+        .and_then(|_| verify_at(&tmp, model, evidence));
+    let parity = match outcome {
+        Ok(parity) => parity,
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(e);
+        }
+    };
     std::fs::rename(&tmp, &target).map_err(|e| {
         let _ = std::fs::remove_file(&tmp);
         format!("renaming {} into place: {e}", target.display())
     })?;
     crate::build::sync_dir(parent)?;
-    Ok(ovp_intake::vaultops::rel_to(vault_root, &target))
+    Ok((target, parity))
+}
+
+/// Re-verify the CURRENT generation against in-memory projections (stage-3b
+/// standalone check; `write_shadow` already verified the candidate it
+/// promoted).
+pub fn verify_shadow(
+    vault_root: &Path,
+    model: &IndexModel,
+    evidence: Option<&EvidenceModel>,
+) -> Result<ShadowParity, String> {
+    verify_at(&sqlite_path(vault_root)?, model, evidence)
 }
 
 fn build_into(
@@ -136,8 +211,8 @@ fn build_into(
     evidence: Option<&EvidenceModel>,
 ) -> Result<(), String> {
     let mut conn = Connection::open(path).map_err(|e| format!("opening {}: {e}", path.display()))?;
-    // Rebuildable projection built into a tmp file: durability comes from the
-    // rename + dir fsync, not the journal — skip WAL/fsync during the build.
+    // The candidate is made durable by the explicit file sync + rename in
+    // `write_shadow`, not by the journal — skip WAL/fsync during the build.
     conn.pragma_update(None, "journal_mode", "OFF")
         .and_then(|_| conn.pragma_update(None, "synchronous", "OFF"))
         .map_err(|e| format!("pragmas: {e}"))?;
@@ -336,10 +411,11 @@ fn build_into(
     Ok(())
 }
 
-/// Parity report between the shadow database and the in-memory projections it
-/// was built from. Counts must ALL match and every sampled row must
-/// round-trip field-for-field — any mismatch is an `Err` naming the first
-/// divergence, because a silently drifting shadow is worse than none.
+/// Parity report between a shadow database and the in-memory projections it
+/// was built from. Counts must ALL match and every sampled row — INCLUDING
+/// its child-table rows — must round-trip field-for-field; any mismatch is an
+/// `Err` naming the first divergence, because a silently drifting shadow is
+/// worse than none.
 #[derive(Debug, PartialEq)]
 pub struct ShadowParity {
     pub sources: usize,
@@ -361,17 +437,25 @@ fn sample_indices(len: usize, want: usize) -> Vec<usize> {
     (0..want).map(|i| i * len / want).collect()
 }
 
-pub fn verify_shadow(
-    vault_root: &Path,
+const SAMPLES_PER_SURFACE: usize = 20;
+
+/// Compare two full-row JSON encodings, naming the surface and key on drift.
+fn expect_row(surface: &str, key: &str, got: &Value, want: &Value) -> Result<(), String> {
+    if got != want {
+        return Err(format!(
+            "{surface} {key} diverges:\n  sqlite: {got}\n  model:  {want}"
+        ));
+    }
+    Ok(())
+}
+
+fn verify_at(
+    path: &Path,
     model: &IndexModel,
     evidence: Option<&EvidenceModel>,
 ) -> Result<ShadowParity, String> {
-    let path = sqlite_path(vault_root);
-    let conn = Connection::open_with_flags(
-        &path,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-    )
-    .map_err(|e| format!("opening {}: {e}", path.display()))?;
+    let conn = Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| format!("opening {}: {e}", path.display()))?;
 
     let count = |table: &str| -> Result<usize, String> {
         conn.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |r| {
@@ -405,80 +489,274 @@ pub fn verify_shadow(
         .unwrap_or((0, 0));
     expect("cards", parity.cards, want_cards)?;
     expect("units", parity.units, want_units)?;
+    // Child tables count-check in full (cheap) so drift there cannot hide
+    // outside the sampled parents.
+    let want_tags: usize = model
+        .sources
+        .iter()
+        .map(|s| s.tags.len() + s.tags_inferred.len() + s.tags_implied.len())
+        .sum();
+    expect("source_tags", count("source_tags")?, want_tags)?;
+    let want_entities: usize = model.sources.iter().map(|s| s.entities.len()).sum();
+    expect("source_entities", count("source_entities")?, want_entities)?;
+    let want_card_titles: usize = model.packs.iter().map(|p| p.card_titles.len()).sum();
+    expect("pack_card_titles", count("pack_card_titles")?, want_card_titles)?;
+    let want_claim_sources: usize = model.claims.iter().map(|c| c.sources.len()).sum();
+    expect("claim_sources", count("claim_sources")?, want_claim_sources)?;
 
-    // Row-level samples: sources by sha, cards/units by id, claims by
-    // position-independent lookup on claim_id + claim text.
     let mut sampled = 0usize;
-    for i in sample_indices(model.sources.len(), 20) {
+
+    // --- sources: every column + ordered (tag, kind) pairs + entities ---
+    for i in sample_indices(model.sources.len(), SAMPLES_PER_SURFACE) {
         let s = &model.sources[i];
-        let (status, title, fail_count): (String, Option<String>, i64) = conn
+        let got = conn
             .query_row(
-                "SELECT status, title, fail_count FROM sources WHERE sha256 = ?1",
+                "SELECT status, title, author, url, origin, rel_path, date, content_date,
+                 captured_on, processed_on, last_run_id, pack_dir, fail_count, last_reason
+                 FROM sources WHERE sha256 = ?1",
                 [&s.sha256],
-                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+                |r| {
+                    Ok(json!({
+                        "status": r.get::<_, String>(0)?,
+                        "title": r.get::<_, Option<String>>(1)?,
+                        "author": r.get::<_, Option<String>>(2)?,
+                        "url": r.get::<_, Option<String>>(3)?,
+                        "origin": r.get::<_, Option<String>>(4)?,
+                        "rel_path": r.get::<_, Option<String>>(5)?,
+                        "date": r.get::<_, Option<String>>(6)?,
+                        "content_date": r.get::<_, Option<String>>(7)?,
+                        "captured_on": r.get::<_, Option<String>>(8)?,
+                        "processed_on": r.get::<_, Option<String>>(9)?,
+                        "last_run_id": r.get::<_, Option<String>>(10)?,
+                        "pack_dir": r.get::<_, Option<String>>(11)?,
+                        "fail_count": r.get::<_, i64>(12)?,
+                        "last_reason": r.get::<_, Option<String>>(13)?,
+                    }))
+                },
             )
             .map_err(|e| format!("sampling source {}: {e}", s.sha256))?;
-        if status != enum_str(&s.status) || title != s.title || fail_count as usize != s.fail_count
-        {
-            return Err(format!("source {} diverges: sqlite ({status}, {title:?}, {fail_count}) vs model ({}, {:?}, {})", s.sha256, enum_str(&s.status), s.title, s.fail_count));
-        }
-        let tag_count: i64 = conn
-            .query_row(
-                "SELECT COUNT(*) FROM source_tags WHERE sha256 = ?1",
-                [&s.sha256],
-                |r| r.get(0),
-            )
+        let want = json!({
+            "status": enum_str(&s.status),
+            "title": s.title, "author": s.author, "url": s.url, "origin": s.origin,
+            "rel_path": s.rel_path, "date": s.date, "content_date": s.content_date,
+            "captured_on": s.captured_on, "processed_on": s.processed_on,
+            "last_run_id": s.last_run_id, "pack_dir": s.pack_dir,
+            "fail_count": s.fail_count, "last_reason": s.last_reason,
+        });
+        expect_row("source", &s.sha256, &got, &want)?;
+
+        let got_tags: Vec<(String, String)> = conn
+            .prepare("SELECT tag, kind FROM source_tags WHERE sha256 = ?1 ORDER BY rowid")
+            .and_then(|mut st| {
+                st.query_map([&s.sha256], |r| Ok((r.get(0)?, r.get(1)?)))?
+                    .collect::<Result<Vec<_>, _>>()
+            })
             .map_err(|e| format!("sampling tags {}: {e}", s.sha256))?;
-        let want_tags = s.tags.len() + s.tags_inferred.len() + s.tags_implied.len();
-        if tag_count as usize != want_tags {
-            return Err(format!(
-                "source {} tag rows diverge: sqlite {tag_count} vs model {want_tags}",
-                s.sha256
-            ));
-        }
+        let want_tags: Vec<(String, String)> = s
+            .tags
+            .iter()
+            .map(|t| (t.clone(), "tag".to_string()))
+            .chain(s.tags_inferred.iter().map(|t| (t.clone(), "inferred".to_string())))
+            .chain(s.tags_implied.iter().map(|t| (t.clone(), "implied".to_string())))
+            .collect();
+        expect_row("source_tags", &s.sha256, &json!(got_tags), &json!(want_tags))?;
+
+        let got_entities: Vec<String> = conn
+            .prepare("SELECT entity FROM source_entities WHERE sha256 = ?1 ORDER BY rowid")
+            .and_then(|mut st| {
+                st.query_map([&s.sha256], |r| r.get(0))?
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .map_err(|e| format!("sampling entities {}: {e}", s.sha256))?;
+        expect_row("source_entities", &s.sha256, &json!(got_entities), &json!(s.entities))?;
         sampled += 1;
     }
-    if let Some(ev) = evidence {
-        for i in sample_indices(ev.units.len(), 20) {
-            let u = &ev.units[i];
-            let (text, quote, line): (String, String, Option<i64>) = conn
-                .query_row(
-                    "SELECT text, quote, line FROM units WHERE id = ?1",
-                    [&u.id],
-                    |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
-                )
-                .map_err(|e| format!("sampling unit {}: {e}", u.id))?;
-            if text != u.text || quote != u.quote || line.map(|l| l as usize) != u.line {
-                return Err(format!("unit {} diverges", u.id));
-            }
-            sampled += 1;
-        }
-        for i in sample_indices(ev.cards.len(), 20) {
-            let c = &ev.cards[i];
-            let content: String = conn
-                .query_row("SELECT content FROM cards WHERE id = ?1", [&c.id], |r| {
-                    r.get(0)
-                })
-                .map_err(|e| format!("sampling card {}: {e}", c.id))?;
-            if content != c.content {
-                return Err(format!("card {} diverges", c.id));
-            }
-            sampled += 1;
-        }
+
+    // --- packs: every column + ordered card titles ---
+    for i in sample_indices(model.packs.len(), SAMPLES_PER_SURFACE) {
+        let p = &model.packs[i];
+        let got = conn
+            .query_row(
+                "SELECT title, date, units, cards, json_repaired, source_sha256
+                 FROM packs WHERE pack_dir = ?1",
+                [&p.pack_dir],
+                |r| {
+                    Ok(json!({
+                        "title": r.get::<_, String>(0)?,
+                        "date": r.get::<_, Option<String>>(1)?,
+                        "units": r.get::<_, i64>(2)?,
+                        "cards": r.get::<_, i64>(3)?,
+                        "json_repaired": r.get::<_, i64>(4)? != 0,
+                        "source_sha256": r.get::<_, Option<String>>(5)?,
+                    }))
+                },
+            )
+            .map_err(|e| format!("sampling pack {}: {e}", p.pack_dir))?;
+        let want = json!({
+            "title": p.title, "date": p.date, "units": p.units, "cards": p.cards,
+            "json_repaired": p.json_repaired, "source_sha256": p.source_sha256,
+        });
+        expect_row("pack", &p.pack_dir, &got, &want)?;
+
+        let got_titles: Vec<String> = conn
+            .prepare("SELECT title FROM pack_card_titles WHERE pack_dir = ?1 ORDER BY idx")
+            .and_then(|mut st| {
+                st.query_map([&p.pack_dir], |r| r.get(0))?
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .map_err(|e| format!("sampling card titles {}: {e}", p.pack_dir))?;
+        expect_row("pack_card_titles", &p.pack_dir, &json!(got_titles), &json!(p.card_titles))?;
+        sampled += 1;
     }
-    for i in sample_indices(model.claims.len(), 20) {
+
+    // --- runs: every column. Keyed by report_file, NOT run_id — same-day
+    // reruns share a run_id (`daily-<date>`), so run_id is ambiguous on real
+    // vaults; the report file is one-per-run.
+    for i in sample_indices(model.runs.len(), SAMPLES_PER_SURFACE) {
+        let r0 = &model.runs[i];
+        let got = conn
+            .query_row(
+                "SELECT run_id, date, succeeded, failed, skipped, blocked, ingested,
+                 pinboard_new, lifecycle_warnings FROM runs WHERE report_file = ?1",
+                [&r0.report_file],
+                |r| {
+                    Ok(json!({
+                        "run_id": r.get::<_, String>(0)?,
+                        "date": r.get::<_, String>(1)?,
+                        "succeeded": r.get::<_, i64>(2)?,
+                        "failed": r.get::<_, i64>(3)?,
+                        "skipped": r.get::<_, i64>(4)?,
+                        "blocked": r.get::<_, i64>(5)?,
+                        "ingested": r.get::<_, i64>(6)?,
+                        "pinboard_new": r.get::<_, i64>(7)?,
+                        "lifecycle_warnings": r.get::<_, i64>(8)?,
+                    }))
+                },
+            )
+            .map_err(|e| format!("sampling run {}: {e}", r0.report_file))?;
+        let want = json!({
+            "run_id": r0.run_id, "date": r0.date, "succeeded": r0.succeeded,
+            "failed": r0.failed, "skipped": r0.skipped, "blocked": r0.blocked,
+            "ingested": r0.ingested, "pinboard_new": r0.pinboard_new,
+            "lifecycle_warnings": r0.lifecycle_warnings,
+        });
+        expect_row("run", &r0.report_file, &got, &want)?;
+        sampled += 1;
+    }
+
+    // --- claims: every column + ordered source list ---
+    for i in sample_indices(model.claims.len(), SAMPLES_PER_SURFACE) {
         let c = &model.claims[i];
         let n: i64 = conn
             .query_row(
-                "SELECT COUNT(*) FROM claims WHERE claim_id = ?1 AND claim = ?2 AND status = ?3",
-                (&c.claim_id, &c.claim, enum_str(&c.status)),
+                "SELECT COUNT(*) FROM claims WHERE claim_id = ?1 AND claim = ?2
+                 AND status = ?3 AND coalesce(claim_key,'') = coalesce(?4,'')
+                 AND coalesce(theme,'') = coalesce(?5,'')
+                 AND coalesce(strength,'') = coalesce(?6,'')
+                 AND coalesce(run_id,'') = coalesce(?7,'')
+                 AND coalesce(run_date,'') = coalesce(?8,'')
+                 AND coalesce(lane,'') = coalesce(?9,'')",
+                (
+                    &c.claim_id,
+                    &c.claim,
+                    enum_str(&c.status),
+                    &c.claim_key,
+                    &c.theme,
+                    &c.strength,
+                    &c.run_id,
+                    &c.run_date,
+                    &c.lane,
+                ),
                 |r| r.get(0),
             )
             .map_err(|e| format!("sampling claim {}: {e}", c.claim_id))?;
         if n == 0 {
             return Err(format!("claim {} missing or diverges", c.claim_id));
         }
+        let got_sources: Vec<String> = conn
+            .prepare("SELECT sha256 FROM claim_sources WHERE claim_id = ?1 ORDER BY rowid")
+            .and_then(|mut st| {
+                st.query_map([&c.claim_id], |r| r.get(0))?
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .map_err(|e| format!("sampling claim sources {}: {e}", c.claim_id))?;
+        // claim_id is NOT unique on real vaults (a claim can appear in both
+        // the durable and caveated lanes) — compare the AGGREGATE source list
+        // across every model row sharing this id, in model order (insertion
+        // order preserves it).
+        let want_sources: Vec<&String> = model
+            .claims
+            .iter()
+            .filter(|other| other.claim_id == c.claim_id)
+            .flat_map(|other| other.sources.iter())
+            .collect();
+        expect_row("claim_sources", &c.claim_id, &json!(got_sources), &json!(want_sources))?;
         sampled += 1;
+    }
+
+    if let Some(ev) = evidence {
+        // --- cards: every column ---
+        for i in sample_indices(ev.cards.len(), SAMPLES_PER_SURFACE) {
+            let c = &ev.cards[i];
+            let got = conn
+                .query_row(
+                    "SELECT pack_dir, source_sha256, source_title, title, content, unit_type,
+                     cited_unit_ids FROM cards WHERE id = ?1",
+                    [&c.id],
+                    |r| {
+                        Ok(json!({
+                            "pack_dir": r.get::<_, String>(0)?,
+                            "source_sha256": r.get::<_, Option<String>>(1)?,
+                            "source_title": r.get::<_, String>(2)?,
+                            "title": r.get::<_, String>(3)?,
+                            "content": r.get::<_, String>(4)?,
+                            "unit_type": r.get::<_, Option<String>>(5)?,
+                            "cited_unit_ids": r.get::<_, String>(6)?,
+                        }))
+                    },
+                )
+                .map_err(|e| format!("sampling card {}: {e}", c.id))?;
+            let want = json!({
+                "pack_dir": c.pack_dir, "source_sha256": c.source_sha256,
+                "source_title": c.source_title, "title": c.title, "content": c.content,
+                "unit_type": c.unit_type,
+                "cited_unit_ids": serde_json::to_string(&c.cited_unit_ids).unwrap_or_else(|_| "[]".into()),
+            });
+            expect_row("card", &c.id, &got, &want)?;
+            sampled += 1;
+        }
+        // --- units: every column ---
+        for i in sample_indices(ev.units.len(), SAMPLES_PER_SURFACE) {
+            let u = &ev.units[i];
+            let got = conn
+                .query_row(
+                    "SELECT pack_dir, source_sha256, source_title, unit_id, text, quote, line,
+                     attribution, modality FROM units WHERE id = ?1",
+                    [&u.id],
+                    |r| {
+                        Ok(json!({
+                            "pack_dir": r.get::<_, String>(0)?,
+                            "source_sha256": r.get::<_, Option<String>>(1)?,
+                            "source_title": r.get::<_, String>(2)?,
+                            "unit_id": r.get::<_, String>(3)?,
+                            "text": r.get::<_, String>(4)?,
+                            "quote": r.get::<_, String>(5)?,
+                            "line": r.get::<_, Option<i64>>(6)?,
+                            "attribution": r.get::<_, String>(7)?,
+                            "modality": r.get::<_, String>(8)?,
+                        }))
+                    },
+                )
+                .map_err(|e| format!("sampling unit {}: {e}", u.id))?;
+            let want = json!({
+                "pack_dir": u.pack_dir, "source_sha256": u.source_sha256,
+                "source_title": u.source_title, "unit_id": u.unit_id, "text": u.text,
+                "quote": u.quote, "line": u.line, "attribution": u.attribution,
+                "modality": u.modality,
+            });
+            expect_row("unit", &u.id, &got, &want)?;
+            sampled += 1;
+        }
     }
 
     Ok(ShadowParity { sampled, ..parity })
@@ -489,6 +767,19 @@ mod tests {
     use super::*;
     use crate::evidence::{CardEvidenceRow, UnitEvidenceRow};
     use crate::model::{ClaimRow, ClaimStatus, OpsState, PackRow, SourceRow, SourceStatus, Totals};
+
+    /// In-process tests pin the db path explicitly (no env: parallel tests
+    /// share the process environment); the CLI e2e covers env resolution.
+    fn shadow_at(
+        dir: &Path,
+        model: &IndexModel,
+        evidence: Option<&EvidenceModel>,
+    ) -> Result<(PathBuf, ShadowParity), String> {
+        let tmp = dir.join("candidate.sqlite");
+        build_into(&tmp, model, evidence)?;
+        let parity = verify_at(&tmp, model, evidence)?;
+        Ok((tmp, parity))
+    }
 
     fn model() -> IndexModel {
         IndexModel {
@@ -501,21 +792,21 @@ mod tests {
                 sha256: "sha-a".into(),
                 status: SourceStatus::Processed,
                 title: Some("A 标题 <\"quoted\">".into()),
-                author: None,
+                author: Some("Ada".into()),
                 url: Some("https://e.x/a?q=1&z=2".into()),
-                origin: None,
+                origin: Some("pinboard".into()),
                 rel_path: Some("50-Inbox/03-Processed/a.md".into()),
                 date: Some("2026-08-01".into()),
-                content_date: None,
-                captured_on: None,
+                content_date: Some("2026-07-30".into()),
+                captured_on: Some("2026-07-31".into()),
                 processed_on: Some("2026-08-02".into()),
-                last_run_id: None,
+                last_run_id: Some("daily-2026-08-02".into()),
                 pack_dir: Some("40-Resources/Reader/a".into()),
                 fail_count: 0,
                 last_reason: None,
                 tags: vec!["ai".into()],
                 tags_inferred: vec!["agents".into(), "记忆".into()],
-                tags_implied: vec![],
+                tags_implied: vec!["ml".into()],
                 entities: vec!["Anthropic".into()],
             }],
             packs: vec![PackRow {
@@ -540,7 +831,18 @@ mod tests {
                 run_date: None,
                 lane: None,
             }],
-            runs: vec![],
+            runs: vec![crate::model::RunRow {
+                run_id: "daily-2026-08-02".into(),
+                date: "2026-08-02".into(),
+                report_file: ".ovp/reports/daily-2026-08-02.json".into(),
+                succeeded: 3,
+                failed: 1,
+                skipped: 0,
+                blocked: 0,
+                ingested: 2,
+                pinboard_new: 1,
+                lifecycle_warnings: 0,
+            }],
             ops: OpsState::default(),
         }
     }
@@ -576,59 +878,88 @@ mod tests {
     }
 
     #[test]
-    fn shadow_round_trips_and_verifies() {
+    fn shadow_round_trips_and_verifies_all_surfaces() {
         let tmp = tempfile::tempdir().unwrap();
         let m = model();
         let ev = evidence();
-        let rel = write_shadow(tmp.path(), &m, Some(&ev)).unwrap();
-        assert_eq!(rel, ".ovp/index/read-model.sqlite");
-
-        let parity = verify_shadow(tmp.path(), &m, Some(&ev)).unwrap();
+        let (_, parity) = shadow_at(tmp.path(), &m, Some(&ev)).unwrap();
         assert_eq!(
             parity,
             ShadowParity {
                 sources: 1,
                 packs: 1,
                 claims: 1,
-                runs: 0,
+                runs: 1,
                 cards: 1,
                 units: 1,
-                sampled: 4,
+                sampled: 6,
             }
         );
-
-        // No stray tmp generations left behind, and rebuilds replace cleanly.
-        write_shadow(tmp.path(), &m, Some(&ev)).unwrap();
-        let strays: Vec<_> = std::fs::read_dir(tmp.path().join(".ovp/index"))
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .map(|e| e.file_name().to_string_lossy().into_owned())
-            .filter(|n| n.contains(".tmp."))
-            .collect();
-        assert!(strays.is_empty(), "stray tmp files: {strays:?}");
     }
 
     #[test]
-    fn verify_catches_divergence() {
+    fn verify_catches_divergence_in_unsampled_looking_fields() {
         let tmp = tempfile::tempdir().unwrap();
         let m = model();
         let ev = evidence();
-        write_shadow(tmp.path(), &m, Some(&ev)).unwrap();
+        let db = tmp.path().join("candidate.sqlite");
+        build_into(&db, &m, Some(&ev)).unwrap();
 
-        // A model that gained a source after the shadow was built must fail
-        // the count check.
+        // Count drift.
         let mut newer = m.clone();
         let mut extra = newer.sources[0].clone();
         extra.sha256 = "sha-b".into();
         newer.sources.push(extra);
-        let err = verify_shadow(tmp.path(), &newer, Some(&ev)).unwrap_err();
+        let err = verify_at(&db, &newer, Some(&ev)).unwrap_err();
         assert!(err.contains("sources"), "unexpected error: {err}");
 
-        // A silently edited row must fail the sample check.
+        // Field-level drift in fields the OLD sampler never looked at:
+        // author, a tag KIND, an entity, a run column, a card citation.
         let mut edited = m.clone();
-        edited.sources[0].title = Some("tampered".into());
-        let err = verify_shadow(tmp.path(), &edited, Some(&ev)).unwrap_err();
-        assert!(err.contains("diverges"), "unexpected error: {err}");
+        edited.sources[0].author = Some("Mallory".into());
+        assert!(verify_at(&db, &edited, Some(&ev)).is_err(), "author drift");
+
+        let mut edited = m.clone();
+        edited.sources[0].tags_implied = vec!["other".into()];
+        assert!(verify_at(&db, &edited, Some(&ev)).is_err(), "tag-kind drift");
+
+        let mut edited = m.clone();
+        edited.sources[0].entities = vec!["Someone".into()];
+        assert!(verify_at(&db, &edited, Some(&ev)).is_err(), "entity drift");
+
+        let mut edited = m.clone();
+        edited.runs[0].ingested = 99;
+        assert!(verify_at(&db, &edited, Some(&ev)).is_err(), "run drift");
+
+        let mut ev_edited = ev.clone();
+        ev_edited.cards[0].cited_unit_ids = vec!["u-2".into()];
+        assert!(verify_at(&db, &m, Some(&ev_edited)).is_err(), "citation drift");
+
+        let mut edited = m.clone();
+        edited.packs[0].card_titles = vec!["Other".into()];
+        assert!(verify_at(&db, &edited, Some(&ev)).is_err(), "card-title drift");
+    }
+
+    #[test]
+    fn write_shadow_keeps_last_good_when_candidate_fails_verify() {
+        // Simulate the promotion contract at the verify layer: a candidate
+        // that fails parity must never replace the previous generation.
+        // (write_shadow wires cache-path resolution + this exact sequence;
+        // the e2e exercises it end-to-end through the binary.)
+        let tmp = tempfile::tempdir().unwrap();
+        let m = model();
+        let ev = evidence();
+        let (good, _) = shadow_at(tmp.path(), &m, Some(&ev)).unwrap();
+
+        let mut drifted = m.clone();
+        drifted.sources[0].title = Some("tampered".into());
+        // Candidate built from drifted model verifies fine against itself…
+        let candidate = tmp.path().join("candidate2.sqlite");
+        build_into(&candidate, &drifted, Some(&ev)).unwrap();
+        // …but never against the authoritative model — promotion must stop.
+        assert!(verify_at(&candidate, &m, Some(&ev)).is_err());
+        // Last-good is still readable and still passes.
+        assert!(verify_at(&good, &m, Some(&ev)).is_ok());
     }
 
     #[test]

--- a/crates/ovp-index/src/sqlite.rs
+++ b/crates/ovp-index/src/sqlite.rs
@@ -1,0 +1,643 @@
+//! SQLite shadow read-model (stage 3 of `docs/design/storage-read-model.md`).
+//!
+//! Same philosophy as the JSON projection: derived, rebuildable state — every
+//! build produces a FRESH database file that atomically replaces the previous
+//! generation, so there is no migration story (`ovp2 index` IS the
+//! migration). The JSON files remain the serving projection; this shadow
+//! exists to be diffed against them (`verify_shadow`) until parity has soaked
+//! long enough to switch endpoints over (stage 4).
+//!
+//! Deliberately NOT here yet: incremental cursors (full rebuild is minutes at
+//! 100x scale, measured), FTS tables (stage 3c), vector columns (stage 5).
+
+use std::path::{Path, PathBuf};
+
+use rusqlite::Connection;
+use serde::Serialize;
+
+use crate::evidence::EvidenceModel;
+use crate::model::IndexModel;
+
+pub const SQLITE_FILE: &str = ".ovp/index/read-model.sqlite";
+const SCHEMA_VERSION: &str = "1";
+
+pub fn sqlite_path(vault_root: &Path) -> PathBuf {
+    vault_root.join(SQLITE_FILE)
+}
+
+/// serde's snake_case string for a status enum — the SAME strings the JSON
+/// projection carries, so parity comparison is byte-for-byte.
+fn enum_str<T: Serialize>(v: &T) -> String {
+    serde_json::to_value(v)
+        .ok()
+        .and_then(|j| j.as_str().map(String::from))
+        .unwrap_or_default()
+}
+
+const DDL: &str = "
+CREATE TABLE meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+CREATE TABLE sources(
+  sha256 TEXT NOT NULL, status TEXT NOT NULL, title TEXT, author TEXT,
+  url TEXT, origin TEXT, rel_path TEXT, date TEXT, content_date TEXT,
+  captured_on TEXT, processed_on TEXT, last_run_id TEXT, pack_dir TEXT,
+  fail_count INTEGER NOT NULL, last_reason TEXT);
+CREATE INDEX idx_sources_sha ON sources(sha256);
+CREATE INDEX idx_sources_status ON sources(status);
+CREATE INDEX idx_sources_date ON sources(date);
+CREATE TABLE source_tags(sha256 TEXT NOT NULL, tag TEXT NOT NULL, kind TEXT NOT NULL);
+CREATE INDEX idx_source_tags ON source_tags(tag, sha256);
+CREATE TABLE source_entities(sha256 TEXT NOT NULL, entity TEXT NOT NULL);
+CREATE INDEX idx_source_entities ON source_entities(entity, sha256);
+CREATE TABLE packs(
+  pack_dir TEXT NOT NULL, title TEXT NOT NULL, date TEXT,
+  units INTEGER NOT NULL, cards INTEGER NOT NULL,
+  json_repaired INTEGER NOT NULL, source_sha256 TEXT);
+CREATE INDEX idx_packs_dir ON packs(pack_dir);
+CREATE INDEX idx_packs_source ON packs(source_sha256);
+CREATE TABLE pack_card_titles(pack_dir TEXT NOT NULL, idx INTEGER NOT NULL, title TEXT NOT NULL);
+CREATE INDEX idx_pack_card_titles ON pack_card_titles(pack_dir, idx);
+CREATE TABLE claims(
+  claim_id TEXT NOT NULL, claim_key TEXT, claim TEXT NOT NULL, theme TEXT,
+  status TEXT NOT NULL, strength TEXT, run_id TEXT, run_date TEXT, lane TEXT);
+CREATE INDEX idx_claims_id ON claims(claim_id);
+CREATE INDEX idx_claims_status ON claims(status);
+CREATE TABLE claim_sources(claim_id TEXT NOT NULL, sha256 TEXT NOT NULL);
+CREATE INDEX idx_claim_sources ON claim_sources(claim_id);
+CREATE INDEX idx_claim_sources_sha ON claim_sources(sha256);
+CREATE TABLE runs(
+  run_id TEXT NOT NULL, date TEXT NOT NULL, report_file TEXT NOT NULL,
+  succeeded INTEGER NOT NULL, failed INTEGER NOT NULL, skipped INTEGER NOT NULL,
+  blocked INTEGER NOT NULL, ingested INTEGER NOT NULL,
+  pinboard_new INTEGER NOT NULL, lifecycle_warnings INTEGER NOT NULL);
+CREATE TABLE cards(
+  id TEXT NOT NULL, pack_dir TEXT NOT NULL, source_sha256 TEXT,
+  source_title TEXT NOT NULL, title TEXT NOT NULL, content TEXT NOT NULL,
+  unit_type TEXT, cited_unit_ids TEXT NOT NULL);
+CREATE INDEX idx_cards_id ON cards(id);
+CREATE INDEX idx_cards_pack ON cards(pack_dir);
+CREATE INDEX idx_cards_source ON cards(source_sha256);
+CREATE TABLE units(
+  id TEXT NOT NULL, pack_dir TEXT NOT NULL, source_sha256 TEXT,
+  source_title TEXT NOT NULL, unit_id TEXT NOT NULL, text TEXT NOT NULL,
+  quote TEXT NOT NULL, line INTEGER, attribution TEXT NOT NULL,
+  modality TEXT NOT NULL);
+CREATE INDEX idx_units_id ON units(id);
+CREATE INDEX idx_units_pack ON units(pack_dir);
+CREATE INDEX idx_units_source ON units(source_sha256);
+";
+
+/// Build the shadow database into a unique temp file and atomically rename it
+/// over the previous generation. A crash mid-build leaves only a stale tmp
+/// (removed on the next build) — the previous generation stays intact, never
+/// a torn database. Plain (non-unique) indexes throughout: this is a
+/// projection, and a constraint abort on quirky data would kill the whole
+/// index build; uniqueness is the parity checker's job.
+pub fn write_shadow(
+    vault_root: &Path,
+    model: &IndexModel,
+    evidence: Option<&EvidenceModel>,
+) -> Result<String, String> {
+    let target = sqlite_path(vault_root);
+    let parent = target
+        .parent()
+        .ok_or_else(|| format!("{} has no parent directory", target.display()))?;
+    std::fs::create_dir_all(parent)
+        .map_err(|e| format!("creating {}: {e}", parent.display()))?;
+    // Sweep stale tmp generations from crashed builds before making a new one.
+    if let Ok(entries) = std::fs::read_dir(parent) {
+        for entry in entries.flatten() {
+            if entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with("read-model.sqlite.tmp.")
+            {
+                let _ = std::fs::remove_file(entry.path());
+            }
+        }
+    }
+    let tmp = parent.join(format!("read-model.sqlite.tmp.{}", std::process::id()));
+
+    let built = build_into(&tmp, model, evidence);
+    if let Err(e) = built {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    std::fs::rename(&tmp, &target).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp);
+        format!("renaming {} into place: {e}", target.display())
+    })?;
+    crate::build::sync_dir(parent)?;
+    Ok(ovp_intake::vaultops::rel_to(vault_root, &target))
+}
+
+fn build_into(
+    path: &Path,
+    model: &IndexModel,
+    evidence: Option<&EvidenceModel>,
+) -> Result<(), String> {
+    let mut conn = Connection::open(path).map_err(|e| format!("opening {}: {e}", path.display()))?;
+    // Rebuildable projection built into a tmp file: durability comes from the
+    // rename + dir fsync, not the journal — skip WAL/fsync during the build.
+    conn.pragma_update(None, "journal_mode", "OFF")
+        .and_then(|_| conn.pragma_update(None, "synchronous", "OFF"))
+        .map_err(|e| format!("pragmas: {e}"))?;
+    conn.execute_batch(DDL).map_err(|e| format!("schema: {e}"))?;
+
+    let tx = conn.transaction().map_err(|e| format!("begin: {e}"))?;
+    {
+        let mut meta = tx
+            .prepare("INSERT INTO meta(key, value) VALUES(?1, ?2)")
+            .map_err(|e| format!("prepare meta: {e}"))?;
+        for (k, v) in [
+            ("schema_version", SCHEMA_VERSION.to_string()),
+            ("index_schema", model.schema.clone()),
+            ("date", model.date.clone()),
+            ("built_at", model.built_at.clone().unwrap_or_default()),
+            ("run_id", model.run_id.clone().unwrap_or_default()),
+        ] {
+            meta.execute((k, v)).map_err(|e| format!("meta {k}: {e}"))?;
+        }
+
+        let mut src = tx
+            .prepare(
+                "INSERT INTO sources(sha256, status, title, author, url, origin, rel_path,
+                 date, content_date, captured_on, processed_on, last_run_id, pack_dir,
+                 fail_count, last_reason)
+                 VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15)",
+            )
+            .map_err(|e| format!("prepare sources: {e}"))?;
+        let mut tag = tx
+            .prepare("INSERT INTO source_tags(sha256, tag, kind) VALUES(?1,?2,?3)")
+            .map_err(|e| format!("prepare source_tags: {e}"))?;
+        let mut ent = tx
+            .prepare("INSERT INTO source_entities(sha256, entity) VALUES(?1,?2)")
+            .map_err(|e| format!("prepare source_entities: {e}"))?;
+        for s in &model.sources {
+            src.execute((
+                &s.sha256,
+                enum_str(&s.status),
+                &s.title,
+                &s.author,
+                &s.url,
+                &s.origin,
+                &s.rel_path,
+                &s.date,
+                &s.content_date,
+                &s.captured_on,
+                &s.processed_on,
+                &s.last_run_id,
+                &s.pack_dir,
+                s.fail_count as i64,
+                &s.last_reason,
+            ))
+            .map_err(|e| format!("source {}: {e}", s.sha256))?;
+            for (kind, list) in [
+                ("tag", &s.tags),
+                ("inferred", &s.tags_inferred),
+                ("implied", &s.tags_implied),
+            ] {
+                for t in list {
+                    tag.execute((&s.sha256, t, kind))
+                        .map_err(|e| format!("tag {}: {e}", s.sha256))?;
+                }
+            }
+            for entity in &s.entities {
+                ent.execute((&s.sha256, entity))
+                    .map_err(|e| format!("entity {}: {e}", s.sha256))?;
+            }
+        }
+
+        let mut pack = tx
+            .prepare(
+                "INSERT INTO packs(pack_dir, title, date, units, cards, json_repaired,
+                 source_sha256) VALUES(?1,?2,?3,?4,?5,?6,?7)",
+            )
+            .map_err(|e| format!("prepare packs: {e}"))?;
+        let mut card_title = tx
+            .prepare("INSERT INTO pack_card_titles(pack_dir, idx, title) VALUES(?1,?2,?3)")
+            .map_err(|e| format!("prepare pack_card_titles: {e}"))?;
+        for p in &model.packs {
+            pack.execute((
+                &p.pack_dir,
+                &p.title,
+                &p.date,
+                p.units as i64,
+                p.cards as i64,
+                p.json_repaired as i64,
+                &p.source_sha256,
+            ))
+            .map_err(|e| format!("pack {}: {e}", p.pack_dir))?;
+            for (idx, t) in p.card_titles.iter().enumerate() {
+                card_title
+                    .execute((&p.pack_dir, idx as i64, t))
+                    .map_err(|e| format!("card title {}: {e}", p.pack_dir))?;
+            }
+        }
+
+        let mut claim = tx
+            .prepare(
+                "INSERT INTO claims(claim_id, claim_key, claim, theme, status, strength,
+                 run_id, run_date, lane) VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9)",
+            )
+            .map_err(|e| format!("prepare claims: {e}"))?;
+        let mut claim_src = tx
+            .prepare("INSERT INTO claim_sources(claim_id, sha256) VALUES(?1,?2)")
+            .map_err(|e| format!("prepare claim_sources: {e}"))?;
+        for c in &model.claims {
+            claim
+                .execute((
+                    &c.claim_id,
+                    &c.claim_key,
+                    &c.claim,
+                    &c.theme,
+                    enum_str(&c.status),
+                    &c.strength,
+                    &c.run_id,
+                    &c.run_date,
+                    &c.lane,
+                ))
+                .map_err(|e| format!("claim {}: {e}", c.claim_id))?;
+            for sha in &c.sources {
+                claim_src
+                    .execute((&c.claim_id, sha))
+                    .map_err(|e| format!("claim source {}: {e}", c.claim_id))?;
+            }
+        }
+
+        let mut run = tx
+            .prepare(
+                "INSERT INTO runs(run_id, date, report_file, succeeded, failed, skipped,
+                 blocked, ingested, pinboard_new, lifecycle_warnings)
+                 VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9,?10)",
+            )
+            .map_err(|e| format!("prepare runs: {e}"))?;
+        for r in &model.runs {
+            run.execute((
+                &r.run_id,
+                &r.date,
+                &r.report_file,
+                r.succeeded as i64,
+                r.failed as i64,
+                r.skipped as i64,
+                r.blocked as i64,
+                r.ingested as i64,
+                r.pinboard_new as i64,
+                r.lifecycle_warnings as i64,
+            ))
+            .map_err(|e| format!("run {}: {e}", r.run_id))?;
+        }
+
+        if let Some(ev) = evidence {
+            let mut card = tx
+                .prepare(
+                    "INSERT INTO cards(id, pack_dir, source_sha256, source_title, title,
+                     content, unit_type, cited_unit_ids)
+                     VALUES(?1,?2,?3,?4,?5,?6,?7,?8)",
+                )
+                .map_err(|e| format!("prepare cards: {e}"))?;
+            for c in &ev.cards {
+                card.execute((
+                    &c.id,
+                    &c.pack_dir,
+                    &c.source_sha256,
+                    &c.source_title,
+                    &c.title,
+                    &c.content,
+                    &c.unit_type,
+                    serde_json::to_string(&c.cited_unit_ids).unwrap_or_else(|_| "[]".into()),
+                ))
+                .map_err(|e| format!("card {}: {e}", c.id))?;
+            }
+            let mut unit = tx
+                .prepare(
+                    "INSERT INTO units(id, pack_dir, source_sha256, source_title, unit_id,
+                     text, quote, line, attribution, modality)
+                     VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9,?10)",
+                )
+                .map_err(|e| format!("prepare units: {e}"))?;
+            for u in &ev.units {
+                unit.execute((
+                    &u.id,
+                    &u.pack_dir,
+                    &u.source_sha256,
+                    &u.source_title,
+                    &u.unit_id,
+                    &u.text,
+                    &u.quote,
+                    u.line.map(|l| l as i64),
+                    &u.attribution,
+                    &u.modality,
+                ))
+                .map_err(|e| format!("unit {}: {e}", u.id))?;
+            }
+        }
+    }
+    tx.commit().map_err(|e| format!("commit: {e}"))?;
+    Ok(())
+}
+
+/// Parity report between the shadow database and the in-memory projections it
+/// was built from. Counts must ALL match and every sampled row must
+/// round-trip field-for-field — any mismatch is an `Err` naming the first
+/// divergence, because a silently drifting shadow is worse than none.
+#[derive(Debug, PartialEq)]
+pub struct ShadowParity {
+    pub sources: usize,
+    pub packs: usize,
+    pub claims: usize,
+    pub runs: usize,
+    pub cards: usize,
+    pub units: usize,
+    pub sampled: usize,
+}
+
+/// Evenly-spaced sample indices — deterministic, no clock/randomness (cheap
+/// to rerun in tests and on every build).
+fn sample_indices(len: usize, want: usize) -> Vec<usize> {
+    if len == 0 {
+        return Vec::new();
+    }
+    let want = want.min(len);
+    (0..want).map(|i| i * len / want).collect()
+}
+
+pub fn verify_shadow(
+    vault_root: &Path,
+    model: &IndexModel,
+    evidence: Option<&EvidenceModel>,
+) -> Result<ShadowParity, String> {
+    let path = sqlite_path(vault_root);
+    let conn = Connection::open_with_flags(
+        &path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )
+    .map_err(|e| format!("opening {}: {e}", path.display()))?;
+
+    let count = |table: &str| -> Result<usize, String> {
+        conn.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |r| {
+            r.get::<_, i64>(0)
+        })
+        .map(|n| n as usize)
+        .map_err(|e| format!("counting {table}: {e}"))
+    };
+    let expect = |table: &str, got: usize, want: usize| -> Result<(), String> {
+        if got != want {
+            return Err(format!("{table}: sqlite has {got} rows, model has {want}"));
+        }
+        Ok(())
+    };
+
+    let parity = ShadowParity {
+        sources: count("sources")?,
+        packs: count("packs")?,
+        claims: count("claims")?,
+        runs: count("runs")?,
+        cards: count("cards")?,
+        units: count("units")?,
+        sampled: 0,
+    };
+    expect("sources", parity.sources, model.sources.len())?;
+    expect("packs", parity.packs, model.packs.len())?;
+    expect("claims", parity.claims, model.claims.len())?;
+    expect("runs", parity.runs, model.runs.len())?;
+    let (want_cards, want_units) = evidence
+        .map(|e| (e.cards.len(), e.units.len()))
+        .unwrap_or((0, 0));
+    expect("cards", parity.cards, want_cards)?;
+    expect("units", parity.units, want_units)?;
+
+    // Row-level samples: sources by sha, cards/units by id, claims by
+    // position-independent lookup on claim_id + claim text.
+    let mut sampled = 0usize;
+    for i in sample_indices(model.sources.len(), 20) {
+        let s = &model.sources[i];
+        let (status, title, fail_count): (String, Option<String>, i64) = conn
+            .query_row(
+                "SELECT status, title, fail_count FROM sources WHERE sha256 = ?1",
+                [&s.sha256],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .map_err(|e| format!("sampling source {}: {e}", s.sha256))?;
+        if status != enum_str(&s.status) || title != s.title || fail_count as usize != s.fail_count
+        {
+            return Err(format!("source {} diverges: sqlite ({status}, {title:?}, {fail_count}) vs model ({}, {:?}, {})", s.sha256, enum_str(&s.status), s.title, s.fail_count));
+        }
+        let tag_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM source_tags WHERE sha256 = ?1",
+                [&s.sha256],
+                |r| r.get(0),
+            )
+            .map_err(|e| format!("sampling tags {}: {e}", s.sha256))?;
+        let want_tags = s.tags.len() + s.tags_inferred.len() + s.tags_implied.len();
+        if tag_count as usize != want_tags {
+            return Err(format!(
+                "source {} tag rows diverge: sqlite {tag_count} vs model {want_tags}",
+                s.sha256
+            ));
+        }
+        sampled += 1;
+    }
+    if let Some(ev) = evidence {
+        for i in sample_indices(ev.units.len(), 20) {
+            let u = &ev.units[i];
+            let (text, quote, line): (String, String, Option<i64>) = conn
+                .query_row(
+                    "SELECT text, quote, line FROM units WHERE id = ?1",
+                    [&u.id],
+                    |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+                )
+                .map_err(|e| format!("sampling unit {}: {e}", u.id))?;
+            if text != u.text || quote != u.quote || line.map(|l| l as usize) != u.line {
+                return Err(format!("unit {} diverges", u.id));
+            }
+            sampled += 1;
+        }
+        for i in sample_indices(ev.cards.len(), 20) {
+            let c = &ev.cards[i];
+            let content: String = conn
+                .query_row("SELECT content FROM cards WHERE id = ?1", [&c.id], |r| {
+                    r.get(0)
+                })
+                .map_err(|e| format!("sampling card {}: {e}", c.id))?;
+            if content != c.content {
+                return Err(format!("card {} diverges", c.id));
+            }
+            sampled += 1;
+        }
+    }
+    for i in sample_indices(model.claims.len(), 20) {
+        let c = &model.claims[i];
+        let n: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM claims WHERE claim_id = ?1 AND claim = ?2 AND status = ?3",
+                (&c.claim_id, &c.claim, enum_str(&c.status)),
+                |r| r.get(0),
+            )
+            .map_err(|e| format!("sampling claim {}: {e}", c.claim_id))?;
+        if n == 0 {
+            return Err(format!("claim {} missing or diverges", c.claim_id));
+        }
+        sampled += 1;
+    }
+
+    Ok(ShadowParity { sampled, ..parity })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::evidence::{CardEvidenceRow, UnitEvidenceRow};
+    use crate::model::{ClaimRow, ClaimStatus, OpsState, PackRow, SourceRow, SourceStatus, Totals};
+
+    fn model() -> IndexModel {
+        IndexModel {
+            schema: "ovp.index/v2".into(),
+            date: "2026-08-05".into(),
+            built_at: Some("2026-08-05T10:00:00Z".into()),
+            run_id: Some("daily-2026-08-05".into()),
+            totals: Totals::default(),
+            sources: vec![SourceRow {
+                sha256: "sha-a".into(),
+                status: SourceStatus::Processed,
+                title: Some("A 标题 <\"quoted\">".into()),
+                author: None,
+                url: Some("https://e.x/a?q=1&z=2".into()),
+                origin: None,
+                rel_path: Some("50-Inbox/03-Processed/a.md".into()),
+                date: Some("2026-08-01".into()),
+                content_date: None,
+                captured_on: None,
+                processed_on: Some("2026-08-02".into()),
+                last_run_id: None,
+                pack_dir: Some("40-Resources/Reader/a".into()),
+                fail_count: 0,
+                last_reason: None,
+                tags: vec!["ai".into()],
+                tags_inferred: vec!["agents".into(), "记忆".into()],
+                tags_implied: vec![],
+                entities: vec!["Anthropic".into()],
+            }],
+            packs: vec![PackRow {
+                pack_dir: "40-Resources/Reader/a".into(),
+                title: "A pack".into(),
+                date: Some("2026-08-02".into()),
+                units: 1,
+                cards: 1,
+                json_repaired: false,
+                card_titles: vec!["Card one".into()],
+                source_sha256: Some("sha-a".into()),
+            }],
+            claims: vec![ClaimRow {
+                claim_id: "m1-01".into(),
+                claim_key: Some("ck-abc".into()),
+                claim: "记忆是持久状态 with \"quotes\"".into(),
+                theme: Some("agent-memory".into()),
+                status: ClaimStatus::Durable,
+                sources: vec!["sha-a".into()],
+                strength: Some("well_supported".into()),
+                run_id: None,
+                run_date: None,
+                lane: None,
+            }],
+            runs: vec![],
+            ops: OpsState::default(),
+        }
+    }
+
+    fn evidence() -> EvidenceModel {
+        EvidenceModel {
+            schema: "ovp.index.evidence/v1".into(),
+            date: "2026-08-05".into(),
+            cards: vec![CardEvidenceRow {
+                id: "card:40-Resources/Reader/a:0".into(),
+                pack_dir: "40-Resources/Reader/a".into(),
+                source_sha256: Some("sha-a".into()),
+                source_title: "A pack".into(),
+                title: "Card one".into(),
+                content: "内容 body".into(),
+                unit_type: Some("fact".into()),
+                cited_unit_ids: vec!["u-1".into()],
+            }],
+            units: vec![UnitEvidenceRow {
+                id: "unit:40-Resources/Reader/a:u-1".into(),
+                pack_dir: "40-Resources/Reader/a".into(),
+                source_sha256: Some("sha-a".into()),
+                source_title: "A pack".into(),
+                unit_id: "u-1".into(),
+                text: "unit text 中文".into(),
+                quote: "\"quoted\" 引文".into(),
+                line: Some(12),
+                attribution: "author".into(),
+                modality: "asserted".into(),
+            }],
+            warnings: vec![],
+        }
+    }
+
+    #[test]
+    fn shadow_round_trips_and_verifies() {
+        let tmp = tempfile::tempdir().unwrap();
+        let m = model();
+        let ev = evidence();
+        let rel = write_shadow(tmp.path(), &m, Some(&ev)).unwrap();
+        assert_eq!(rel, ".ovp/index/read-model.sqlite");
+
+        let parity = verify_shadow(tmp.path(), &m, Some(&ev)).unwrap();
+        assert_eq!(
+            parity,
+            ShadowParity {
+                sources: 1,
+                packs: 1,
+                claims: 1,
+                runs: 0,
+                cards: 1,
+                units: 1,
+                sampled: 4,
+            }
+        );
+
+        // No stray tmp generations left behind, and rebuilds replace cleanly.
+        write_shadow(tmp.path(), &m, Some(&ev)).unwrap();
+        let strays: Vec<_> = std::fs::read_dir(tmp.path().join(".ovp/index"))
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp."))
+            .collect();
+        assert!(strays.is_empty(), "stray tmp files: {strays:?}");
+    }
+
+    #[test]
+    fn verify_catches_divergence() {
+        let tmp = tempfile::tempdir().unwrap();
+        let m = model();
+        let ev = evidence();
+        write_shadow(tmp.path(), &m, Some(&ev)).unwrap();
+
+        // A model that gained a source after the shadow was built must fail
+        // the count check.
+        let mut newer = m.clone();
+        let mut extra = newer.sources[0].clone();
+        extra.sha256 = "sha-b".into();
+        newer.sources.push(extra);
+        let err = verify_shadow(tmp.path(), &newer, Some(&ev)).unwrap_err();
+        assert!(err.contains("sources"), "unexpected error: {err}");
+
+        // A silently edited row must fail the sample check.
+        let mut edited = m.clone();
+        edited.sources[0].title = Some("tampered".into());
+        let err = verify_shadow(tmp.path(), &edited, Some(&ev)).unwrap_err();
+        assert!(err.contains("diverges"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn sample_indices_are_bounded_and_deterministic() {
+        assert!(sample_indices(0, 20).is_empty());
+        assert_eq!(sample_indices(3, 20), vec![0, 1, 2]);
+        let s = sample_indices(1000, 20);
+        assert_eq!(s.len(), 20);
+        assert!(s.windows(2).all(|w| w[0] < w[1]));
+        assert!(*s.last().unwrap() < 1000);
+    }
+}


### PR DESCRIPTION
## What

Stage 3a of `docs/design/storage-read-model.md`: `ovp2 index` / `ovp2 console` / daily (terminal write, mid-run refresh, AND post-tags-bootstrap rebuild) now shadow-project the read model into SQLite. The JSON files remain the serving projection — this is the dual-write soak that precedes any endpoint switch (stage 4).

- **rusqlite 0.37 (bundled), no ORM.** Normalized tables: meta / sources / source_tags / source_entities / packs / pack_card_titles / claims / claim_sources / runs / cards / units. Status strings identical to the JSON projection (serde snake_case) so parity is byte-for-byte.
- **Machine-local cache placement**: `~/Library/Caches/ovp/<vault-fingerprint>/read-model.sqlite` (LOCALAPPDATA / XDG on other platforms, `OVP_CACHE_DIR` override) — never inside the synced vault. Fingerprint = sha256(canonical root), no state file in the vault.
- **Verify-then-promote generation contract**: build fresh into a unique tmp → fsync the file → verify parity against the in-memory projections → only then atomically rename over last-good (+ dir fsync). Any failure leaves the previous generation intact. Fresh-file-per-build = no migration story (`ovp2 index` IS the migration), same contract as the JSON projection.
- **Parity gate on EVERY build**: all table counts (incl. child tables) must equal the in-memory model, plus 20 evenly-spaced samples per surface compared **every column + ordered child rows** (tags with kinds, entities, card titles, claim sources). Failure is a loud warning, not a lost daily run.

## The gate already earned its keep

On the live vault (1,471 sources / 19,341 cards / 40,231 units) the full-row sampler surfaced two real lookup-key ambiguities before any endpoint depends on this data: same-day reruns share `run_id` (runs now sample by `report_file`), and a `claim_id` can legitimately exist in both durable and caveated lanes (claim_sources compare the per-id aggregate). 120 sampled rows now verify clean; full build+verify = ~2.5 s, 70 MB db.

## Review gates

`codex review` round 1: 1×P1 (cache placement — the doc's own rule) + 4×P2 (verify-before-promote, full-row sampling, bootstrap staleness, candidate fsync) — **all five fixed**, each covered by tests. e2e asserts the shadow lands in the cache dir and NOT inside the vault.

## Not in this PR (per plan)

Serving from sqlite (stage 4), incremental cursors, FTS surfaces (stage 3c), vector columns (stage 5).

Workspace: 1,355 tests green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a machine-local SQLite read model mirroring generated index and evidence data.
  * Automatically refreshes and verifies the read model during indexing, console, and daily workflows.
  * Preserves the last verified version if an update fails.
  * Keeps derived database files outside the synchronized vault.

* **Bug Fixes**
  * Added parity checks to detect discrepancies between generated data and the SQLite read model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->