### PR TITLE
fix(knowledge): count theme sources by canonical identity (URL first)

### DIFF
--- a/console-ui/src/lib/derive.themeSources.test.ts
+++ b/console-ui/src/lib/derive.themeSources.test.ts
@@ -1,7 +1,7 @@
 /** Distinct-source accounting on the knowledge wall + the source page's
  * "supports crystal knowledge" rail. Pure derive functions — no DOM. */
 import { describe, expect, it } from 'vitest';
-import { sourceThemes, themeWall } from './derive';
+import { caseCanonicalIds, sourceThemes, themeWall } from './derive';
 import type { ClaimRow } from './types';
 
 const claim = (
@@ -41,6 +41,40 @@ describe('themeWall source counts', () => {
     const wall = themeWall([], [{ theme: 'Ledger only', count: 4 }]);
     expect(wall[0].sources).toBe(0);
     expect(wall[0].total).toBe(4);
+  });
+
+  it('re-captures of the same document collapse to ONE source via the canonical map', () => {
+    // Live-vault case (2026-08-07): the same article clipped twice a month
+    // apart → two case ids, two content shas, ONE url. The theme showed
+    // "2 sources" while genuinely resting on one document.
+    const model = {
+      sources: [
+        { sha256: 'sha-april', url: 'https://example.com/a' },
+        { sha256: 'sha-may', url: 'https://example.com/a' },
+        { sha256: 'sha-other', url: 'https://example.com/b' },
+      ],
+      packs: [
+        { pack_dir: '40-Resources/Reader/case-april', source_sha256: 'sha-april' },
+        { pack_dir: '40-Resources/Reader/case-may', source_sha256: 'sha-may' },
+        { pack_dir: '40-Resources/Reader/case-other', source_sha256: 'sha-other' },
+        // Legacy pack without a source link falls back to the sha, then case id.
+        { pack_dir: '40-Resources/Reader/case-orphan', source_sha256: null },
+      ],
+    };
+    const canonical = caseCanonicalIds(model);
+    expect(canonical.get('case-april')).toBe('https://example.com/a');
+    expect(canonical.get('case-may')).toBe('https://example.com/a');
+    expect(canonical.get('case-orphan')).toBe('case-orphan');
+
+    const wall = themeWall(
+      [
+        claim('c1', 'T', ['case-april', 'case-may']),
+        claim('c2', 'T', ['case-april', 'case-other']),
+      ],
+      [],
+      canonical,
+    );
+    expect(wall[0].sources).toBe(2);
   });
 
   it('rejected/superseded claims do not contribute sources', () => {

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -1049,6 +1049,10 @@ export function activeClaims(claims: ClaimRow[]): ClaimRow[] {
 export function themeWall(
   claims: ClaimRow[],
   ledgerThemes: { theme: string; count: number }[],
+  // Optional case-id → canonical-identity map (see `caseCanonicalIds`):
+  // collapses re-captures of the same document so `sources` counts
+  // INDEPENDENT documents, not vault copies. Absent = raw case ids.
+  canonical?: Map<string, string>,
 ): ThemeGroup[] {
   const groups = new Map<string, ThemeGroup>();
   const caseSets = new Map<string, Set<string>>();
@@ -1066,7 +1070,7 @@ export function themeWall(
   }
   for (const c of activeClaims(claims)) {
     const g = ensure(c.theme ?? '');
-    for (const s of c.sources) caseSets.get(g.theme)?.add(s);
+    for (const s of c.sources) caseSets.get(g.theme)?.add(canonical?.get(s) ?? s);
     if (c.status === 'durable') {
       // The first durable claim is the wall snippet, even when a caveated
       // one was seen first.
@@ -1090,6 +1094,25 @@ export function themeWall(
   return [...groups.values()].sort(
     (a, b) => b.total - a.total || a.theme.localeCompare(b.theme),
   );
+}
+
+/** case id → canonical source identity for DISTINCT-source counting: the
+ * source URL when present (re-captures of the same article get different
+ * content shas but share the URL — 58 such pairs in the live vault when this
+ * shipped), else the content sha, else the case id itself. */
+export function caseCanonicalIds(model: {
+  sources: { sha256: string; url?: string | null }[];
+  packs: { pack_dir: string; source_sha256?: string | null }[];
+}): Map<string, string> {
+  const bySha = new Map(model.sources.map((s) => [s.sha256, s]));
+  const out = new Map<string, string>();
+  for (const p of model.packs) {
+    const caseId = p.pack_dir.split(/[/\\]/).filter(Boolean).pop();
+    if (!caseId) continue;
+    const src = p.source_sha256 ? bySha.get(p.source_sha256) : undefined;
+    out.set(caseId, src?.url?.trim() || p.source_sha256 || caseId);
+  }
+  return out;
 }
 
 /** Theme-card source badge: null hides it. `sources` counts only INDEXED

--- a/console-ui/src/pages/KnowledgePage.tsx
+++ b/console-ui/src/pages/KnowledgePage.tsx
@@ -20,6 +20,7 @@ import { AgeLabel, EmptyState, ModelGate, PageHelp } from '../components/ui';
 import { useI18n } from '../i18n';
 import { fetchThemes } from '../lib/api';
 import {
+  caseCanonicalIds,
   isMiscTheme,
   sortThemeWall,
   themeRoute,
@@ -157,7 +158,11 @@ function KnowledgeBody({ model }: { model: IndexModel }) {
       { replace: true },
     );
   };
-  const wall = sortThemeWall(themeWall(model.claims, themes), sortKey, sortDir);
+  const wall = sortThemeWall(
+    themeWall(model.claims, themes, caseCanonicalIds(model)),
+    sortKey,
+    sortDir,
+  );
 
   return (
     <>


### PR DESCRIPTION
Theme cards counted distinct **case ids**; a re-captured article (same URL, different content sha — hash dedup can't catch it) inflated the count: the operator's example theme showed **2 sources** while resting on one document. The live vault has **58 duplicate-URL groups** (of 1479 URL-bearing sources).

Fix: `caseCanonicalIds(model)` maps case id → source URL (fallback sha, then case id); `themeWall` takes the optional map and counts distinct canonical identities. The flagged example now honestly shows **1 source** with the single-source warning — the exact signal the badge exists for.

Not in scope (follow-up candidates): intake-level URL dedup, and retiring the 58 existing extra copies (claims already cite both cases; needs a data-ops pass, not a display fix).

Tests: vitest 151/151 (new canonical-collapse + orphan-pack fallback case), tsc clean.