### PR TITLE
feat(server): stage 4 — portal serves from the sqlite read-model (operator direct-switch), JSON fallback + whole-model parity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,11 @@ homepage = "https://github.com/fakechris/obsidian_vault_pipeline"
 
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+# float_roundtrip: the sqlite read-model stores display state (ops/totals)
+# as JSON and the parity gate requires f64-exact reconstruction — serde_json's
+# default fast float parser can be 1 ULP off from ryu's shortest output
+# (found live: success_rate_pct 97.47634069400631 → …632).
+serde_json = { version = "1", features = ["float_roundtrip"] }
 toml = "0.8"
 clap = { version = "4", features = ["derive"] }
 sha2 = "0.10"

--- a/console-ui/src/components/IndexHealthBanner.tsx
+++ b/console-ui/src/components/IndexHealthBanner.tsx
@@ -1,0 +1,85 @@
+/** Stage-4 repair surface: a thin warning strip shown ONLY when the sqlite
+ * read-model failed to load (the model payload carries `sqlite_error`).
+ * Today the server has already fallen back to the JSON projection, so data
+ * stays correct — but once the fallback is retired this banner IS the
+ * degradation story, so it ships with the switch, not after it. The button
+ * triggers `POST /api/index/rebuild` (`ovp2 index` under the hood: full
+ * rebuild + whole-model parity + atomic promote) and polls the status until
+ * the run finishes; the banner clears itself when the next model poll loads
+ * sqlite cleanly. */
+import { useEffect, useState } from 'react';
+import { useI18n } from '../i18n';
+import { indexHealth } from '../lib/derive';
+import { fetchIndexRebuildStatus, startIndexRebuild } from '../lib/api';
+import { useModel } from '../model';
+
+const POLL_MS = 2_000;
+
+export default function IndexHealthBanner() {
+  const { t } = useI18n();
+  const { model } = useModel();
+  const [rebuilding, setRebuilding] = useState(false);
+  const [outcome, setOutcome] = useState<string | null>(null);
+
+  const serverRebuilding = model?.index_rebuild?.running ?? false;
+  const health = indexHealth(model?.sqlite_error, rebuilding || serverRebuilding);
+
+  useEffect(() => {
+    if (!rebuilding) return;
+    const id = window.setInterval(() => {
+      fetchIndexRebuildStatus()
+        .then((status) => {
+          if (status.running) return;
+          setRebuilding(false);
+          if (status.last && status.last.ok === false) {
+            setOutcome(
+              t('indexHealth.rebuildFailed', {
+                err: status.last.error ?? status.last.stderr_tail ?? `exit ${status.last.exit}`,
+              }),
+            );
+          } else {
+            setOutcome(t('indexHealth.rebuildDone'));
+          }
+        })
+        .catch(() => {
+          // Transient poll failure: keep polling; the interval survives.
+        });
+    }, POLL_MS);
+    return () => window.clearInterval(id);
+  }, [rebuilding, t]);
+
+  if (health === 'ok') {
+    // A finished rebuild's outcome stays visible until the error clears via
+    // the next model poll (success) or the operator retries (failure).
+    if (!outcome) return null;
+    return (
+      <div className="index-health ok" role="status">
+        <span>{outcome}</span>
+      </div>
+    );
+  }
+
+  const start = () => {
+    setOutcome(null);
+    setRebuilding(true);
+    startIndexRebuild().catch((e: unknown) => {
+      setRebuilding(false);
+      setOutcome(t('indexHealth.rebuildFailed', { err: e instanceof Error ? e.message : String(e) }));
+    });
+  };
+
+  return (
+    <div className="index-health warn" role="alert">
+      {health === 'rebuilding' ? (
+        <span>{t('indexHealth.rebuilding')}</span>
+      ) : (
+        <>
+          <span>{t('indexHealth.error')}</span>
+          <button type="button" onClick={start}>
+            {t('indexHealth.rebuild')}
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/console-ui/src/components/Shell.tsx
+++ b/console-ui/src/components/Shell.tsx
@@ -17,6 +17,7 @@ import { STATIC_MODE } from '../lib/api';
 import { isDesktopApp, openInSystemBrowser } from '../lib/desktopExternalLinks';
 import ErrorBoundary from './ErrorBoundary';
 import RunBanner from './RunBanner';
+import IndexHealthBanner from './IndexHealthBanner';
 import SearchOmnibox from './SearchOmnibox';
 
 // The published site is knowledge-only: Knowledge (home), Library, Search. The
@@ -191,6 +192,7 @@ export default function Shell() {
       {/* Run heartbeat + health dot are live-ops chrome — hidden on the
           published static site (no server, no run state). */}
       {!STATIC_MODE && <RunBanner />}
+      {!STATIC_MODE && <IndexHealthBanner />}
       <div className="page">
         <div className="shell">
           <div className="shell-head">

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -750,6 +750,13 @@ export const en = {
   'system.vaultRoot': 'vault',
   'system.schema': 'index schema',
   'system.indexDate': 'index date',
+  'indexHealth.error':
+    'Knowledge index store failed to load — serving the JSON fallback. Data stays correct; search relevance may degrade.',
+  'indexHealth.rebuild': 'Rebuild index',
+  'indexHealth.rebuilding': 'Rebuilding the index store…',
+  'indexHealth.rebuildFailed': 'Rebuild failed: {err}',
+  'indexHealth.rebuildDone': 'Rebuild finished — data refreshes on the next poll.',
+  'system.servingBackend': 'serving backend',
   'system.builtAt': 'built',
   'system.runId': 'run id',
   'system.counts': 'counts',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -713,6 +713,13 @@ export const zh: Record<keyof typeof en, string> = {
   'system.vaultRoot': 'vault 路径',
   'system.schema': '索引 schema',
   'system.indexDate': '索引日期',
+  'indexHealth.error':
+    '知识索引库读取失败——已自动降级到 JSON 后备通路。数据仍然正确,检索相关性可能下降。',
+  'indexHealth.rebuild': '重建索引库',
+  'indexHealth.rebuilding': '索引库重建中…',
+  'indexHealth.rebuildFailed': '重建失败:{err}',
+  'indexHealth.rebuildDone': '重建完成——数据将在下次轮询刷新。',
+  'system.servingBackend': '服务后端',
   'system.builtAt': '构建时刻',
   'system.runId': '运行 id',
   'system.counts': '统计',

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -220,6 +220,28 @@ export async function startRunNow(job: string): Promise<void> {
   }
 }
 
+/** Trigger the sqlite-repair projection rebuild (`ovp2 index` under the
+ * hood: JSON + shadow + whole-model parity). 409 = already running. */
+export async function startIndexRebuild(): Promise<void> {
+  const resp = await fetch('/api/index/rebuild', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: '{}',
+  });
+  if (!resp.ok && resp.status !== 202) {
+    const body = (await resp.json().catch(() => null)) as { error?: string } | null;
+    throw new Error(body?.error ?? `rebuild failed (${resp.status})`);
+  }
+}
+
+export interface IndexRebuildStatus {
+  running: boolean;
+  last?: { ok?: boolean; exit?: number | null; error?: string; stderr_tail?: string } | null;
+}
+export function fetchIndexRebuildStatus(): Promise<IndexRebuildStatus> {
+  return fetchJson<IndexRebuildStatus>('/api/index/rebuild/status');
+}
+
 /** LLM provider config (a GUI over .ovp/providers.toml; secrets masked). */
 export interface ProvidersPayload {
   env: Record<string, string>;

--- a/console-ui/src/lib/derive.indexHealth.test.ts
+++ b/console-ui/src/lib/derive.indexHealth.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { indexHealth } from './derive';
+
+/** Truth table for the stage-4 repair banner (pure, node env). */
+describe('indexHealth', () => {
+  it('is ok when sqlite loads cleanly', () => {
+    expect(indexHealth(null, false)).toBe('ok');
+    expect(indexHealth(undefined, false)).toBe('ok');
+  });
+
+  it('raises the banner only on a RECORDED sqlite failure', () => {
+    // serving_backend === 'json' alone is legitimate (fresh JSON right
+    // after a tag-curation rebuild) — the banner keys on the error.
+    expect(indexHealth('disk I/O error', false)).toBe('error');
+  });
+
+  it('an in-flight rebuild outranks the error (operator already acted)', () => {
+    expect(indexHealth('disk I/O error', true)).toBe('rebuilding');
+    expect(indexHealth(null, true)).toBe('rebuilding');
+  });
+});

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -1223,3 +1223,19 @@ export function closureNodeIds(
   }
   return out;
 }
+
+/** Index-store health for the stage-4 repair banner. Pure so the node-env
+ * tests can pin the truth table: a REBUILD in flight outranks the error
+ * (the operator already acted), and only a recorded sqlite failure — not a
+ * mere 'json' serving_backend, which is legitimate right after a JSON-only
+ * rebuild — raises the banner. */
+export type IndexHealth = 'ok' | 'error' | 'rebuilding';
+
+export function indexHealth(
+  sqliteError: string | null | undefined,
+  rebuildRunning: boolean,
+): IndexHealth {
+  if (rebuildRunning) return 'rebuilding';
+  if (sqliteError) return 'error';
+  return 'ok';
+}

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -409,6 +409,9 @@ export interface SettingsPayload {
    * the server-computed age. Null when no index is built yet. */
   built_at: string | null;
   run_id: string | null;
+  /** Stage-4 observation window: which store served the model —
+   * 'sqlite' or 'json' (the legacy fallback). */
+  serving_backend?: string;
   age_seconds: number | null;
   counts: SettingsCounts | null;
   /** LIVE queued backlog (01-Raw walk at serve time) — the authoritative-now
@@ -536,6 +539,18 @@ export interface IndexModel {
   /** Live-server overlay: the tool-loop agent serves /api/ask. The SPA
    * pre-generates a chat id and polls the progress feed from turn 1. */
   ask_agent?: boolean;
+  /** Live-server overlay (stage 4): which store the model was served from —
+   * 'sqlite' (the read-model shadow) or 'json' (the legacy fallback).
+   * Absent in static snapshots. */
+  serving_backend?: string;
+  /** Live-server overlay: the last sqlite load failure, null when healthy.
+   * Non-null drives the repair banner (rebuild button). */
+  sqlite_error?: string | null;
+  /** Live-server overlay: the portal-triggered projection rebuild state. */
+  index_rebuild?: {
+    running: boolean;
+    last?: { ok?: boolean; exit?: number | null; error?: string; stderr_tail?: string } | null;
+  };
   schema: string;
   date: string;
   /** Wall-clock build instant (UTC RFC3339). Absent on pre-P1 indexes — the

--- a/console-ui/src/pages/SystemPage.tsx
+++ b/console-ui/src/pages/SystemPage.tsx
@@ -606,6 +606,11 @@ function SettingsSection({ refreshKey = 0 }: { refreshKey?: number }) {
           <dd className="tiny">
             <AgeLabel builtAt={settings.built_at} />
           </dd>
+          {/* Stage-4 observation window: which store served this model —
+              expect a steady 'sqlite'; 'json' here without a recent tag
+              edit means the shadow is failing (see the repair banner). */}
+          <dt>{t('system.servingBackend')}</dt>
+          <dd className="mono tiny">{settings.serving_backend ?? '—'}</dd>
           <dt>{t('system.runId')}</dt>
           <dd className="mono tiny">
             {settings.run_id ?? t('system.noIndex')}

--- a/console-ui/src/styles/index.css
+++ b/console-ui/src/styles/index.css
@@ -19,3 +19,32 @@
   --color-source-deep: #22c55e;
   --color-highlight: #fbbf24;
 }
+
+/* Stage-4 index-store repair banner (IndexHealthBanner): thin strip under
+ * the run banner; visible ONLY when the sqlite read-model failed (amber) or
+ * a rebuild just finished (quiet confirmation). House rules: no shadows. */
+.index-health {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3, 12px);
+  padding: 6px 16px;
+  font-size: 13px;
+  border-bottom: 1px solid var(--border, rgba(0, 0, 0, 0.08));
+}
+.index-health.warn {
+  background: var(--warn-bg, #fdf3e3);
+  color: var(--warn-fg, #7a4d05);
+}
+.index-health.ok {
+  background: var(--surface-2, #f6f4ef);
+  color: var(--muted, #6b6459);
+}
+.index-health button {
+  font: inherit;
+  padding: 2px 10px;
+  border: 1px solid currentColor;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}

--- a/crates/ovp-index/src/sqlite.rs
+++ b/crates/ovp-index/src/sqlite.rs
@@ -1057,6 +1057,14 @@ pub fn read_evidence_sqlite(vault_root: &Path) -> Result<Option<EvidenceModel>, 
 fn read_evidence_sqlite_at(path: &Path) -> Result<Option<EvidenceModel>, String> {
     let conn = Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
         .map_err(|e| format!("opening {}: {e}", path.display()))?;
+    // Same guard as the index reader — both caches must fall back TOGETHER
+    // on an unsupported generation, never serve evidence from one schema
+    // and the model from another.
+    if meta_value(&conn, "schema_version")? != SCHEMA_VERSION {
+        return Err(format!(
+            "shadow schema is not v{SCHEMA_VERSION} — rebuild the projection (`ovp2 index`)"
+        ));
+    }
     if meta_value(&conn, "has_evidence")? != "1" {
         return Ok(None);
     }

--- a/crates/ovp-index/src/sqlite.rs
+++ b/crates/ovp-index/src/sqlite.rs
@@ -19,6 +19,7 @@
 //! Deliberately NOT here yet: incremental cursors (full rebuild is minutes at
 //! 100x scale, measured), FTS tables (stage 3c), vector columns (stage 5).
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use rusqlite::Connection;
@@ -29,7 +30,7 @@ use crate::evidence::EvidenceModel;
 use crate::model::IndexModel;
 
 const SQLITE_FILE: &str = "read-model.sqlite";
-const SCHEMA_VERSION: &str = "2";
+const SCHEMA_VERSION: &str = "3";
 /// The FTS analyzer version, stamped into `meta` — index-side and query-side
 /// tokenization MUST match, so any change to [`tokenize_for_fts`] bumps this
 /// and the next build re-tokenizes everything (fresh-file builds make that
@@ -187,8 +188,9 @@ CREATE TABLE claims(
   status TEXT NOT NULL, strength TEXT, run_id TEXT, run_date TEXT, lane TEXT);
 CREATE INDEX idx_claims_id ON claims(claim_id);
 CREATE INDEX idx_claims_status ON claims(status);
-CREATE TABLE claim_sources(claim_id TEXT NOT NULL, sha256 TEXT NOT NULL);
+CREATE TABLE claim_sources(claim_rowid INTEGER NOT NULL, claim_id TEXT NOT NULL, sha256 TEXT NOT NULL);
 CREATE INDEX idx_claim_sources ON claim_sources(claim_id);
+CREATE INDEX idx_claim_sources_rowid ON claim_sources(claim_rowid);
 CREATE INDEX idx_claim_sources_sha ON claim_sources(sha256);
 CREATE TABLE runs(
   run_id TEXT NOT NULL, date TEXT NOT NULL, report_file TEXT NOT NULL,
@@ -321,6 +323,34 @@ fn build_into(
             ("date", model.date.clone()),
             ("built_at", model.built_at.clone().unwrap_or_default()),
             ("run_id", model.run_id.clone().unwrap_or_default()),
+            // Display-state blobs (small, no query need) so the FULL
+            // IndexModel/EvidenceModel reconstruct from this file alone —
+            // stage 4 serves from here, JSON is only the fallback.
+            (
+                "totals_json",
+                serde_json::to_string(&model.totals).map_err(|e| format!("totals: {e}"))?,
+            ),
+            (
+                "ops_json",
+                serde_json::to_string(&model.ops).map_err(|e| format!("ops: {e}"))?,
+            ),
+            (
+                "has_evidence",
+                if evidence.is_some() { "1" } else { "0" }.to_string(),
+            ),
+            (
+                "evidence_schema",
+                evidence.map(|e| e.schema.clone()).unwrap_or_default(),
+            ),
+            (
+                "evidence_date",
+                evidence.map(|e| e.date.clone()).unwrap_or_default(),
+            ),
+            (
+                "evidence_warnings_json",
+                serde_json::to_string(&evidence.map(|e| e.warnings.clone()).unwrap_or_default())
+                    .map_err(|e| format!("warnings: {e}"))?,
+            ),
         ] {
             meta.execute((k, v)).map_err(|e| format!("meta {k}: {e}"))?;
         }
@@ -427,7 +457,7 @@ fn build_into(
             )
             .map_err(|e| format!("prepare claims: {e}"))?;
         let mut claim_src = tx
-            .prepare("INSERT INTO claim_sources(claim_id, sha256) VALUES(?1,?2)")
+            .prepare("INSERT INTO claim_sources(claim_rowid, claim_id, sha256) VALUES(?1,?2,?3)")
             .map_err(|e| format!("prepare claim_sources: {e}"))?;
         let mut claims_fts = tx
             .prepare("INSERT INTO claims_fts(rowid, text) VALUES(?1,?2)")
@@ -453,7 +483,7 @@ fn build_into(
                 .map_err(|e| format!("claims_fts {}: {e}", c.claim_id))?;
             for sha in &c.sources {
                 claim_src
-                    .execute((&c.claim_id, sha))
+                    .execute((rowid, &c.claim_id, sha))
                     .map_err(|e| format!("claim source {}: {e}", c.claim_id))?;
             }
         }
@@ -778,6 +808,322 @@ fn fts_search_on(
     run(&terms.join(" OR "))
 }
 
+/// Reconstruct the FULL `IndexModel` from the shadow database — the stage-4
+/// serving path. Row order is insertion order (`ORDER BY rowid`), which is
+/// the model order the projection was built from, so a round-trip is
+/// `PartialEq`-identical to the model that produced the file (and the
+/// parity gate asserts exactly that on every build).
+pub fn read_index_sqlite(vault_root: &Path) -> Result<IndexModel, String> {
+    read_index_sqlite_at(&sqlite_path(vault_root)?)
+}
+
+fn meta_value(conn: &Connection, key: &str) -> Result<String, String> {
+    conn.query_row("SELECT value FROM meta WHERE key = ?1", [key], |r| r.get(0))
+        .map_err(|e| format!("reading meta {key}: {e}"))
+}
+
+fn parse_enum<T: serde::de::DeserializeOwned>(s: &str, what: &str) -> Result<T, String> {
+    serde_json::from_value(Value::String(s.to_string()))
+        .map_err(|e| format!("parsing {what} `{s}`: {e}"))
+}
+
+fn read_index_sqlite_at(path: &Path) -> Result<IndexModel, String> {
+    let conn = Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| format!("opening {}: {e}", path.display()))?;
+    if meta_value(&conn, "schema_version")? != SCHEMA_VERSION {
+        return Err(format!(
+            "shadow schema is not v{SCHEMA_VERSION} — rebuild the projection (`ovp2 index`)"
+        ));
+    }
+
+    // Child rows first, grouped by their owner, insertion order preserved.
+    type TagKinds = (Vec<String>, Vec<String>, Vec<String>);
+    let mut tags_by_sha: HashMap<String, TagKinds> = HashMap::new();
+    conn.prepare("SELECT sha256, tag, kind FROM source_tags ORDER BY rowid")
+        .and_then(|mut st| {
+            st.query_map([], |r| {
+                Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?, r.get::<_, String>(2)?))
+            })?
+            .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|e| format!("reading source_tags: {e}"))?
+        .into_iter()
+        .for_each(|(sha, tag, kind)| {
+            let entry = tags_by_sha.entry(sha).or_default();
+            match kind.as_str() {
+                "inferred" => entry.1.push(tag),
+                "implied" => entry.2.push(tag),
+                _ => entry.0.push(tag),
+            }
+        });
+    let mut entities_by_sha: HashMap<String, Vec<String>> = HashMap::new();
+    conn.prepare("SELECT sha256, entity FROM source_entities ORDER BY rowid")
+        .and_then(|mut st| {
+            st.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))?
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|e| format!("reading source_entities: {e}"))?
+        .into_iter()
+        .for_each(|(sha, entity)| entities_by_sha.entry(sha).or_default().push(entity));
+
+    let sources = conn
+        .prepare(
+            "SELECT sha256, status, title, author, url, origin, rel_path, date, content_date,
+             captured_on, processed_on, last_run_id, pack_dir, fail_count, last_reason
+             FROM sources ORDER BY rowid",
+        )
+        .and_then(|mut st| {
+            st.query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, Option<String>>(2)?,
+                    r.get::<_, Option<String>>(3)?,
+                    r.get::<_, Option<String>>(4)?,
+                    r.get::<_, Option<String>>(5)?,
+                    r.get::<_, Option<String>>(6)?,
+                    r.get::<_, Option<String>>(7)?,
+                    r.get::<_, Option<String>>(8)?,
+                    r.get::<_, Option<String>>(9)?,
+                    r.get::<_, Option<String>>(10)?,
+                    r.get::<_, Option<String>>(11)?,
+                    r.get::<_, Option<String>>(12)?,
+                    r.get::<_, i64>(13)?,
+                    r.get::<_, Option<String>>(14)?,
+                ))
+            })?
+            .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|e| format!("reading sources: {e}"))?
+        .into_iter()
+        .map(|row| {
+            let (tags, tags_inferred, tags_implied) =
+                tags_by_sha.remove(&row.0).unwrap_or_default();
+            Ok(crate::model::SourceRow {
+                entities: entities_by_sha.remove(&row.0).unwrap_or_default(),
+                sha256: row.0,
+                status: parse_enum(&row.1, "source status")?,
+                title: row.2,
+                author: row.3,
+                url: row.4,
+                origin: row.5,
+                rel_path: row.6,
+                date: row.7,
+                content_date: row.8,
+                captured_on: row.9,
+                processed_on: row.10,
+                last_run_id: row.11,
+                pack_dir: row.12,
+                fail_count: row.13 as usize,
+                last_reason: row.14,
+                tags,
+                tags_inferred,
+                tags_implied,
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+
+    let mut titles_by_pack: HashMap<String, Vec<String>> = HashMap::new();
+    conn.prepare("SELECT pack_dir, title FROM pack_card_titles ORDER BY pack_dir, idx")
+        .and_then(|mut st| {
+            st.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))?
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|e| format!("reading pack_card_titles: {e}"))?
+        .into_iter()
+        .for_each(|(pack, title)| titles_by_pack.entry(pack).or_default().push(title));
+
+    let packs = conn
+        .prepare(
+            "SELECT pack_dir, title, date, units, cards, json_repaired, source_sha256
+             FROM packs ORDER BY rowid",
+        )
+        .and_then(|mut st| {
+            st.query_map([], |r| {
+                Ok(crate::model::PackRow {
+                    pack_dir: r.get(0)?,
+                    title: r.get(1)?,
+                    date: r.get(2)?,
+                    units: r.get::<_, i64>(3)? as usize,
+                    cards: r.get::<_, i64>(4)? as usize,
+                    json_repaired: r.get::<_, i64>(5)? != 0,
+                    card_titles: Vec::new(),
+                    source_sha256: r.get(6)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|e| format!("reading packs: {e}"))?
+        .into_iter()
+        .map(|mut pack| {
+            pack.card_titles = titles_by_pack.remove(&pack.pack_dir).unwrap_or_default();
+            pack
+        })
+        .collect::<Vec<_>>();
+
+    let mut sources_by_claim_rowid: HashMap<i64, Vec<String>> = HashMap::new();
+    conn.prepare("SELECT claim_rowid, sha256 FROM claim_sources ORDER BY rowid")
+        .and_then(|mut st| {
+            st.query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?)))?
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|e| format!("reading claim_sources: {e}"))?
+        .into_iter()
+        .for_each(|(rowid, sha)| sources_by_claim_rowid.entry(rowid).or_default().push(sha));
+
+    let claims = conn
+        .prepare(
+            "SELECT rowid, claim_id, claim_key, claim, theme, status, strength, run_id,
+             run_date, lane FROM claims ORDER BY rowid",
+        )
+        .and_then(|mut st| {
+            st.query_map([], |r| {
+                Ok((
+                    r.get::<_, i64>(0)?,
+                    crate::model::ClaimRow {
+                        claim_id: r.get(1)?,
+                        claim_key: r.get(2)?,
+                        claim: r.get(3)?,
+                        theme: r.get(4)?,
+                        status: crate::model::ClaimStatus::Caveated,
+                        sources: Vec::new(),
+                        strength: r.get(6)?,
+                        run_id: r.get(7)?,
+                        run_date: r.get(8)?,
+                        lane: r.get(9)?,
+                    },
+                    r.get::<_, String>(5)?,
+                ))
+            })?
+            .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|e| format!("reading claims: {e}"))?
+        .into_iter()
+        .map(|(rowid, mut claim, status)| {
+            claim.status = parse_enum(&status, "claim status")?;
+            claim.sources = sources_by_claim_rowid.remove(&rowid).unwrap_or_default();
+            Ok(claim)
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+
+    let runs = conn
+        .prepare(
+            "SELECT run_id, date, report_file, succeeded, failed, skipped, blocked, ingested,
+             pinboard_new, lifecycle_warnings FROM runs ORDER BY rowid",
+        )
+        .and_then(|mut st| {
+            st.query_map([], |r| {
+                Ok(crate::model::RunRow {
+                    run_id: r.get(0)?,
+                    date: r.get(1)?,
+                    report_file: r.get(2)?,
+                    succeeded: r.get::<_, i64>(3)? as usize,
+                    failed: r.get::<_, i64>(4)? as usize,
+                    skipped: r.get::<_, i64>(5)? as usize,
+                    blocked: r.get::<_, i64>(6)? as usize,
+                    ingested: r.get::<_, i64>(7)? as usize,
+                    pinboard_new: r.get::<_, i64>(8)? as usize,
+                    lifecycle_warnings: r.get::<_, i64>(9)? as usize,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|e| format!("reading runs: {e}"))?;
+
+    let built_at = meta_value(&conn, "built_at")?;
+    let run_id = meta_value(&conn, "run_id")?;
+    Ok(IndexModel {
+        schema: meta_value(&conn, "index_schema")?,
+        date: meta_value(&conn, "date")?,
+        built_at: (!built_at.is_empty()).then_some(built_at),
+        run_id: (!run_id.is_empty()).then_some(run_id),
+        totals: serde_json::from_str(&meta_value(&conn, "totals_json")?)
+            .map_err(|e| format!("parsing totals: {e}"))?,
+        sources,
+        packs,
+        claims,
+        runs,
+        ops: serde_json::from_str(&meta_value(&conn, "ops_json")?)
+            .map_err(|e| format!("parsing ops: {e}"))?,
+    })
+}
+
+/// Reconstruct the evidence sidecar — `Ok(None)` mirrors a build without an
+/// evidence model (the JSON path's "legitimately absent" case).
+pub fn read_evidence_sqlite(vault_root: &Path) -> Result<Option<EvidenceModel>, String> {
+    read_evidence_sqlite_at(&sqlite_path(vault_root)?)
+}
+
+fn read_evidence_sqlite_at(path: &Path) -> Result<Option<EvidenceModel>, String> {
+    let conn = Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| format!("opening {}: {e}", path.display()))?;
+    if meta_value(&conn, "has_evidence")? != "1" {
+        return Ok(None);
+    }
+    let cards = conn
+        .prepare(
+            "SELECT id, pack_dir, source_sha256, source_title, title, content, unit_type,
+             cited_unit_ids FROM cards ORDER BY rowid",
+        )
+        .and_then(|mut st| {
+            st.query_map([], |r| {
+                Ok((
+                    crate::evidence::CardEvidenceRow {
+                        id: r.get(0)?,
+                        pack_dir: r.get(1)?,
+                        source_sha256: r.get(2)?,
+                        source_title: r.get(3)?,
+                        title: r.get(4)?,
+                        content: r.get(5)?,
+                        unit_type: r.get(6)?,
+                        cited_unit_ids: Vec::new(),
+                    },
+                    r.get::<_, String>(7)?,
+                ))
+            })?
+            .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|e| format!("reading cards: {e}"))?
+        .into_iter()
+        .map(|(mut card, cited)| {
+            card.cited_unit_ids = serde_json::from_str(&cited)
+                .map_err(|e| format!("parsing cited_unit_ids for {}: {e}", card.id))?;
+            Ok(card)
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    let units = conn
+        .prepare(
+            "SELECT id, pack_dir, source_sha256, source_title, unit_id, text, quote, line,
+             attribution, modality FROM units ORDER BY rowid",
+        )
+        .and_then(|mut st| {
+            st.query_map([], |r| {
+                Ok(crate::evidence::UnitEvidenceRow {
+                    id: r.get(0)?,
+                    pack_dir: r.get(1)?,
+                    source_sha256: r.get(2)?,
+                    source_title: r.get(3)?,
+                    unit_id: r.get(4)?,
+                    text: r.get(5)?,
+                    quote: r.get(6)?,
+                    line: r.get::<_, Option<i64>>(7)?.map(|l| l as usize),
+                    attribution: r.get(8)?,
+                    modality: r.get(9)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|e| format!("reading units: {e}"))?;
+    Ok(Some(EvidenceModel {
+        schema: meta_value(&conn, "evidence_schema")?,
+        date: meta_value(&conn, "evidence_date")?,
+        cards,
+        units,
+        warnings: serde_json::from_str(&meta_value(&conn, "evidence_warnings_json")?)
+            .map_err(|e| format!("parsing warnings: {e}"))?,
+    }))
+}
+
 /// Parity report between a shadow database and the in-memory projections it
 /// was built from. Counts must ALL match and every sampled row — INCLUDING
 /// its child-table rows — must round-trip field-for-field; any mismatch is an
@@ -794,17 +1140,6 @@ pub struct ShadowParity {
     pub sampled: usize,
 }
 
-/// Evenly-spaced sample indices — deterministic, no clock/randomness (cheap
-/// to rerun in tests and on every build).
-fn sample_indices(len: usize, want: usize) -> Vec<usize> {
-    if len == 0 {
-        return Vec::new();
-    }
-    let want = want.min(len);
-    (0..want).map(|i| i * len / want).collect()
-}
-
-const SAMPLES_PER_SURFACE: usize = 20;
 
 /// Compare two full-row JSON encodings, naming the surface and key on drift.
 fn expect_row(surface: &str, key: &str, got: &Value, want: &Value) -> Result<(), String> {
@@ -922,265 +1257,116 @@ fn verify_at(
         ("date".to_string(), model.date.clone()),
         ("built_at".to_string(), model.built_at.clone().unwrap_or_default()),
         ("run_id".to_string(), model.run_id.clone().unwrap_or_default()),
+        (
+            "totals_json".to_string(),
+            serde_json::to_string(&model.totals).unwrap_or_default(),
+        ),
+        (
+            "ops_json".to_string(),
+            serde_json::to_string(&model.ops).unwrap_or_default(),
+        ),
+        (
+            "has_evidence".to_string(),
+            if evidence.is_some() { "1" } else { "0" }.to_string(),
+        ),
+        (
+            "evidence_schema".to_string(),
+            evidence.map(|e| e.schema.clone()).unwrap_or_default(),
+        ),
+        (
+            "evidence_date".to_string(),
+            evidence.map(|e| e.date.clone()).unwrap_or_default(),
+        ),
+        (
+            "evidence_warnings_json".to_string(),
+            serde_json::to_string(&evidence.map(|e| e.warnings.clone()).unwrap_or_default())
+                .unwrap_or_default(),
+        ),
     ];
     want_meta.sort();
     expect_row("meta", "scalars", &json!(got_meta), &json!(want_meta))?;
 
-    let mut sampled = 0usize;
-
-    // --- sources: every column + ordered (tag, kind) pairs + entities ---
-    for i in sample_indices(model.sources.len(), SAMPLES_PER_SURFACE) {
-        let s = &model.sources[i];
-        let got = conn
-            .query_row(
-                "SELECT status, title, author, url, origin, rel_path, date, content_date,
-                 captured_on, processed_on, last_run_id, pack_dir, fail_count, last_reason
-                 FROM sources WHERE sha256 = ?1",
-                [&s.sha256],
-                |r| {
-                    Ok(json!({
-                        "status": r.get::<_, String>(0)?,
-                        "title": r.get::<_, Option<String>>(1)?,
-                        "author": r.get::<_, Option<String>>(2)?,
-                        "url": r.get::<_, Option<String>>(3)?,
-                        "origin": r.get::<_, Option<String>>(4)?,
-                        "rel_path": r.get::<_, Option<String>>(5)?,
-                        "date": r.get::<_, Option<String>>(6)?,
-                        "content_date": r.get::<_, Option<String>>(7)?,
-                        "captured_on": r.get::<_, Option<String>>(8)?,
-                        "processed_on": r.get::<_, Option<String>>(9)?,
-                        "last_run_id": r.get::<_, Option<String>>(10)?,
-                        "pack_dir": r.get::<_, Option<String>>(11)?,
-                        "fail_count": r.get::<_, i64>(12)?,
-                        "last_reason": r.get::<_, Option<String>>(13)?,
-                    }))
-                },
-            )
-            .map_err(|e| format!("sampling source {}: {e}", s.sha256))?;
-        let want = json!({
-            "status": enum_str(&s.status),
-            "title": s.title, "author": s.author, "url": s.url, "origin": s.origin,
-            "rel_path": s.rel_path, "date": s.date, "content_date": s.content_date,
-            "captured_on": s.captured_on, "processed_on": s.processed_on,
-            "last_run_id": s.last_run_id, "pack_dir": s.pack_dir,
-            "fail_count": s.fail_count, "last_reason": s.last_reason,
-        });
-        expect_row("source", &s.sha256, &got, &want)?;
-
-        let got_tags: Vec<(String, String)> = conn
-            .prepare("SELECT tag, kind FROM source_tags WHERE sha256 = ?1 ORDER BY rowid")
-            .and_then(|mut st| {
-                st.query_map([&s.sha256], |r| Ok((r.get(0)?, r.get(1)?)))?
-                    .collect::<Result<Vec<_>, _>>()
-            })
-            .map_err(|e| format!("sampling tags {}: {e}", s.sha256))?;
-        let want_tags: Vec<(String, String)> = s
-            .tags
+    // FULL-model equality: reconstruct both projections from this database
+    // through the exact stage-4 serving readers and require PartialEq with
+    // the models that produced it — the gate proves the serving path, not a
+    // sample of it. Section-by-section comparison names the divergence.
+    // Name the FIRST divergent row (vec sections) or dump both sides
+    // (scalar sections) — "diverges in ops" alone is undebuggable.
+    fn first_diff<T: PartialEq + Serialize>(
+        name: &str,
+        rebuilt: &[T],
+        want: &[T],
+    ) -> Result<(), String> {
+        if rebuilt == want {
+            return Ok(());
+        }
+        let i = rebuilt
             .iter()
-            .map(|t| (t.clone(), "tag".to_string()))
-            .chain(s.tags_inferred.iter().map(|t| (t.clone(), "inferred".to_string())))
-            .chain(s.tags_implied.iter().map(|t| (t.clone(), "implied".to_string())))
-            .collect();
-        expect_row("source_tags", &s.sha256, &json!(got_tags), &json!(want_tags))?;
-
-        let got_entities: Vec<String> = conn
-            .prepare("SELECT entity FROM source_entities WHERE sha256 = ?1 ORDER BY rowid")
-            .and_then(|mut st| {
-                st.query_map([&s.sha256], |r| r.get(0))?
-                    .collect::<Result<Vec<_>, _>>()
-            })
-            .map_err(|e| format!("sampling entities {}: {e}", s.sha256))?;
-        expect_row("source_entities", &s.sha256, &json!(got_entities), &json!(s.entities))?;
-        sampled += 1;
+            .zip(want.iter())
+            .position(|(a, b)| a != b)
+            .unwrap_or(rebuilt.len().min(want.len()));
+        Err(format!(
+            "reconstructed index diverges in {name}[{i}]:\n  sqlite: {}\n  model:  {}",
+            rebuilt
+                .get(i)
+                .and_then(|v| serde_json::to_string(v).ok())
+                .unwrap_or_else(|| "<missing>".into()),
+            want.get(i)
+                .and_then(|v| serde_json::to_string(v).ok())
+                .unwrap_or_else(|| "<missing>".into()),
+        ))
     }
-
-    // --- packs: every column + ordered card titles ---
-    for i in sample_indices(model.packs.len(), SAMPLES_PER_SURFACE) {
-        let p = &model.packs[i];
-        let got = conn
-            .query_row(
-                "SELECT title, date, units, cards, json_repaired, source_sha256
-                 FROM packs WHERE pack_dir = ?1",
-                [&p.pack_dir],
-                |r| {
-                    Ok(json!({
-                        "title": r.get::<_, String>(0)?,
-                        "date": r.get::<_, Option<String>>(1)?,
-                        "units": r.get::<_, i64>(2)?,
-                        "cards": r.get::<_, i64>(3)?,
-                        "json_repaired": r.get::<_, i64>(4)? != 0,
-                        "source_sha256": r.get::<_, Option<String>>(5)?,
-                    }))
-                },
-            )
-            .map_err(|e| format!("sampling pack {}: {e}", p.pack_dir))?;
-        let want = json!({
-            "title": p.title, "date": p.date, "units": p.units, "cards": p.cards,
-            "json_repaired": p.json_repaired, "source_sha256": p.source_sha256,
-        });
-        expect_row("pack", &p.pack_dir, &got, &want)?;
-
-        let got_titles: Vec<String> = conn
-            .prepare("SELECT title FROM pack_card_titles WHERE pack_dir = ?1 ORDER BY idx")
-            .and_then(|mut st| {
-                st.query_map([&p.pack_dir], |r| r.get(0))?
-                    .collect::<Result<Vec<_>, _>>()
-            })
-            .map_err(|e| format!("sampling card titles {}: {e}", p.pack_dir))?;
-        expect_row("pack_card_titles", &p.pack_dir, &json!(got_titles), &json!(p.card_titles))?;
-        sampled += 1;
-    }
-
-    // --- runs: every column. Keyed by report_file, NOT run_id — same-day
-    // reruns share a run_id (`daily-<date>`), so run_id is ambiguous on real
-    // vaults; the report file is one-per-run.
-    for i in sample_indices(model.runs.len(), SAMPLES_PER_SURFACE) {
-        let r0 = &model.runs[i];
-        let got = conn
-            .query_row(
-                "SELECT run_id, date, succeeded, failed, skipped, blocked, ingested,
-                 pinboard_new, lifecycle_warnings FROM runs WHERE report_file = ?1",
-                [&r0.report_file],
-                |r| {
-                    Ok(json!({
-                        "run_id": r.get::<_, String>(0)?,
-                        "date": r.get::<_, String>(1)?,
-                        "succeeded": r.get::<_, i64>(2)?,
-                        "failed": r.get::<_, i64>(3)?,
-                        "skipped": r.get::<_, i64>(4)?,
-                        "blocked": r.get::<_, i64>(5)?,
-                        "ingested": r.get::<_, i64>(6)?,
-                        "pinboard_new": r.get::<_, i64>(7)?,
-                        "lifecycle_warnings": r.get::<_, i64>(8)?,
-                    }))
-                },
-            )
-            .map_err(|e| format!("sampling run {}: {e}", r0.report_file))?;
-        let want = json!({
-            "run_id": r0.run_id, "date": r0.date, "succeeded": r0.succeeded,
-            "failed": r0.failed, "skipped": r0.skipped, "blocked": r0.blocked,
-            "ingested": r0.ingested, "pinboard_new": r0.pinboard_new,
-            "lifecycle_warnings": r0.lifecycle_warnings,
-        });
-        expect_row("run", &r0.report_file, &got, &want)?;
-        sampled += 1;
-    }
-
-    // --- claims: every column + ordered source list ---
-    for i in sample_indices(model.claims.len(), SAMPLES_PER_SURFACE) {
-        let c = &model.claims[i];
-        let n: i64 = conn
-            .query_row(
-                "SELECT COUNT(*) FROM claims WHERE claim_id = ?1 AND claim = ?2
-                 AND status = ?3 AND coalesce(claim_key,'') = coalesce(?4,'')
-                 AND coalesce(theme,'') = coalesce(?5,'')
-                 AND coalesce(strength,'') = coalesce(?6,'')
-                 AND coalesce(run_id,'') = coalesce(?7,'')
-                 AND coalesce(run_date,'') = coalesce(?8,'')
-                 AND coalesce(lane,'') = coalesce(?9,'')",
-                (
-                    &c.claim_id,
-                    &c.claim,
-                    enum_str(&c.status),
-                    &c.claim_key,
-                    &c.theme,
-                    &c.strength,
-                    &c.run_id,
-                    &c.run_date,
-                    &c.lane,
-                ),
-                |r| r.get(0),
-            )
-            .map_err(|e| format!("sampling claim {}: {e}", c.claim_id))?;
-        if n == 0 {
-            return Err(format!("claim {} missing or diverges", c.claim_id));
+    let rebuilt = read_index_sqlite_at(path)?;
+    if rebuilt != *model {
+        first_diff("sources", &rebuilt.sources, &model.sources)?;
+        first_diff("packs", &rebuilt.packs, &model.packs)?;
+        first_diff("claims", &rebuilt.claims, &model.claims)?;
+        first_diff("runs", &rebuilt.runs, &model.runs)?;
+        for (name, differs, got, want) in [
+            (
+                "totals",
+                rebuilt.totals != model.totals,
+                serde_json::to_string(&rebuilt.totals).unwrap_or_default(),
+                serde_json::to_string(&model.totals).unwrap_or_default(),
+            ),
+            (
+                "ops",
+                rebuilt.ops != model.ops,
+                serde_json::to_string(&rebuilt.ops).unwrap_or_default(),
+                serde_json::to_string(&model.ops).unwrap_or_default(),
+            ),
+        ] {
+            if differs {
+                return Err(format!(
+                    "reconstructed index diverges in {name}:\n  sqlite: {got}\n  model:  {want}"
+                ));
+            }
         }
-        let got_sources: Vec<String> = conn
-            .prepare("SELECT sha256 FROM claim_sources WHERE claim_id = ?1 ORDER BY rowid")
-            .and_then(|mut st| {
-                st.query_map([&c.claim_id], |r| r.get(0))?
-                    .collect::<Result<Vec<_>, _>>()
-            })
-            .map_err(|e| format!("sampling claim sources {}: {e}", c.claim_id))?;
-        // claim_id is NOT unique on real vaults (a claim can appear in both
-        // the durable and caveated lanes) — compare the AGGREGATE source list
-        // across every model row sharing this id, in model order (insertion
-        // order preserves it).
-        let want_sources: Vec<&String> = model
-            .claims
-            .iter()
-            .filter(|other| other.claim_id == c.claim_id)
-            .flat_map(|other| other.sources.iter())
-            .collect();
-        expect_row("claim_sources", &c.claim_id, &json!(got_sources), &json!(want_sources))?;
-        sampled += 1;
+        return Err("reconstructed index diverges in header fields".into());
+    }
+    let rebuilt_evidence = read_evidence_sqlite_at(path)?;
+    match (rebuilt_evidence.as_ref(), evidence) {
+        (Some(a), Some(b)) if a == b => {}
+        (None, None) => {}
+        (Some(a), Some(b)) => {
+            for (name, differs) in [
+                ("cards", a.cards != b.cards),
+                ("units", a.units != b.units),
+                ("warnings", a.warnings != b.warnings),
+            ] {
+                if differs {
+                    return Err(format!("reconstructed evidence diverges in {name}"));
+                }
+            }
+            return Err("reconstructed evidence diverges in header fields".into());
+        }
+        _ => return Err("reconstructed evidence presence diverges".into()),
     }
 
-    if let Some(ev) = evidence {
-        // --- cards: every column ---
-        for i in sample_indices(ev.cards.len(), SAMPLES_PER_SURFACE) {
-            let c = &ev.cards[i];
-            let got = conn
-                .query_row(
-                    "SELECT pack_dir, source_sha256, source_title, title, content, unit_type,
-                     cited_unit_ids FROM cards WHERE id = ?1",
-                    [&c.id],
-                    |r| {
-                        Ok(json!({
-                            "pack_dir": r.get::<_, String>(0)?,
-                            "source_sha256": r.get::<_, Option<String>>(1)?,
-                            "source_title": r.get::<_, String>(2)?,
-                            "title": r.get::<_, String>(3)?,
-                            "content": r.get::<_, String>(4)?,
-                            "unit_type": r.get::<_, Option<String>>(5)?,
-                            "cited_unit_ids": r.get::<_, String>(6)?,
-                        }))
-                    },
-                )
-                .map_err(|e| format!("sampling card {}: {e}", c.id))?;
-            let want = json!({
-                "pack_dir": c.pack_dir, "source_sha256": c.source_sha256,
-                "source_title": c.source_title, "title": c.title, "content": c.content,
-                "unit_type": c.unit_type,
-                "cited_unit_ids": serde_json::to_string(&c.cited_unit_ids).unwrap_or_else(|_| "[]".into()),
-            });
-            expect_row("card", &c.id, &got, &want)?;
-            sampled += 1;
-        }
-        // --- units: every column ---
-        for i in sample_indices(ev.units.len(), SAMPLES_PER_SURFACE) {
-            let u = &ev.units[i];
-            let got = conn
-                .query_row(
-                    "SELECT pack_dir, source_sha256, source_title, unit_id, text, quote, line,
-                     attribution, modality FROM units WHERE id = ?1",
-                    [&u.id],
-                    |r| {
-                        Ok(json!({
-                            "pack_dir": r.get::<_, String>(0)?,
-                            "source_sha256": r.get::<_, Option<String>>(1)?,
-                            "source_title": r.get::<_, String>(2)?,
-                            "unit_id": r.get::<_, String>(3)?,
-                            "text": r.get::<_, String>(4)?,
-                            "quote": r.get::<_, String>(5)?,
-                            "line": r.get::<_, Option<i64>>(6)?,
-                            "attribution": r.get::<_, String>(7)?,
-                            "modality": r.get::<_, String>(8)?,
-                        }))
-                    },
-                )
-                .map_err(|e| format!("sampling unit {}: {e}", u.id))?;
-            let want = json!({
-                "pack_dir": u.pack_dir, "source_sha256": u.source_sha256,
-                "source_title": u.source_title, "unit_id": u.unit_id, "text": u.text,
-                "quote": u.quote, "line": u.line, "attribution": u.attribution,
-                "modality": u.modality,
-            });
-            expect_row("unit", &u.id, &got, &want)?;
-            sampled += 1;
-        }
-    }
-
+    // `sampled` now reports FULLY-compared rows (the equality pass covers
+    // every row, not a sample).
+    let sampled =
+        parity.sources + parity.packs + parity.claims + parity.runs + parity.cards + parity.units;
     Ok(ShadowParity { sampled, ..parity })
 }
 
@@ -1474,12 +1660,21 @@ mod tests {
     }
 
     #[test]
-    fn sample_indices_are_bounded_and_deterministic() {
-        assert!(sample_indices(0, 20).is_empty());
-        assert_eq!(sample_indices(3, 20), vec![0, 1, 2]);
-        let s = sample_indices(1000, 20);
-        assert_eq!(s.len(), 20);
-        assert!(s.windows(2).all(|w| w[0] < w[1]));
-        assert!(*s.last().unwrap() < 1000);
+    fn readers_reconstruct_models_identically() {
+        let tmp = test_dir();
+        let m = model();
+        let ev = evidence();
+        let db = tmp.path().join("candidate.sqlite");
+        build_into(&db, &m, Some(&ev)).unwrap();
+        // The stage-4 serving readers must round-trip PartialEq-identically.
+        assert_eq!(read_index_sqlite_at(&db).unwrap(), m);
+        assert_eq!(read_evidence_sqlite_at(&db).unwrap(), Some(ev));
+
+        // An evidence-less build reconstructs as legitimately-absent.
+        let db2 = tmp.path().join("no-evidence.sqlite");
+        build_into(&db2, &m, None).unwrap();
+        assert_eq!(read_evidence_sqlite_at(&db2).unwrap(), None);
+        assert_eq!(read_index_sqlite_at(&db2).unwrap(), m);
     }
+
 }

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -296,6 +296,11 @@ struct AppState {
     evidence: RwLock<Cached<EvidenceModel>>,
     /// Folded crystal-ledger projections — see [`CrystalCache`].
     crystal: RwLock<CrystalCache>,
+    /// Which store the LAST model load actually served — surfaced on
+    /// /api/model as `serving_backend` so the stage-4 observation window
+    /// has a visible signal (desktop swallows stderr, so the fallback
+    /// warning alone is invisible in the GUI).
+    serving_backend: RwLock<&'static str>,
     /// Bilingual sidecars for `/api/source/:sha` — `cards_zh.json` alone is
     /// over 10 MB on the live vault and was parsed from disk on EVERY source
     /// request; same mtime-keyed reload as the model.
@@ -540,24 +545,45 @@ impl AppState {
         db.max(json)
     }
 
+    /// True when the sqlite shadow is at least as new as the JSON files —
+    /// a JSON-only rebuild (portal tag curation calls `rebuild_index_now`,
+    /// which does not re-shadow) must serve the NEWER JSON, never a valid
+    /// but older shadow generation.
+    fn sqlite_is_newest(&self) -> bool {
+        let db = ovp_index::sqlite::sqlite_path(&self.vault_root)
+            .ok()
+            .and_then(|p| mtime_of(&p));
+        let json = mtime_of(&self.index_path()).max(mtime_of(&self.evidence_path()));
+        match (db, json) {
+            (Some(db), Some(json)) => db >= json,
+            (Some(_), None) => true,
+            _ => false,
+        }
+    }
+
     /// Stage-4 loader: the sqlite read-model is the serving store (operator
-    /// decision 2026-08-06 — direct switch); the JSON projection remains the
+    /// decision 2026-08-06 — direct switch) WHEN it is the newest
+    /// generation; the JSON projection serves otherwise and remains the
     /// fallback until the observation window closes. `OVP_INDEX_BACKEND=json`
     /// forces the old path.
     fn load_model_projection(&self) -> Option<IndexModel> {
-        if index_backend_is_sqlite() {
+        if index_backend_is_sqlite() && self.sqlite_is_newest() {
             match ovp_index::sqlite::read_index_sqlite(&self.vault_root) {
-                Ok(model) => return Some(model),
+                Ok(model) => {
+                    *self.serving_backend.write().unwrap() = "sqlite";
+                    return Some(model);
+                }
                 Err(e) => eprintln!(
                     "warning: sqlite read-model unavailable ({e}); serving the JSON fallback"
                 ),
             }
         }
+        *self.serving_backend.write().unwrap() = "json";
         read_index(&self.vault_root).ok()
     }
 
     fn load_evidence_projection(&self) -> Option<EvidenceModel> {
-        if index_backend_is_sqlite() {
+        if index_backend_is_sqlite() && self.sqlite_is_newest() {
             match ovp_index::sqlite::read_evidence_sqlite(&self.vault_root) {
                 // Ok(None) = the shadow generation was built without an
                 // evidence model — mirror the JSON absent case, no fallback.
@@ -783,6 +809,7 @@ pub fn run_server(config: ServeConfig) -> Result<(), String> {
         model: RwLock::new(Cached::default()),
         evidence: RwLock::new(Cached::default()),
         crystal: RwLock::new(CrystalCache::default()),
+        serving_backend: RwLock::new("unloaded"),
         cards_zh: RwLock::new(Cached::default()),
         claims_zh: RwLock::new(Cached::default()),
         last_run: RwLock::new(Cached::default()),
@@ -2486,6 +2513,14 @@ fn handle_model(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
         // Agent-mode discovery: the SPA pre-generates a session id and polls
         // /api/ask/progress from turn 1 only when the agent path is live.
         obj.insert("ask_agent".into(), serde_json::json!(state.ask_agent));
+        // Stage-4 observability: which store the model actually came from
+        // (sqlite | json | unloaded). The desktop swallows stderr, so the
+        // fallback warning alone is invisible — this field is the visible
+        // signal the JSON-retirement observation window reads.
+        obj.insert(
+            "serving_backend".into(),
+            serde_json::json!(*state.serving_backend.read().unwrap()),
+        );
         // Attention acknowledgements overlay: (sha,status) pairs the operator
         // dismissed. All attention surfaces (Today, System, the nav dot)
         // derive from this one model payload, so filtering stays consistent.
@@ -5042,6 +5077,7 @@ mod tests {
             model: RwLock::new(Cached::default()),
             evidence: RwLock::new(Cached::default()),
             crystal: RwLock::new(CrystalCache::default()),
+            serving_backend: RwLock::new("unloaded"),
             cards_zh: RwLock::new(Cached::default()),
             claims_zh: RwLock::new(Cached::default()),
             last_run: RwLock::new(Cached::default()),
@@ -7533,6 +7569,22 @@ mod tests {
             st.current_evidence().expect("evidence from sqlite").date,
             "2026-03-03"
         );
+        assert_eq!(*st.serving_backend.read().unwrap(), "sqlite");
+
+        // A JSON-only rebuild (the tag-curation path re-writes index.json
+        // without re-shadowing) must flip serving to the NEWER JSON — a
+        // valid but OLDER shadow generation must not shadow it.
+        ovp_index::write_index(&vault, &index_dated("2026-04-04")).unwrap();
+        set_mtime(
+            &vault.join(".ovp/index/index.json"),
+            SystemTime::now() + Duration::from_secs(5),
+        );
+        assert_eq!(
+            st.current_model().expect("model from json").date,
+            "2026-04-04",
+            "newer JSON must win over an older valid shadow"
+        );
+        assert_eq!(*st.serving_backend.read().unwrap(), "json");
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -516,35 +516,67 @@ impl AppState {
     /// `daily` process rebuilding the index is picked up on the next request
     /// — the portal is never stuck on the startup snapshot.
     fn current_model(&self) -> Option<Arc<IndexModel>> {
-        let path = self.index_path();
-        freshen(&self.model, &path, || read_index(&self.vault_root).ok())
+        let stamp = self.projection_stamp();
+        freshen_with(&self.model, &stamp, || self.load_model_projection())
     }
 
-    /// The cached evidence sidecar, same mtime-keyed auto-reload as the model
-    /// (keyed on `evidence.json`). Legitimately absent on pre-M31 vaults; a
-    /// missing file caches `None` without re-reading every request, yet
-    /// reloads the instant one appears.
+    /// The cached evidence sidecar, same stamp-keyed auto-reload as the
+    /// model. Legitimately absent on pre-M31 vaults; a missing file caches
+    /// `None` without re-reading every request, yet reloads the instant one
+    /// appears.
     fn current_evidence(&self) -> Option<Arc<EvidenceModel>> {
-        let path = self.evidence_path();
-        freshen(&self.evidence, &path, || {
-            read_evidence(&self.vault_root).ok()
-        })
+        let stamp = self.projection_stamp();
+        freshen_with(&self.evidence, &stamp, || self.load_evidence_projection())
+    }
+
+    /// Freshness stamp for the serving projections: the NEWEST of the sqlite
+    /// shadow and the JSON files — whichever store a rebuild touched last
+    /// invalidates the cache, in both backends and through fallback flips.
+    fn projection_stamp(&self) -> Option<SystemTime> {
+        let db = ovp_index::sqlite::sqlite_path(&self.vault_root)
+            .ok()
+            .and_then(|p| mtime_of(&p));
+        let json = mtime_of(&self.index_path()).max(mtime_of(&self.evidence_path()));
+        db.max(json)
+    }
+
+    /// Stage-4 loader: the sqlite read-model is the serving store (operator
+    /// decision 2026-08-06 — direct switch); the JSON projection remains the
+    /// fallback until the observation window closes. `OVP_INDEX_BACKEND=json`
+    /// forces the old path.
+    fn load_model_projection(&self) -> Option<IndexModel> {
+        if index_backend_is_sqlite() {
+            match ovp_index::sqlite::read_index_sqlite(&self.vault_root) {
+                Ok(model) => return Some(model),
+                Err(e) => eprintln!(
+                    "warning: sqlite read-model unavailable ({e}); serving the JSON fallback"
+                ),
+            }
+        }
+        read_index(&self.vault_root).ok()
+    }
+
+    fn load_evidence_projection(&self) -> Option<EvidenceModel> {
+        if index_backend_is_sqlite() {
+            match ovp_index::sqlite::read_evidence_sqlite(&self.vault_root) {
+                // Ok(None) = the shadow generation was built without an
+                // evidence model — mirror the JSON absent case, no fallback.
+                Ok(evidence) => return evidence,
+                Err(e) => eprintln!(
+                    "warning: sqlite evidence unavailable ({e}); serving the JSON fallback"
+                ),
+            }
+        }
+        read_evidence(&self.vault_root).ok()
     }
 
     /// Force-reload both caches from disk regardless of mtime. `/api/refresh`
     /// keeps this for scripts; with mtime auto-reload it is now optional
     /// (every accessor already freshens on its own).
     fn refresh_model(&self) {
-        force_reload(
-            &self.model,
-            &self.index_path(),
-            read_index(&self.vault_root).ok(),
-        );
-        force_reload(
-            &self.evidence,
-            &self.evidence_path(),
-            read_evidence(&self.vault_root).ok(),
-        );
+        let stamp = self.projection_stamp();
+        force_reload_with(&self.model, stamp, self.load_model_projection());
+        force_reload_with(&self.evidence, stamp, self.load_evidence_projection());
         force_reload(
             &self.last_run,
             &self.last_run_path(),
@@ -643,34 +675,51 @@ fn freshen<T>(
     path: &Path,
     load: impl FnOnce() -> Option<T>,
 ) -> Option<Arc<T>> {
-    let disk = mtime_of(path);
+    let stamp = mtime_of(path);
+    freshen_with(cache, &stamp, load)
+}
+
+/// [`freshen`] against a PRE-COMPUTED stamp — for caches whose freshness
+/// spans more than one file (the serving projections watch both the sqlite
+/// shadow and the JSON fallback).
+fn freshen_with<T>(
+    cache: &RwLock<Cached<T>>,
+    stamp: &Option<SystemTime>,
+    load: impl FnOnce() -> Option<T>,
+) -> Option<Arc<T>> {
     {
         let guard = cache.read().unwrap();
-        if guard.loaded && guard.stamp == disk {
+        if guard.loaded && guard.stamp == *stamp {
             return guard.data.clone();
         }
     }
     let mut guard = cache.write().unwrap();
     // Re-check under the write lock: another thread may have just reloaded.
-    // Re-stat too — the file could have changed again between the read
-    // guard's stat and acquiring the write lock.
-    let disk = mtime_of(path);
-    if guard.loaded && guard.stamp == disk {
+    if guard.loaded && guard.stamp == *stamp {
         return guard.data.clone();
     }
     let data = load().map(Arc::new);
     *guard = Cached {
         loaded: true,
-        stamp: disk,
+        stamp: *stamp,
         data: data.clone(),
     };
     data
 }
 
+/// `OVP_INDEX_BACKEND`: `sqlite` (the default — operator decision
+/// 2026-08-06, direct switch) or `json` to force the legacy path.
+fn index_backend_is_sqlite() -> bool {
+    !std::env::var("OVP_INDEX_BACKEND").is_ok_and(|v| v == "json")
+}
+
 /// Force-store a freshly-read value with the file's current mtime, bypassing
 /// the freshness check. Used by `/api/refresh`.
 fn force_reload<T>(cache: &RwLock<Cached<T>>, path: &Path, data: Option<T>) {
-    let stamp = mtime_of(path);
+    force_reload_with(cache, mtime_of(path), data);
+}
+
+fn force_reload_with<T>(cache: &RwLock<Cached<T>>, stamp: Option<SystemTime>, data: Option<T>) {
     *cache.write().unwrap() = Cached {
         loaded: true,
         stamp,
@@ -7450,6 +7499,43 @@ mod tests {
     }
 
     // ---- mtime-based cache auto-reload (fix/serve-mtime-reload) ----
+
+    #[test]
+    fn serves_from_sqlite_shadow_even_without_json() {
+        // Stage 4: the sqlite shadow is the serving store. Keep the test
+        // cache out of the developer's real platform cache (OnceLock,
+        // first-call-wins; other tests resolve misses to the JSON fallback
+        // either way).
+        ovp_index::sqlite::override_cache_base(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../.run/stage4-tests-server"),
+        );
+        let root = temp_root("sqlite-serving");
+        let vault = root.join("vault");
+        std::fs::create_dir_all(&vault).unwrap();
+
+        let model = index_dated("2026-03-03");
+        let evidence = evidence_dated("2026-03-03");
+        ovp_index::write_index(&vault, &model).unwrap();
+        ovp_index::write_evidence(&vault, &evidence).unwrap();
+        // Round-trip through the JSON readers so the shadow is built from
+        // the EXACT on-disk generation (write normalizes formatting).
+        let model = read_index(&vault).unwrap();
+        let evidence = ovp_index::read_evidence(&vault).unwrap();
+        ovp_index::sqlite::write_shadow(&vault, &model, Some(&evidence)).unwrap();
+
+        // Remove the JSON projections: only the shadow can serve now.
+        std::fs::remove_file(vault.join(".ovp/index/index.json")).unwrap();
+        std::fs::remove_file(vault.join(".ovp/index/evidence.json")).unwrap();
+
+        let st = state(vault.clone(), None);
+        assert_eq!(st.current_model().expect("model from sqlite").date, "2026-03-03");
+        assert_eq!(
+            st.current_evidence().expect("evidence from sqlite").date,
+            "2026-03-03"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
 
     /// A minimal index whose `date` field labels the version, so tests can
     /// assert WHICH on-disk model an accessor returned.

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -301,6 +301,14 @@ struct AppState {
     /// has a visible signal (desktop swallows stderr, so the fallback
     /// warning alone is invisible in the GUI).
     serving_backend: RwLock<&'static str>,
+    /// The last sqlite load FAILURE (None after a healthy load) — the
+    /// portal's repair banner reads this; once the JSON fallback is retired
+    /// this is the difference between "silently degraded" and "the operator
+    /// was told and offered the rebuild button".
+    sqlite_error: RwLock<Option<String>>,
+    /// The one in-flight portal-triggered projection rebuild (repair flow):
+    /// double-click protection + last-outcome surface, mirroring ManualRun.
+    index_rebuild: Arc<std::sync::Mutex<IndexRebuild>>,
     /// Bilingual sidecars for `/api/source/:sha` — `cards_zh.json` alone is
     /// over 10 MB on the live vault and was parsed from disk on EVERY source
     /// request; same mtime-keyed reload as the model.
@@ -363,6 +371,15 @@ struct AppState {
     _source_work_worker_lock: Option<ovp_intake::RunLock>,
     /// True when this process runs the background source-work worker.
     source_work_worker_here: bool,
+}
+
+/// State of the portal-triggered projection rebuild (the sqlite repair
+/// flow: `ovp2 index` rebuilds JSON + shadow from the ledgers and packs).
+#[derive(Default)]
+struct IndexRebuild {
+    running: bool,
+    /// Last finished rebuild: `{ok, exit, finished, stderr_tail}`.
+    last: Option<serde_json::Value>,
 }
 
 /// State of the portal-triggered manual pipeline run.
@@ -571,11 +588,15 @@ impl AppState {
             match ovp_index::sqlite::read_index_sqlite(&self.vault_root) {
                 Ok(model) => {
                     *self.serving_backend.write().unwrap() = "sqlite";
+                    *self.sqlite_error.write().unwrap() = None;
                     return Some(model);
                 }
-                Err(e) => eprintln!(
-                    "warning: sqlite read-model unavailable ({e}); serving the JSON fallback"
-                ),
+                Err(e) => {
+                    eprintln!(
+                        "warning: sqlite read-model unavailable ({e}); serving the JSON fallback"
+                    );
+                    *self.sqlite_error.write().unwrap() = Some(e);
+                }
             }
         }
         *self.serving_backend.write().unwrap() = "json";
@@ -810,6 +831,8 @@ pub fn run_server(config: ServeConfig) -> Result<(), String> {
         evidence: RwLock::new(Cached::default()),
         crystal: RwLock::new(CrystalCache::default()),
         serving_backend: RwLock::new("unloaded"),
+        sqlite_error: RwLock::new(None),
+        index_rebuild: Arc::new(std::sync::Mutex::new(IndexRebuild::default())),
         cards_zh: RwLock::new(Cached::default()),
         claims_zh: RwLock::new(Cached::default()),
         last_run: RwLock::new(Cached::default()),
@@ -915,6 +938,7 @@ fn serve_loop(server: &Server, state: &Arc<AppState>) {
             if p == "/api/tags/decision"
                 || p == "/api/publish"
                 || p == "/api/schedule/run"
+                || p == "/api/index/rebuild"
                 || p == "/api/schedule/features"
                 || p == "/api/attention/ack"
                 || p == "/api/providers"
@@ -1046,6 +1070,8 @@ fn dispatch(
         (Method::Get, "/api/publish/status") => handle_publish_status(state),
         (Method::Post, "/api/publish") => handle_publish_start(state),
         (Method::Get, "/api/schedule/run/status") => handle_run_status(state),
+        (Method::Get, "/api/index/rebuild/status") => handle_index_rebuild_status(state),
+        (Method::Post, "/api/index/rebuild") => handle_index_rebuild_start(state),
         (Method::Get, "/api/schedule") => handle_schedule(state),
         (Method::Post, "/api/schedule/features") => handle_schedule_features(state, body),
         (Method::Get, p) if p.starts_with("/api/ask/progress") => {
@@ -1740,6 +1766,71 @@ fn handle_publish_status(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>>
 
 /// Jobs the portal may trigger — the registry's built-ins.
 const MANUAL_RUN_JOBS: &[&str] = &["daily", "crystallize"];
+
+fn handle_index_rebuild_status(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
+    let rebuild = state.index_rebuild.lock().unwrap_or_else(|e| e.into_inner());
+    let body = serde_json::json!({"running": rebuild.running, "last": rebuild.last});
+    json_response(200, &body.to_string())
+}
+
+/// The sqlite REPAIR flow: rebuild every projection (JSON + shadow, with the
+/// whole-model parity gate) by running `ovp2 index` as a child — the same
+/// battle-tested path daily uses, never a second in-process implementation.
+/// The shadow's verify-then-promote contract means a failed rebuild leaves
+/// last-good untouched; success is picked up by the mtime stamps on the next
+/// request, no cache poke needed.
+fn handle_index_rebuild_start(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
+    {
+        let mut slot = state.index_rebuild.lock().unwrap_or_else(|e| e.into_inner());
+        if slot.running {
+            return json_response(
+                409,
+                r#"{"error":"an index rebuild is already in progress","code":"rebuild_running"}"#,
+            );
+        }
+        slot.running = true;
+    }
+    let bin = state
+        .ovp2_bin
+        .clone()
+        .or_else(|| std::env::current_exe().ok());
+    let Some(bin) = bin else {
+        let mut slot = state.index_rebuild.lock().unwrap_or_else(|e| e.into_inner());
+        slot.running = false;
+        return json_response(500, r#"{"error":"cannot resolve the ovp2 binary"}"#);
+    };
+    let vault_root = state.vault_root.clone();
+    let slot = Arc::clone(&state.index_rebuild);
+    std::thread::spawn(move || {
+        let out = std::process::Command::new(&bin)
+            .args(["index", "--vault-root", &vault_root.display().to_string()])
+            .output();
+        let last = match out {
+            Ok(out) => {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                let tail: String = stderr
+                    .lines()
+                    .rev()
+                    .take(5)
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .rev()
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                serde_json::json!({
+                    "ok": out.status.success(),
+                    "exit": out.status.code(),
+                    "stderr_tail": tail,
+                })
+            }
+            Err(e) => serde_json::json!({"ok": false, "error": format!("spawn: {e}")}),
+        };
+        let mut slot = slot.lock().unwrap_or_else(|e| e.into_inner());
+        slot.running = false;
+        slot.last = Some(last);
+    });
+    json_response(202, r#"{"started":true}"#)
+}
 
 fn handle_run_start(state: &AppState, body: &str) -> Response<std::io::Cursor<Vec<u8>>> {
     let job = if body.trim().is_empty() {
@@ -2521,6 +2612,20 @@ fn handle_model(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
             "serving_backend".into(),
             serde_json::json!(*state.serving_backend.read().unwrap()),
         );
+        // Repair surface: the last sqlite failure (null when healthy) and
+        // whether a portal-triggered rebuild is in flight — the SPA banner
+        // derives entirely from these plus serving_backend.
+        obj.insert(
+            "sqlite_error".into(),
+            serde_json::json!(*state.sqlite_error.read().unwrap()),
+        );
+        {
+            let rebuild = state.index_rebuild.lock().unwrap_or_else(|e| e.into_inner());
+            obj.insert(
+                "index_rebuild".into(),
+                serde_json::json!({"running": rebuild.running, "last": rebuild.last}),
+            );
+        }
         // Attention acknowledgements overlay: (sha,status) pairs the operator
         // dismissed. All attention surfaces (Today, System, the nav dot)
         // derive from this one model payload, so filtering stays consistent.
@@ -3544,6 +3649,9 @@ fn handle_settings(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
         // freshness.
         "built_at": model.as_deref().and_then(|m| m.built_at.clone()),
         "run_id": model.as_deref().and_then(|m| m.run_id.clone()),
+        // Stage-4 observation window: which store served the model. Reading
+        // it AFTER current_model() above means it reflects this very load.
+        "serving_backend": *state.serving_backend.read().unwrap(),
         "age_seconds": model.as_deref().and_then(|m| age_seconds(m.built_at.as_deref())),
         "counts": model.as_deref().map(|m| serde_json::json!({
             "sources": m.totals.sources,
@@ -5078,6 +5186,8 @@ mod tests {
             evidence: RwLock::new(Cached::default()),
             crystal: RwLock::new(CrystalCache::default()),
             serving_backend: RwLock::new("unloaded"),
+            sqlite_error: RwLock::new(None),
+            index_rebuild: Arc::new(std::sync::Mutex::new(IndexRebuild::default())),
             cards_zh: RwLock::new(Cached::default()),
             claims_zh: RwLock::new(Cached::default()),
             last_run: RwLock::new(Cached::default()),


### PR DESCRIPTION
## What

Stage 4 of `docs/design/storage-read-model.md`, per operator decision (2026-08-06): **direct switch, no soak wait** — the portal serves from the sqlite read-model now; the JSON projections stay as the fallback until the observation window closes (tracked todo: then cut the legacy path).

- **Serving readers**: `read_index_sqlite` / `read_evidence_sqlite` reconstruct the FULL models from the shadow. Schema v3 adds totals/ops/evidence-header meta blobs and `claim_rowid` ownership on `claim_sources` (duplicate claim_ids reconstruct exactly).
- **Parity gate upgraded from 20-row sampling to WHOLE-model `PartialEq`** through the exact serving readers — 64,086 rows compared on the live vault every build — with first-divergent-row diagnostics. The gate immediately caught a real defect: serde_json's default fast float parser is 1 ULP off ryu's shortest output (`success_rate_pct …631 → …632`); the workspace now enables `float_roundtrip`. A sampling gate would likely never have hit this.
- **Server**: `OVP_INDEX_BACKEND=sqlite` (default) | `json` (forces legacy). Loaders serve whichever store is **newest** (a JSON-only rebuild like portal tag curation must not be shadowed by a valid-but-older sqlite generation); freshness stamp = newest of shadow/JSON; any sqlite failure logs and serves the JSON fallback; `/api/refresh` reloads through the same loaders.
- **Observability**: `/api/model` carries `serving_backend: sqlite|json` — the desktop swallows stderr, so this is the visible signal for the JSON-retirement observation window.

## Failure model (unchanged contract: the shadow is a disposable projection)

Crash mid-build → only the tmp candidate is lost, last-good serves. Corrupt/missing db → automatic JSON fallback, portal uninterrupted; repair = `ovp2 index` (2.5 s live) or the next daily run. Deleting the whole cache dir loses nothing.

## Review gates

`codex review`: R1 found 1×P1 (stale-but-valid shadow pinning over newer JSON) + 1×P2 (evidence reader missing the schema guard) — both fixed with regression tests (serving flips both ways).

## Live verification

Real vault: build+full-parity 2.5 s, 82 MB db; temp `ovp2 serve` → `/api/model` 200 in 56 ms served from sqlite, zero fallback warnings; test proves sqlite-only serving with the JSON files deleted.

## Deploy

`ovp-server` changed → full desktop app rebuild + restart required (not just the sidecar).

Workspace: 1,362 tests green.
