### PR TITLE
fix(portal): row-level claim_zh splice; sidecar embed default for local staging

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -57,12 +57,17 @@ jobs:
         run: node scripts/release/set-desktop-version.mjs "$TAG"
 
       # The sidecar the in-app scheduler exec's. Live enrichment features on;
-      # `embed` (ONNX semantic themes) is OFF — its `ort` tree has no clean
-      # x86_64-apple-darwin build (why dist dropped that target) and it bloats
-      # the DMG. Themes stay a follow-up (lazy model download). Keeps both
-      # arches identical and small. Uses scripts/build-desktop-sidecar.sh so
-      # local rebuilds can't silently ship a no-feature binary (2026-07-31).
+      # `embed` (ONNX semantic themes) is OFF FOR RELEASES — its `ort` tree
+      # has no clean x86_64-apple-darwin build (why dist dropped that target)
+      # and it bloats the DMG; both arches stay identical and small. The
+      # feature set is PINNED here because the script's local default now
+      # includes embed on arm64 (2026-08-06: a lean locally-staged sidecar
+      # couldn't run crystal-themes, and the themes projection silently went
+      # a month stale). Uses scripts/build-desktop-sidecar.sh so local
+      # rebuilds can't silently ship a no-feature binary (2026-07-31).
       - name: Build ovp2 sidecar
+        env:
+          OVP2_SIDECAR_FEATURES: anthropic,pinboard-live,web-fetch-live,github-live
         run: bash scripts/build-desktop-sidecar.sh ${{ matrix.target }}
 
       - name: Build the portal (embedded by ovp-server)

--- a/crates/ovp-api-projection/src/bodies.rs
+++ b/crates/ovp-api-projection/src/bodies.rs
@@ -266,7 +266,12 @@ pub fn claim_body_with_lineage(
         .and_then(|m| m.get(&rec.claim_key).or_else(|| m.get(&rec.claim_id)));
 
     let mut body = json!({
+        // Historical field name: the endpoint's public `claim_id` has always
+        // carried the CANONICAL claim_key (kept for client compat);
+        // `claim_key` states it explicitly so key-based consumers (the zh
+        // lookup rule shared with /api/model) need no folklore.
         "claim_id": rec.claim_key,
+        "claim_key": rec.claim_key,
         "claim": rec.claim,
         "theme": rec.theme,
         "strength": format!("{:?}", rec.strength).to_lowercase(),

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -2585,6 +2585,18 @@ fn handle_terrain(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
     }
 }
 
+/// The zh-translation lookup key for a claim JSON object: canonical
+/// `claim_key` when present, else `claim_id` — ONE rule for every endpoint,
+/// or /api/model and /api/claim disagree on whether a translation exists.
+fn claim_zh_lookup_key(obj: &serde_json::Map<String, serde_json::Value>) -> String {
+    obj.get("claim_key")
+        .and_then(|v| v.as_str())
+        .filter(|k| !k.is_empty())
+        .or_else(|| obj.get("claim_id").and_then(|v| v.as_str()))
+        .unwrap_or_default()
+        .to_string()
+}
+
 fn handle_model(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
     // Overlay the LIVE heartbeat over the baked `ops.last_run` so the SPA banner
     // never reads a stale "running" snapshot baked into index.json.
@@ -2644,12 +2656,7 @@ fn handle_model(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
                     .and_then(|v| v.as_str())
                     .unwrap_or_default()
                     .to_string();
-                let key = claim_obj
-                    .get("claim_key")
-                    .and_then(|v| v.as_str())
-                    .or_else(|| claim_obj.get("claim_id").and_then(|v| v.as_str()))
-                    .unwrap_or_default()
-                    .to_string();
+                let key = claim_zh_lookup_key(claim_obj);
                 if let Some(zh) = claims_zh.get_fresh(&key, &en) {
                     claim_obj.insert("claim_zh".into(), serde_json::json!(zh));
                 }
@@ -2845,19 +2852,16 @@ fn handle_claim(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>
         Some(mut v) => {
             // Rebuildable bilingual projection — authority claim stays English.
             if let Some(obj) = v.as_object_mut() {
-                let key = obj
-                    .get("claim_id")
-                    .and_then(|x| x.as_str())
-                    .unwrap_or("")
-                    .to_string();
+                // Same key rule as /api/model (claim_key, else claim_id) —
+                // the two endpoints must agree on whether a zh exists; and
+                // the mtime-cached file, not a per-request disk parse.
+                let key = claim_zh_lookup_key(obj);
                 let en = obj
                     .get("claim")
                     .and_then(|x| x.as_str())
                     .unwrap_or("")
                     .to_string();
-                if let Ok(zh_file) =
-                    ovp_memory::bilingual::ClaimsZhFile::load(&state.vault_root)
-                {
+                if let Some(zh_file) = state.current_claims_zh() {
                     if let Some(zh) = zh_file.get_fresh(&key, &en) {
                         obj.insert("claim_zh".into(), serde_json::json!(zh));
                     }
@@ -5198,8 +5202,14 @@ mod tests {
     }
 
     fn temp_root(name: &str) -> PathBuf {
-        let dir =
-            std::env::temp_dir().join(format!("ovp-server-test-{}-{name}", std::process::id()));
+        // Gitignored repo-local artifact root (never /tmp — repo rule).
+        // Canonicalized: handlers legitimately reject paths containing `..`
+        // (the publish out-dir guard), and static resolution compares
+        // absolute forms.
+        let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../.run/server-tests");
+        std::fs::create_dir_all(&base).unwrap();
+        let base = base.canonicalize().expect("canonicalize test root");
+        let dir = base.join(format!("{}-{name}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         dir
@@ -7674,6 +7684,44 @@ mod tests {
     }
 
     // ---- mtime-based cache auto-reload (fix/serve-mtime-reload) ----
+
+    #[test]
+    fn claim_endpoint_zh_lookup_uses_the_same_key_rule_as_model() {
+        // write_ledger records carry DISTINCT claim_key ("a") and claim_id
+        // ("id-a") — the regression CodeRabbit asked for: both endpoints
+        // must key zh by claim_key first, or /api/model shows a translation
+        // /api/claim/{id} omits.
+        let vault = portal_vault("claim-zh-key", "50-Inbox/03-Processed/good.md", "body\n");
+        write_ledger(&vault);
+        let st = state(vault.clone(), None);
+        let v = body_json(dispatch(&st, Method::Get, "/api/claim/a", ""));
+        let key = v["claim_key"].as_str().expect("claim_key in body").to_string();
+        let en = v["claim"].as_str().expect("claim text").to_string();
+        // The fixture's UNDERLYING record has claim_id "id-a" ≠ claim_key
+        // "a"; the body's public `claim_id` field historically carries the
+        // KEY (see claim_body) — the explicit claim_key field states it.
+        assert_eq!(key, "a");
+        assert!(v.get("claim_zh").is_none(), "no zh yet");
+
+        let mut zh = ovp_memory::bilingual::ClaimsZhFile::default();
+        zh.entries.insert(
+            key,
+            ovp_memory::bilingual::ClaimZhEntry {
+                claim_zh: "键一致性翻译".into(),
+                en_hash: ovp_intake::vaultops::hex_sha256(en.trim().as_bytes())[..16].to_string(),
+                model: None,
+                translated_at: None,
+            },
+        );
+        zh.save(&vault).unwrap();
+
+        // Fresh state (the zh cache is mtime-keyed; a new file loads clean).
+        let st = state(vault.clone(), None);
+        let v = body_json(dispatch(&st, Method::Get, "/api/claim/a", ""));
+        assert_eq!(v["claim_zh"], serde_json::json!("键一致性翻译"));
+
+        let _ = std::fs::remove_dir_all(vault.parent().unwrap());
+    }
 
     #[test]
     fn model_splices_claim_zh_on_every_row_including_unclassified() {

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -2626,6 +2626,35 @@ fn handle_model(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
                 serde_json::json!({"running": rebuild.running, "last": rebuild.last}),
             );
         }
+        // Splice claim_zh onto EVERY claim row (fresh-by-en_hash semantics).
+        // The theme-pages lookup only covers claims cited by real community
+        // pages, so Unclassified claims read "0/N 中文就绪" even when their
+        // translations exist on disk — row-level splice makes the zh surface
+        // independent of theme membership.
+        if let Some((claims_zh, rows)) = state
+            .current_claims_zh()
+            .zip(obj.get_mut("claims").and_then(|c| c.as_array_mut()))
+        {
+            for row in rows {
+                let Some(claim_obj) = row.as_object_mut() else {
+                    continue;
+                };
+                let en = claim_obj
+                    .get("claim")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                let key = claim_obj
+                    .get("claim_key")
+                    .and_then(|v| v.as_str())
+                    .or_else(|| claim_obj.get("claim_id").and_then(|v| v.as_str()))
+                    .unwrap_or_default()
+                    .to_string();
+                if let Some(zh) = claims_zh.get_fresh(&key, &en) {
+                    claim_obj.insert("claim_zh".into(), serde_json::json!(zh));
+                }
+            }
+        }
         // Attention acknowledgements overlay: (sha,status) pairs the operator
         // dismissed. All attention surfaces (Today, System, the nav dot)
         // derive from this one model payload, so filtering stays consistent.
@@ -7645,6 +7674,77 @@ mod tests {
     }
 
     // ---- mtime-based cache auto-reload (fix/serve-mtime-reload) ----
+
+    #[test]
+    fn model_splices_claim_zh_on_every_row_including_unclassified() {
+        let root = temp_root("claim-zh-splice");
+        let vault = root.join("vault");
+        std::fs::create_dir_all(&vault).unwrap();
+
+        let mut model = index_dated("2026-08-06");
+        model.claims = vec![
+            ovp_index::ClaimRow {
+                claim_id: "m1-01".into(),
+                claim_key: Some("ck-fresh".into()),
+                claim: "Agents need memory".into(),
+                theme: Some("Unclassified".into()),
+                status: ovp_index::ClaimStatus::Durable,
+                sources: vec![],
+                strength: None,
+                run_id: None,
+                run_date: None,
+                lane: None,
+            },
+            ovp_index::ClaimRow {
+                claim_id: "m1-02".into(),
+                claim_key: Some("ck-stale".into()),
+                claim: "This text was edited after translation".into(),
+                theme: Some("Unclassified".into()),
+                status: ovp_index::ClaimStatus::Caveated,
+                sources: vec![],
+                strength: None,
+                run_id: None,
+                run_date: None,
+                lane: None,
+            },
+        ];
+        ovp_index::write_index(&vault, &model).unwrap();
+
+        let mut zh = ovp_memory::bilingual::ClaimsZhFile::default();
+        let hash =
+            |en: &str| ovp_intake::vaultops::hex_sha256(en.trim().as_bytes())[..16].to_string();
+        zh.entries.insert(
+            "ck-fresh".into(),
+            ovp_memory::bilingual::ClaimZhEntry {
+                claim_zh: "智能体需要记忆".into(),
+                en_hash: hash("Agents need memory"),
+                model: None,
+                translated_at: None,
+            },
+        );
+        // Stale: en_hash no longer matches the live claim text — must NOT
+        // splice (fresh-by-en_hash is the honesty contract).
+        zh.entries.insert(
+            "ck-stale".into(),
+            ovp_memory::bilingual::ClaimZhEntry {
+                claim_zh: "过期翻译".into(),
+                en_hash: hash("some OLD text"),
+                model: None,
+                translated_at: None,
+            },
+        );
+        zh.save(&vault).unwrap();
+
+        let st = state(vault.clone(), None);
+        let body = body_json(handle_model(&st));
+        let claims = body["claims"].as_array().expect("claims");
+        // Unclassified membership is irrelevant: the splice is row-level,
+        // not routed through theme-page citation.
+        assert_eq!(claims[0]["claim_zh"], serde_json::json!("智能体需要记忆"));
+        assert!(claims[1].get("claim_zh").is_none(), "stale zh must not splice");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
 
     #[test]
     fn serves_from_sqlite_shadow_even_without_json() {

--- a/scripts/build-desktop-sidecar.sh
+++ b/scripts/build-desktop-sidecar.sh
@@ -42,10 +42,13 @@ TRIPLE="${1:-$(rustc -vV | awk '/^host:/{print $2}')}"
 # release-desktop.yml — this default never changes shipped DMGs.
 if [ -n "${OVP2_SIDECAR_FEATURES:-}" ]; then
   FEATURES="$OVP2_SIDECAR_FEATURES"
-elif [ "$TRIPLE" = "x86_64-apple-darwin" ]; then
-  FEATURES="anthropic,pinboard-live,web-fetch-live,github-live"
-else
+elif [ "$TRIPLE" = "aarch64-apple-darwin" ]; then
+  # The documented local-staging target gets the embedder by default.
   FEATURES="anthropic,pinboard-live,web-fetch-live,github-live,embed"
+else
+  # Everything else (x86_64-apple-darwin release job, any third-party
+  # triple) keeps the lean set — opt in via OVP2_SIDECAR_FEATURES.
+  FEATURES="anthropic,pinboard-live,web-fetch-live,github-live"
 fi
 OUT_DIR="apps/desktop/src-tauri/binaries"
 OUT="$OUT_DIR/ovp2-${TRIPLE}"

--- a/scripts/build-desktop-sidecar.sh
+++ b/scripts/build-desktop-sidecar.sh
@@ -34,7 +34,19 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
 TRIPLE="${1:-$(rustc -vV | awk '/^host:/{print $2}')}"
-FEATURES="${OVP2_SIDECAR_FEATURES:-anthropic,pinboard-live,web-fetch-live,github-live,embed}"
+# Per-target default for LOCAL staging: `embed` pulls in `ort`, which has no
+# clean Intel-mac build — x64 keeps the lean set, arm64 (every dev/operator
+# machine) gets the embedder so a locally staged sidecar can run
+# crystal-themes (2026-08-06: a lean sidecar left themes.json a month stale).
+# RELEASES pin their own lean set via OVP2_SIDECAR_FEATURES in
+# release-desktop.yml — this default never changes shipped DMGs.
+if [ -n "${OVP2_SIDECAR_FEATURES:-}" ]; then
+  FEATURES="$OVP2_SIDECAR_FEATURES"
+elif [ "$TRIPLE" = "x86_64-apple-darwin" ]; then
+  FEATURES="anthropic,pinboard-live,web-fetch-live,github-live"
+else
+  FEATURES="anthropic,pinboard-live,web-fetch-live,github-live,embed"
+fi
 OUT_DIR="apps/desktop/src-tauri/binaries"
 OUT="$OUT_DIR/ovp2-${TRIPLE}"
 

--- a/scripts/build-desktop-sidecar.sh
+++ b/scripts/build-desktop-sidecar.sh
@@ -34,7 +34,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
 TRIPLE="${1:-$(rustc -vV | awk '/^host:/{print $2}')}"
-FEATURES="${OVP2_SIDECAR_FEATURES:-anthropic,pinboard-live,web-fetch-live,github-live}"
+FEATURES="${OVP2_SIDECAR_FEATURES:-anthropic,pinboard-live,web-fetch-live,github-live,embed}"
 OUT_DIR="apps/desktop/src-tauri/binaries"
 OUT="$OUT_DIR/ovp2-${TRIPLE}"
 


### PR DESCRIPTION
## What

Two fixes from the stale-themes incident (203 post-July-10 packs fell into Unclassified; theme pages showed "0/202 中文就绪" despite translations existing on disk):

1. **`/api/model` splices `claim_zh` onto EVERY claim row** from the cached `claims_zh.json` (fresh-by-`en_hash` semantics; stale entries skipped). The theme-pages lookup only covers claims cited by real community pages, so Unclassified claims could never show their zh even when translated — the zh surface is now independent of theme membership. Test pins fresh-splices/stale-skips on an Unclassified row.
2. **`build-desktop-sidecar.sh`: `embed` joins the default features for LOCAL arm64 staging** — a lean locally-staged sidecar couldn't run crystal-themes embedding at all, which is exactly how the themes projection went four weeks stale with daily printing its hint into a swallowed stderr. Per codex review: the release workflow now PINS its deliberate lean set explicitly (`OVP2_SIDECAR_FEATURES` env), so shipped DMGs are byte-policy-unchanged (no Intel ort problem, no DMG bloat); x64 local builds also stay lean.

## Operational recovery (already applied on the live vault)

crystal-themes re-run with an embed-capable sidecar: 1,486/1,486 packs covered, 29 communities; index re-projected (sqlite shadow parity green) — **Unclassified dropped 257 → 32** (better than the ~55 estimate; re-clustering also re-homed some old noise).

## Review gates

`codex review`: 1×P1 (the new embed default would have broken the Intel release matrix job) — fixed by pinning the release feature set in the workflow and scoping the default to local staging.

Workspace: 1,363 tests green.

## Deploy

`ovp-server` changed → full app rebuild + restart on the operator machine (no portal frontend change in this PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claim results now include refreshed Chinese translations when available, including previously unclassified claims.
  * Claim responses now provide a consistent claim identifier for reliable tracking.
* **Bug Fixes**
  * Prevented outdated translations from appearing after the underlying English claim changes.
* **Desktop Releases**
  * Standardized release configurations across supported architectures.
  * Apple Silicon builds retain embedding support, while other targets use a streamlined configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->