### PR TITLE
feat(schedule+portal): weekly themes job with init migration, stale-themes attention, knowledge wall sorting

### DIFF
--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -758,7 +758,7 @@ export const en = {
   'indexHealth.rebuildDone': 'Rebuild finished — data refreshes on the next poll.',
   'system.servingBackend': 'serving backend',
   'today.themesStale':
-    '{n} reader pack(s) are not clustered into themes yet — their claims sit in Unclassified. The weekly themes job (Sun 09:30) will re-cluster, or run `ovp2 crystal-themes` now.',
+    '{n} reader pack(s) are not clustered into themes yet — their claims sit in Unclassified. The weekly themes job (Sun 09:30) re-clusters when its runner includes the embedder; otherwise run `ovp2 crystal-themes` with an embed-capable build.',
   'knowledge.sortCount': 'Count',
   'knowledge.sortName': 'Name',
   'knowledge.sortDir.asc': '↑',

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -757,6 +757,12 @@ export const en = {
   'indexHealth.rebuildFailed': 'Rebuild failed: {err}',
   'indexHealth.rebuildDone': 'Rebuild finished — data refreshes on the next poll.',
   'system.servingBackend': 'serving backend',
+  'today.themesStale':
+    '{n} reader pack(s) are not clustered into themes yet — their claims sit in Unclassified. The weekly themes job (Sun 09:30) will re-cluster, or run `ovp2 crystal-themes` now.',
+  'knowledge.sortCount': 'Count',
+  'knowledge.sortName': 'Name',
+  'knowledge.sortDir.asc': '↑',
+  'knowledge.sortDir.desc': '↓',
   'system.builtAt': 'built',
   'system.runId': 'run id',
   'system.counts': 'counts',

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -759,6 +759,7 @@ export const en = {
   'system.servingBackend': 'serving backend',
   'today.themesStale':
     '{n} reader pack(s) are not clustered into themes yet — their claims sit in Unclassified. The weekly themes job (Sun 09:30) re-clusters when its runner includes the embedder; otherwise run `ovp2 crystal-themes` with an embed-capable build.',
+  'knowledge.sortDirLabel': 'sort direction',
   'knowledge.sortCount': 'Count',
   'knowledge.sortName': 'Name',
   'knowledge.sortDir.asc': '↑',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -721,7 +721,7 @@ export const zh: Record<keyof typeof en, string> = {
   'indexHealth.rebuildDone': '重建完成——数据将在下次轮询刷新。',
   'system.servingBackend': '服务后端',
   'today.themesStale':
-    '{n} 个阅读包尚未聚类进主题——它们的主张暂在 Unclassified。每周主题任务(周日 09:30)会自动重聚类,也可立即运行 `ovp2 crystal-themes`。',
+    '{n} 个阅读包尚未聚类进主题——它们的主张暂在 Unclassified。每周主题任务(周日 09:30)在运行器带嵌入器时自动重聚类;否则请用带 embed 的构建手动运行 `ovp2 crystal-themes`。',
   'knowledge.sortCount': '数量',
   'knowledge.sortName': '名称',
   'knowledge.sortDir.asc': '↑',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -720,6 +720,12 @@ export const zh: Record<keyof typeof en, string> = {
   'indexHealth.rebuildFailed': '重建失败:{err}',
   'indexHealth.rebuildDone': '重建完成——数据将在下次轮询刷新。',
   'system.servingBackend': '服务后端',
+  'today.themesStale':
+    '{n} 个阅读包尚未聚类进主题——它们的主张暂在 Unclassified。每周主题任务(周日 09:30)会自动重聚类,也可立即运行 `ovp2 crystal-themes`。',
+  'knowledge.sortCount': '数量',
+  'knowledge.sortName': '名称',
+  'knowledge.sortDir.asc': '↑',
+  'knowledge.sortDir.desc': '↓',
   'system.builtAt': '构建时刻',
   'system.runId': '运行 id',
   'system.counts': '统计',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -722,6 +722,7 @@ export const zh: Record<keyof typeof en, string> = {
   'system.servingBackend': '服务后端',
   'today.themesStale':
     '{n} 个阅读包尚未聚类进主题——它们的主张暂在 Unclassified。每周主题任务(周日 09:30)在运行器带嵌入器时自动重聚类;否则请用带 embed 的构建手动运行 `ovp2 crystal-themes`。',
+  'knowledge.sortDirLabel': '排序方向',
   'knowledge.sortCount': '数量',
   'knowledge.sortName': '名称',
   'knowledge.sortDir.asc': '↑',

--- a/console-ui/src/lib/derive.sortThemeWall.test.ts
+++ b/console-ui/src/lib/derive.sortThemeWall.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { sortThemeWall, type ThemeGroup } from './derive';
+
+const g = (theme: string, total: number): ThemeGroup => ({
+  theme,
+  total,
+  durable: total,
+  caveated: 0,
+});
+
+describe('sortThemeWall', () => {
+  const wall = [g('beta', 5), g('alpha', 5), g('gamma', 12), g('delta', 1)];
+
+  it('count desc reproduces the historical wall order (ties by name asc)', () => {
+    expect(sortThemeWall(wall, 'count', 'desc').map((x) => x.theme)).toEqual([
+      'gamma',
+      'alpha',
+      'beta',
+      'delta',
+    ]);
+  });
+
+  it('count asc flips the primary key but keeps name-asc ties', () => {
+    expect(sortThemeWall(wall, 'count', 'asc').map((x) => x.theme)).toEqual([
+      'delta',
+      'alpha',
+      'beta',
+      'gamma',
+    ]);
+  });
+
+  it('name sorts alphabetically both ways', () => {
+    expect(sortThemeWall(wall, 'name', 'asc').map((x) => x.theme)).toEqual([
+      'alpha',
+      'beta',
+      'delta',
+      'gamma',
+    ]);
+    expect(sortThemeWall(wall, 'name', 'desc').map((x) => x.theme)).toEqual([
+      'gamma',
+      'delta',
+      'beta',
+      'alpha',
+    ]);
+  });
+
+  it('does not mutate its input', () => {
+    const before = wall.map((x) => x.theme);
+    sortThemeWall(wall, 'name', 'desc');
+    expect(wall.map((x) => x.theme)).toEqual(before);
+  });
+});

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -1239,3 +1239,23 @@ export function indexHealth(
   if (sqliteError) return 'error';
   return 'ok';
 }
+
+/** Knowledge-wall sort control (operator request 2026-08-06): by claim
+ * count or theme name, either direction. Ties always break by name asc so
+ * the order is deterministic under every mode; the default ('count'/'desc')
+ * reproduces the wall's historical order exactly. */
+export type ThemeSortKey = 'count' | 'name';
+export type ThemeSortDir = 'asc' | 'desc';
+
+export function sortThemeWall(
+  groups: ThemeGroup[],
+  key: ThemeSortKey,
+  dir: ThemeSortDir,
+): ThemeGroup[] {
+  return [...groups].sort((a, b) => {
+    const primary =
+      key === 'count' ? a.total - b.total : a.theme.localeCompare(b.theme);
+    const signed = dir === 'asc' ? primary : -primary;
+    return signed || a.theme.localeCompare(b.theme);
+  });
+}

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -546,6 +546,10 @@ export interface IndexModel {
   /** Live-server overlay: the last sqlite load failure, null when healthy.
    * Non-null drives the repair banner (rebuild button). */
   sqlite_error?: string | null;
+  /** Live-server overlay: packs the semantic-themes projection has never
+   * clustered. Non-zero surfaces in the Today attention feed — the daily
+   * CLI printed this hint into a swallowed stderr for a month once. */
+  themes_stale_packs?: number;
   /** Live-server overlay: the portal-triggered projection rebuild state. */
   index_rebuild?: {
     running: boolean;

--- a/console-ui/src/pages/KnowledgePage.tsx
+++ b/console-ui/src/pages/KnowledgePage.tsx
@@ -193,7 +193,7 @@ function KnowledgeBody({ model }: { model: IndexModel }) {
             </button>
             <button
               type="button"
-              aria-label="sort direction"
+              aria-label={t('knowledge.sortDirLabel')}
               onClick={() => setSort(sortKey, sortDir === 'asc' ? 'desc' : 'asc')}
             >
               {sortDir === 'asc' ? t('knowledge.sortDir.asc') : t('knowledge.sortDir.desc')}

--- a/console-ui/src/pages/KnowledgePage.tsx
+++ b/console-ui/src/pages/KnowledgePage.tsx
@@ -19,7 +19,15 @@ const KnowledgeTerrain = lazy(() => import('../components/KnowledgeTerrain'));
 import { AgeLabel, EmptyState, ModelGate, PageHelp } from '../components/ui';
 import { useI18n } from '../i18n';
 import { fetchThemes } from '../lib/api';
-import { isMiscTheme, themeRoute, themeWall, type ThemeGroup } from '../lib/derive';
+import {
+  isMiscTheme,
+  sortThemeWall,
+  themeRoute,
+  themeWall,
+  type ThemeGroup,
+  type ThemeSortDir,
+  type ThemeSortKey,
+} from '../lib/derive';
 import type { IndexModel, ThemeCount } from '../lib/types';
 import { useModel } from '../model';
 
@@ -121,7 +129,22 @@ function KnowledgeBody({ model }: { model: IndexModel }) {
     };
   }, []);
 
-  const wall = themeWall(model.claims, themes);
+  // Sort control (URL-parameterized like the view toggle; default = the
+  // historical count-desc wall).
+  const sortKey: ThemeSortKey = params.get('sort') === 'name' ? 'name' : 'count';
+  const sortDir: ThemeSortDir =
+    params.get('dir') === 'asc' ? 'asc' : params.get('dir') === 'desc' ? 'desc' : sortKey === 'name' ? 'asc' : 'desc';
+  const setSort = (key: ThemeSortKey, dir: ThemeSortDir) => {
+    setParams(
+      (p) => {
+        p.set('sort', key);
+        p.set('dir', dir);
+        return p;
+      },
+      { replace: true },
+    );
+  };
+  const wall = sortThemeWall(themeWall(model.claims, themes), sortKey, sortDir);
 
   return (
     <>
@@ -149,6 +172,34 @@ function KnowledgeBody({ model }: { model: IndexModel }) {
           {t('knowledge.viewTerrain')}
         </button>
         </div>
+
+        {/* Sort control (list view only): key toggle + direction, same
+            seg-toggle vocabulary as the perspective switch. */}
+        {view === 'list' && (
+          <div className="seg-toggle persp-toggle" role="group">
+            <button
+              type="button"
+              className={sortKey === 'count' ? 'active' : ''}
+              onClick={() => setSort('count', sortKey === 'count' ? sortDir : 'desc')}
+            >
+              {t('knowledge.sortCount')}
+            </button>
+            <button
+              type="button"
+              className={sortKey === 'name' ? 'active' : ''}
+              onClick={() => setSort('name', sortKey === 'name' ? sortDir : 'asc')}
+            >
+              {t('knowledge.sortName')}
+            </button>
+            <button
+              type="button"
+              aria-label="sort direction"
+              onClick={() => setSort(sortKey, sortDir === 'asc' ? 'desc' : 'asc')}
+            >
+              {sortDir === 'asc' ? t('knowledge.sortDir.asc') : t('knowledge.sortDir.desc')}
+            </button>
+          </div>
+        )}
 
         {/* Perspective switch — a SIBLING of .tab-row (not nested), so the
             .tab-row button rules don't clobber the .seg-toggle contrast. Shares

--- a/console-ui/src/pages/TodayPage.tsx
+++ b/console-ui/src/pages/TodayPage.tsx
@@ -184,10 +184,16 @@ function ClaimsThatDay({ view }: { view: DayView }) {
 function Attention({ model }: { model: IndexModel }) {
   const { t } = useI18n();
   const sources = attentionSources(model);
-  if (sources.length === 0) return null;
+  const staleThemes = model.themes_stale_packs ?? 0;
+  if (sources.length === 0 && staleThemes === 0) return null;
   return (
     <div className="section">
       <h2>{t('today.attentionTitle')}</h2>
+      {staleThemes > 0 && (
+        <div className="card attention-card sm">
+          <p style={{ margin: 0 }}>{t('today.themesStale', { n: staleThemes })}</p>
+        </div>
+      )}
       {sources.map((s) => (
         <AttentionCard source={s} key={s.sha256} />
       ))}

--- a/crates/ovp-cli/src/commands/schedule.rs
+++ b/crates/ovp-cli/src/commands/schedule.rs
@@ -670,6 +670,10 @@ pub enum RegistryOutcome {
     /// the flags) were reconciled, preserving operator edits (enabled state +
     /// custom jobs).
     Reconciled,
+    /// Existed; missing BUILT-IN jobs were inserted at their default
+    /// positions (init-time migration for upgrades), everything else
+    /// untouched.
+    Migrated,
     /// Existed and already matched — left untouched.
     Unchanged,
 }
@@ -714,6 +718,29 @@ fn ensure_registry(cfg: &ScheduleConfig, reconcile: bool) -> Result<RegistryOutc
         return Ok(RegistryOutcome::Seeded);
     }
     if !reconcile {
+        // Seed-if-absent is init's promise — but a NEW built-in job must
+        // still reach existing registries, or upgrades never get it (the
+        // desktop only ever runs `init`). This is an edit-preserving
+        // MIGRATION: only jobs whose id the registry lacks are inserted, at
+        // their default-registry position (registry order is catch-up
+        // execution order — `themes` must run before `crystallize`).
+        // Operators turn a built-in off with `schedule disable`, not by
+        // deleting it; a deleted built-in is restored disabled? No — it is
+        // restored as the default ships it; disable it again if unwanted.
+        let mut reg = super::scheduler::load_registry(&cfg.vault_root)?
+            .expect("registry_path exists but load returned None");
+        let mut inserted = false;
+        for (pos, fresh_job) in fresh.jobs.iter().enumerate() {
+            if reg.get(&fresh_job.id).is_none() {
+                let at = pos.min(reg.jobs.len());
+                reg.jobs.insert(at, fresh_job.clone());
+                inserted = true;
+            }
+        }
+        if inserted {
+            super::scheduler::save_registry(&cfg.vault_root, &reg)?;
+            return Ok(RegistryOutcome::Migrated);
+        }
         return Ok(RegistryOutcome::Unchanged);
     }
     let mut reg = super::scheduler::load_registry(&cfg.vault_root)?
@@ -956,8 +983,9 @@ pub fn run_init(args: InstallArgs) -> Result<(), CliError> {
     };
     let reg_path = super::scheduler::registry_path(&cfg.vault_root);
     let state = match outcome {
-        RegistryOutcome::Seeded => "seeded (daily + weekly crystallize)",
+        RegistryOutcome::Seeded => "seeded (daily + weekly themes + weekly crystallize)",
         RegistryOutcome::Reconciled => "reconciled (built-in jobs + env-file; edits kept)",
+        RegistryOutcome::Migrated => "migrated (new built-in job(s) added; edits kept)",
         RegistryOutcome::Unchanged => "already up to date",
     };
     println!("schedule init: {} — registry {}", state, reg_path.display());
@@ -998,6 +1026,9 @@ pub fn run_install(args: InstallArgs) -> Result<(), CliError> {
         }
         RegistryOutcome::Reconciled => {
             println!("  registry:  {reg_path} (built-in jobs + env-file reconciled; edits kept)");
+        }
+        RegistryOutcome::Migrated => {
+            println!("  registry:  {reg_path} (new built-in job(s) added; edits kept)");
         }
         RegistryOutcome::Unchanged => {
             println!("  registry:  {reg_path} (existing, left untouched)");
@@ -1318,6 +1349,34 @@ mod tests {
         assert_eq!(ensure_registry(&c, true).unwrap(), RegistryOutcome::Reconciled);
         let reconciled = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap();
         assert_eq!(reconciled.get("daily").unwrap().cadence, "daily 09:00");
+    }
+
+    #[test]
+    fn init_migrates_missing_builtin_jobs_preserving_edits_and_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut c = cfg();
+        c.vault_root = dir.path().to_path_buf();
+        c.env_file = dir.path().join(".ovp/daily.env");
+        assert_eq!(ensure_registry(&c, false).unwrap(), RegistryOutcome::Seeded);
+
+        // Model an upgrade: a registry from before the `themes` built-in,
+        // carrying operator edits that must survive the migration.
+        let mut reg = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap();
+        reg.jobs.retain(|j| j.id != "themes");
+        let daily = reg.get_mut("daily").unwrap();
+        daily.cadence = "every 4h".into();
+        super::super::scheduler::save_registry(dir.path(), &reg).unwrap();
+
+        assert_eq!(ensure_registry(&c, false).unwrap(), RegistryOutcome::Migrated);
+        let after = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap();
+        // Inserted at its default position: BEFORE crystallize (registry
+        // order is catch-up execution order — themes must re-cluster first).
+        let ids: Vec<&str> = after.jobs.iter().map(|j| j.id.as_str()).collect();
+        assert_eq!(ids, vec!["daily", "themes", "crystallize"]);
+        assert_eq!(after.get("daily").unwrap().cadence, "every 4h", "edits survive");
+
+        // Migration is idempotent.
+        assert_eq!(ensure_registry(&c, false).unwrap(), RegistryOutcome::Unchanged);
     }
 
     #[derive(Default)]

--- a/crates/ovp-cli/src/commands/schedule.rs
+++ b/crates/ovp-cli/src/commands/schedule.rs
@@ -752,7 +752,7 @@ fn ensure_registry(cfg: &ScheduleConfig, reconcile: bool) -> Result<RegistryOutc
     // built-in except `daily` — only `--time` owns a cadence, so a reinstall
     // must not reset the operator's crystallize slot to the hard-coded default
     // (codex P2). Custom jobs are left untouched.
-    for fresh_job in fresh.jobs {
+    for (pos, fresh_job) in fresh.jobs.into_iter().enumerate() {
         match reg.get_mut(&fresh_job.id) {
             Some(existing) => {
                 let enabled = existing.enabled;
@@ -765,7 +765,14 @@ fn ensure_registry(cfg: &ScheduleConfig, reconcile: bool) -> Result<RegistryOutc
                 existing.enabled = enabled;
                 existing.cadence = cadence;
             }
-            None => reg.jobs.push(fresh_job), // a built-in the operator removed — restore it
+            // A built-in the operator removed (or one newer than this
+            // registry) — restore/insert at its DEFAULT position: registry
+            // order is catch-up execution order (themes before crystallize),
+            // same rule as the init migration.
+            None => {
+                let at = pos.min(reg.jobs.len());
+                reg.jobs.insert(at, fresh_job);
+            }
         }
     }
     if reg == before {
@@ -1377,6 +1384,16 @@ mod tests {
 
         // Migration is idempotent.
         assert_eq!(ensure_registry(&c, false).unwrap(), RegistryOutcome::Unchanged);
+
+        // Reinstall (reconcile) restores a missing built-in at its default
+        // position too — never appended after crystallize.
+        let mut reg = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap();
+        reg.jobs.retain(|j| j.id != "themes");
+        super::super::scheduler::save_registry(dir.path(), &reg).unwrap();
+        assert_eq!(ensure_registry(&c, true).unwrap(), RegistryOutcome::Reconciled);
+        let after = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap();
+        let ids: Vec<&str> = after.jobs.iter().map(|j| j.id.as_str()).collect();
+        assert_eq!(ids, vec!["daily", "themes", "crystallize"]);
     }
 
     #[derive(Default)]

--- a/crates/ovp-scheduler/src/lib.rs
+++ b/crates/ovp-scheduler/src/lib.rs
@@ -381,20 +381,20 @@ pub fn default_registry(
                 stamp_date: true,
             },
             JobConfig {
-                id: "crystallize".to_string(),
-                cadence: "weekly Sun 10:00".to_string(),
-                argv: crystallize_argv,
-                enabled: true,
-                description: "Cross-source synthesis into durable crystal claims".to_string(),
-                stamp_date: true,
-            },
-            JobConfig {
                 id: "themes".to_string(),
                 cadence: "weekly Sun 09:30".to_string(),
                 argv: themes_argv,
                 enabled: true,
                 description: "Re-cluster semantic themes (embeddings + labels)".to_string(),
                 stamp_date: false,
+            },
+            JobConfig {
+                id: "crystallize".to_string(),
+                cadence: "weekly Sun 10:00".to_string(),
+                argv: crystallize_argv,
+                enabled: true,
+                description: "Cross-source synthesis into durable crystal claims".to_string(),
+                stamp_date: true,
             },
         ],
     }

--- a/crates/ovp-scheduler/src/lib.rs
+++ b/crates/ovp-scheduler/src/lib.rs
@@ -355,6 +355,19 @@ pub fn default_registry(
         "--work-dir".to_string(),
         format!("{VAULT_PLACEHOLDER}/.ovp/work/crystal-synth"),
     ];
+    // Semantic-theme re-clustering: BEFORE crystallize's Sunday slot so the
+    // weekly synthesis batches over fresh communities, and weekly at all so
+    // the themes projection can never quietly go a month stale again
+    // (2026-08-06 incident: 203 unclustered packs → 202 claims in
+    // Unclassified). A build without the `embed` feature skips gracefully
+    // (warn + exit 0), so lean sidecars never fail the tick.
+    let themes_argv = vec![
+        "crystal-themes".to_string(),
+        "--vault-root".to_string(),
+        VAULT_PLACEHOLDER.to_string(),
+        "--client".to_string(),
+        client.to_string(),
+    ];
     Registry {
         version: 1,
         env_file: Some(format!("{VAULT_PLACEHOLDER}/.ovp/daily.env")),
@@ -374,6 +387,14 @@ pub fn default_registry(
                 enabled: true,
                 description: "Cross-source synthesis into durable crystal claims".to_string(),
                 stamp_date: true,
+            },
+            JobConfig {
+                id: "themes".to_string(),
+                cadence: "weekly Sun 09:30".to_string(),
+                argv: themes_argv,
+                enabled: true,
+                description: "Re-cluster semantic themes (embeddings + labels)".to_string(),
+                stamp_date: false,
             },
         ],
     }
@@ -830,7 +851,7 @@ mod tests {
     // -- registry ------------------------------------------------------------
 
     #[test]
-    fn default_registry_has_daily_and_weekly_crystallize() {
+    fn default_registry_has_daily_weekly_crystallize_and_weekly_themes() {
         let reg = default_registry("live", (9, 0), true, Some(40));
         reg.validate().unwrap();
         let daily = reg.get("daily").unwrap();
@@ -854,6 +875,15 @@ mod tests {
             reg.env_file.as_deref(),
             Some(format!("{VAULT_PLACEHOLDER}/.ovp/daily.env").as_str())
         );
+        // The themes job runs BEFORE crystallize's slot and skips gracefully
+        // on embed-less builds — weekly by default so the projection can
+        // never quietly go a month stale again.
+        let themes = reg.get("themes").unwrap();
+        assert_eq!(themes.cadence, "weekly Sun 09:30");
+        assert!(themes.argv.contains(&"crystal-themes".to_string()));
+        assert!(themes.argv.contains(&VAULT_PLACEHOLDER.to_string()));
+        assert!(!themes.stamp_date);
+
     }
 
     #[test]
@@ -1003,35 +1033,38 @@ mod tests {
         }
     }
 
-    fn two_job_registry() -> Registry {
+    /// The full default registry (daily + weekly crystallize + weekly themes).
+    fn default_jobs_registry() -> Registry {
         default_registry("live", (9, 0), false, None)
     }
 
     #[test]
     fn plan_tick_partitions_due_disabled_and_not_due() {
-        let mut reg = two_job_registry();
+        let mut reg = default_jobs_registry();
         reg.get_mut("crystallize").unwrap().enabled = false;
-        let now = dt("2026-07-12T09:30:00"); // Sunday, daily due, crystallize off
+        let now = dt("2026-07-12T09:30:00"); // Sunday: daily + themes due, crystallize off
         let plan = plan_tick(&reg, &State::default(), now);
-        assert_eq!(plan.due, vec!["daily".to_string()]);
+        assert_eq!(plan.due, vec!["daily".to_string(), "themes".to_string()]);
         assert_eq!(plan.skipped_disabled, vec!["crystallize".to_string()]);
         assert!(plan.skipped_not_due.is_empty());
-        // Once daily has run, the next plan has nothing due.
+        // Once both have run, the next plan has nothing due.
         let mut state = State::default();
         state.record("daily", now, "ok");
+        state.record("themes", now, "ok");
         assert!(plan_tick(&reg, &state, now).due.is_empty());
     }
 
     #[test]
     fn tick_runs_due_jobs_and_records_state() {
-        let reg = two_job_registry();
-        let now = dt("2026-07-12T10:30:00"); // both due
+        let reg = default_jobs_registry();
+        let now = dt("2026-07-12T10:30:00"); // all three due (Sunday past 10:00)
         let runner = FakeRunner {
             fail: vec!["crystallize".into()],
             ..Default::default()
         };
         let (new_state, report) = tick_with(&reg, &State::default(), now, &runner);
-        assert_eq!(report.ran.len(), 2);
+        assert_eq!(report.ran.len(), 3);
+        assert_eq!(new_state.runs.get("themes").unwrap().last_status, "ok");
         assert_eq!(new_state.runs.get("daily").unwrap().last_status, "ok");
         assert_eq!(
             new_state.runs.get("crystallize").unwrap().last_status,
@@ -1041,7 +1074,7 @@ mod tests {
 
     #[test]
     fn run_now_ignores_cadence() {
-        let reg = two_job_registry();
+        let reg = default_jobs_registry();
         let now = dt("2026-07-12T08:00:00"); // crystallize NOT due
         let runner = FakeRunner::default();
         let (new_state, ok) =

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -2585,6 +2585,30 @@ fn handle_terrain(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
     }
 }
 
+/// How many packs the semantic-themes projection has never clustered —
+/// mirrors daily's `stale_theme_packs` (a missing/corrupt themes.json counts
+/// every pack as unthemed; that IS the signal to run crystal-themes).
+fn stale_theme_packs_count(vault_root: &Path, model: &IndexModel) -> usize {
+    if model.packs.is_empty() {
+        return 0;
+    }
+    let themes =
+        ovp_domain::crystal::themes::ThemesFile::load(&vault_root.join(".ovp/crystal/themes.json"))
+            .ok()
+            .flatten();
+    match &themes {
+        Some(t) => model
+            .packs
+            .iter()
+            .filter(|p| {
+                let case_id = ovp_domain::vault_layout::pack_case_id(&p.pack_dir);
+                !t.packs.contains_key(case_id)
+            })
+            .count(),
+        None => model.packs.len(),
+    }
+}
+
 fn handle_model(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
     // Overlay the LIVE heartbeat over the baked `ops.last_run` so the SPA banner
     // never reads a stale "running" snapshot baked into index.json.
@@ -2611,6 +2635,15 @@ fn handle_model(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
         obj.insert(
             "serving_backend".into(),
             serde_json::json!(*state.serving_backend.read().unwrap()),
+        );
+        // Themes-staleness overlay: packs missing from the semantic-themes
+        // projection. The daily CLI has printed this hint since 95d9be14 —
+        // into a stderr the desktop swallows, which is how the projection
+        // once went a month stale unnoticed. The portal attention feed reads
+        // THIS field instead. None→0 packs is not staleness (fresh vault).
+        obj.insert(
+            "themes_stale_packs".into(),
+            serde_json::json!(stale_theme_packs_count(&state.vault_root, &model)),
         );
         // Repair surface: the last sqlite failure (null when healthy) and
         // whether a portal-triggered rebuild is in flight — the SPA banner
@@ -6014,7 +6047,10 @@ mod tests {
         let v = body_json(dispatch(&st, Method::Get, "/api/schedule", ""));
         assert_eq!(v["present"], true);
         let jobs = v["jobs"].as_array().unwrap();
-        assert_eq!(jobs.len(), 2);
+        // daily + weekly crystallize + weekly themes (2026-08-06).
+        assert_eq!(jobs.len(), 3);
+        let themes = jobs.iter().find(|j| j["id"] == "themes").unwrap();
+        assert_eq!(themes["cadence"], "weekly Sun 09:30");
         let daily = jobs.iter().find(|j| j["id"] == "daily").unwrap();
         assert_eq!(daily["cadence"], "daily 09:00");
         assert_eq!(daily["enabled"], true);

--- a/evolution/candidates/scheduler-v2.json
+++ b/evolution/candidates/scheduler-v2.json
@@ -1,0 +1,27 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "scheduler-v2",
+  "base_version": "v1",
+  "target_version": "v2",
+  "surface": "runtime",
+  "component": "runtime.scheduler",
+  "hypothesis": "RUNTIME surface, one automation addition + one registry-lifecycle fix, closing the 2026-08-06 stale-themes incident class (themes.json quietly a month stale; 203 unclustered packs put 202 claims in Unclassified while daily printed its hint into a swallowed stderr). (1) NEW BUILT-IN JOB `themes`: `crystal-themes --client live`, weekly Sun 09:30 — positioned BEFORE crystallize's Sun 10:00 in the registry because registry order is catch-up execution order, so a tick that missed both slots still re-clusters before the weekly synthesis batches by community. A runner without the `embed` feature skips gracefully (warn + exit 0) and never fails the tick. (2) INIT-TIME MIGRATION: `schedule init` (which the desktop runs on every launch) now inserts missing BUILT-IN jobs at their default positions while preserving every operator edit — without this, existing registries never receive a new built-in because init's seed-if-absent contract returns Unchanged. Predicted: fresh installs and upgrades both carry the weekly themes job; operator cadence/argv/enabled edits survive migration byte-for-byte; catch-up ticks run themes before crystallize.",
+  "predicted_delta": {
+    "coverage": "themes projection staleness is bounded at 7 days by schedule instead of unbounded-until-manual-run; the Unclassified bucket tracks corpus noise (~2%) instead of accumulating every new pack's claims (was 17% of all claims after 4 stale weeks)",
+    "operational_reliability": "zero new tick failure modes: embed-less runners no-op with exit 0; migration is idempotent (second init returns Unchanged) and edit-preserving (existing-job configs untouched)"
+  },
+  "guardrails": {
+    "accepted_without_quote": 0,
+    "edits_survive": "migration only INSERTS jobs whose id is absent; cadence/argv/enabled of every existing job are byte-identical after init — pinned by init_migrates_missing_builtin_jobs_preserving_edits_and_order",
+    "catchup_order": "default registry order is daily, themes, crystallize; plan_tick executes in registry order, so a missed-Sunday catch-up re-clusters before synthesis",
+    "lean_runner_safe": "crystal-themes without `embed` warns and exits 0 — a scheduled run on a lean sidecar is a no-op, never a failed tick (the portal attention hint stays up until a capable runner clears it)",
+    "cadence_vocabulary_unchanged": "the job uses the existing `weekly <Day> <HH:MM>` syntax — no new cadence grammar, so older sidecars parsing the registry never stall the tick"
+  },
+  "eval_plan": {
+    "replay_set": "unit fixtures: default registry seeds daily+themes+crystallize in that order; catch-up tick at Sun 10:30 runs all three with themes before crystallize; migration inserts themes before crystallize into a pre-v2 registry while preserving an operator's edited daily cadence, and is idempotent; schedule-endpoint lists the third job. Live vault: registry updated and validated via `schedule list` on the installed sidecar.",
+    "paired_sources": 0,
+    "soak": false
+  },
+  "rollback": "ovp2 schedule disable themes (per-vault, instant) or revert — the job is additive; migration touches only absent ids, so rollback leaves registries exactly as edited.",
+  "ablation_required": false
+}

--- a/evolution/components.json
+++ b/evolution/components.json
@@ -118,7 +118,7 @@
     {
       "id": "runtime.scheduler",
       "surface": "runtime",
-      "current_version": "v1",
+      "current_version": "v2",
       "file": "crates/ovp-scheduler/src/lib.rs",
       "quality_buckets": [
         "operational_reliability"


### PR DESCRIPTION
## What

Closes the stale-themes incident class and adds the requested knowledge-wall sorting (candidate **scheduler-v2**, validated, registry v1→v2).

**1. Weekly `themes` built-in job**
- `crystal-themes --client live`, weekly **Sun 09:30 — BEFORE crystallize's 10:00**, and the default registry orders daily → themes → crystallize because registry order is catch-up execution order (a tick that missed both Sunday slots still re-clusters before synthesis; codex P1).
- **`schedule init` now migrates existing registries**: missing built-ins are inserted at their default positions with every operator edit surviving byte-for-byte (idempotent; pinned by test). Without this, upgrades never received a new built-in (codex P1). Live vault registry already updated + reordered and validated via `schedule list` on the installed sidecar.
- Lean (embed-less) runners skip gracefully with exit 0 — never a failed tick; no new cadence grammar, so older sidecars can't stall.

**2. Stale-themes hint moves to the portal**
- `/api/model` carries `themes_stale_packs` (mirrors daily's `stale_theme_packs`); the Today attention feed shows a bilingual hint when non-zero. The daily CLI printed this into a swallowed stderr for a month once — that's the whole incident. Copy is capability-aware (packaged DMG sidecars are deliberately lean; codex P2).

**3. Knowledge wall sorting**
- Sort by count or name, asc/desc, URL-parameterized (`?sort=&dir=`) like the view toggle; default reproduces the historical count-desc order exactly; ties always break name-asc. Pure `sortThemeWall` + node-env test.

## Review gates

`codex review`: 3×P1 (migration gap, catch-up order, missing candidate spec) + 1×P2 (overpromising hint) — all fixed with tests.

Workspace 1363 green · SPA 134 green + tsc + build.

## Deploy

sidecar rebuild (scheduler/CLI) + full app rebuild+restart (ovp-server) + `deploy-portal.sh` (SPA).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Knowledge sorting by claim count or theme name, with ascending and descending options.
  - Added notifications when theme clustering is outdated, including affected pack counts.
  - Added a weekly automated theme-clustering job before crystallization.
  - Existing schedules now gain missing built-in jobs during initialization without overwriting custom edits.
- **Localization**
  - Added English and Simplified Chinese labels for sorting controls and stale-theme notifications.
- **Bug Fixes**
  - Improved schedule migration reporting and ensured repeated initialization remains safe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->