### PR TITLE
feat(intake): URL dedup for pre-intake legacy sources + intake-dedup-urls command

### DIFF
--- a/crates/ovp-cli/src/commands/intake.rs
+++ b/crates/ovp-cli/src/commands/intake.rs
@@ -70,3 +70,49 @@ pub fn run(args: IntakeArgs) -> Result<(), CliError> {
     );
     Ok(())
 }
+
+/// `intake-dedup-urls` — late URL dedup for pre-intake legacy copies (the
+/// intake ledger only reaches back to its go-live; see
+/// `park_legacy_url_duplicates`). Dry-run unless `apply`.
+pub fn run_dedup_urls(
+    vault_root: &std::path::Path,
+    apply: bool,
+    date: String,
+) -> Result<(), CliError> {
+    let _lock = if apply {
+        Some(ovp_intake::RunLock::acquire(vault_root).map_err(CliError::Io)?)
+    } else {
+        None
+    };
+    let cfg = IntakeConfig::new(
+        vault_root.to_path_buf(),
+        date.clone(),
+        format!("intake-dedup-{date}"),
+    );
+    let groups =
+        ovp_intake::park_legacy_url_duplicates(&cfg, !apply).map_err(CliError::Io)?;
+    if groups.is_empty() {
+        println!("intake-dedup-urls: no duplicate-URL groups in the processed tree");
+        return Ok(());
+    }
+    let mut parked_total = 0usize;
+    for g in &groups {
+        println!("{}", g.url);
+        println!("  keep {}", g.kept);
+        for rec in &g.parked {
+            parked_total += 1;
+            match &rec.to {
+                Some(to) => println!("  park {} → {to}", rec.from),
+                None => println!("  park {}", rec.from),
+            }
+        }
+    }
+    println!(
+        "intake-dedup-urls: {} group(s), {} copy(ies) parked{}",
+        groups.len(),
+        parked_total,
+        if apply { " — run `ovp2 index` (or wait for daily) to refresh projections" }
+        else { " — dry-run, nothing moved; pass --apply to execute" },
+    );
+    Ok(())
+}

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -260,6 +260,17 @@ enum Cmd {
         #[arg(long)]
         dry_run: bool,
     },
+    /// OPS — late URL dedup for pre-intake legacy sources: processed copies
+    /// sharing a URL are parked under the duplicates dir (oldest copy kept),
+    /// with normal Duplicate ledger records. Packs and crystal citations stay
+    /// resolvable. Dry-run by default; pass --apply to move files.
+    IntakeDedupUrls {
+        #[arg(long)]
+        vault_root: PathBuf,
+        /// Actually move files and append ledger records (default: plan only).
+        #[arg(long)]
+        apply: bool,
+    },
     /// PRODUCT — materialize Pinboard bookmarks as notes in
     /// `50-Inbox/02-Pinboard/` (URL-deduped against `.ovp/pinboard-sync.jsonl`
     /// and the intake ledger). Offline via `--fixture <export.json>`; live API
@@ -1610,6 +1621,9 @@ fn main() -> ExitCode {
                 run_id,
                 dry_run,
             })
+        }
+        Cmd::IntakeDedupUrls { vault_root, apply } => {
+            commands::intake::run_dedup_urls(&vault_root, apply, today_iso())
         }
         Cmd::PinboardSync {
             vault_root,

--- a/crates/ovp-intake/src/lib.rs
+++ b/crates/ovp-intake/src/lib.rs
@@ -34,7 +34,10 @@ pub use pinboard::{
 };
 #[cfg(feature = "pinboard-live")]
 pub use pinboard::LivePinboardFetch;
-pub use sweep::{sweep_intake, IntakeConfig, SweepOutcome, MIN_READER_BODY_CHARS};
+pub use sweep::{
+    park_legacy_url_duplicates, processed_tree_urls, sweep_intake, IntakeConfig, LegacyDupGroup,
+    SweepOutcome, MIN_READER_BODY_CHARS,
+};
 pub use vaultops::{
     append_jsonl, append_pipeline_event, hex_sha256, read_jsonl, rel_to, safe_move, write_new,
     PipelineLogEvent, RunLock,

--- a/crates/ovp-intake/src/sweep.rs
+++ b/crates/ovp-intake/src/sweep.rs
@@ -142,6 +142,12 @@ pub fn sweep_intake(
     let mut known_hashes = known_content_hashes(&existing);
     known_hashes.extend(extra_known_hashes.iter().cloned());
     let mut urls = known_urls(&existing);
+    // The ledger only reaches back to its own go-live; sources processed
+    // BEFORE intake existed are invisible to `known_urls`, so a re-clip of a
+    // legacy article used to slip through as a second full copy (58 such
+    // pairs found in the live vault, 2026-08-07). The processed tree itself
+    // is the missing dedup authority.
+    urls.extend(processed_tree_urls(&cfg.vault_root, &layout)?);
     let flagged = flagged_hashes(&existing);
 
     let mut outcome = SweepOutcome { dry_run, ..Default::default() };
@@ -274,6 +280,105 @@ pub fn sweep_intake(
         }
     }
     Ok(outcome)
+}
+
+/// URLs of every source already living under the processed tree (including
+/// previously parked duplicates). Best-effort per file: an unparseable or
+/// URL-less note contributes nothing — this is a dedup net, not a validator.
+pub fn processed_tree_urls(
+    vault_root: &Path,
+    layout: &VaultLayout,
+) -> Result<HashSet<String>, String> {
+    let root = vault_root.join(layout.processed_root());
+    let mut urls = HashSet::new();
+    if !root.is_dir() {
+        return Ok(urls);
+    }
+    for path in collect_markdown(&root)? {
+        if let Ok(s) = read_source_from_path(&path)
+            && !s.source_url.is_empty()
+        {
+            urls.insert(s.source_url);
+        }
+    }
+    Ok(urls)
+}
+
+/// One planned/performed parking from [`park_legacy_url_duplicates`].
+#[derive(Debug)]
+pub struct LegacyDupGroup {
+    pub url: String,
+    /// Vault-relative path of the copy KEPT (the oldest by path order —
+    /// processed paths embed `YYYY-MM/YYYY-MM-DD_…`, so path order is capture
+    /// order).
+    pub kept: String,
+    /// Ledger records for the parked newer copies.
+    pub parked: Vec<IntakeRecord>,
+}
+
+/// Late disposition for pre-intake legacy copies: find processed sources
+/// sharing a URL and park every copy but the oldest under the duplicates dir,
+/// with a normal `Duplicate` ledger record (`dup_of: url:<u>`). Exactly the
+/// disposition intake would have applied had the ledger existed at capture
+/// time. Parked copies KEEP their reader pack and source row, so crystal
+/// claims citing their case ids stay resolvable — this collapses the library
+/// and the counts, it never breaks provenance. Idempotent: a second run finds
+/// no groups (the walk excludes the duplicates dir).
+pub fn park_legacy_url_duplicates(
+    cfg: &IntakeConfig,
+    dry_run: bool,
+) -> Result<Vec<LegacyDupGroup>, String> {
+    let layout = VaultLayout::new();
+    let ledger_path = cfg.vault_root.join(layout.intake_ledger());
+    let log_path = cfg.vault_root.join(layout.pipeline_log());
+    let root = cfg.vault_root.join(layout.processed_root());
+    // The duplicates tree lives inside the processed root — exclude it from
+    // the walk (already-parked copies must not re-enter grouping).
+    let dup_root = root.join("duplicates");
+
+    let mut by_url: std::collections::BTreeMap<String, Vec<(PathBuf, String)>> =
+        std::collections::BTreeMap::new();
+    if root.is_dir() {
+        for path in collect_markdown(&root)? {
+            if path.starts_with(&dup_root) {
+                continue; // already parked
+            }
+            let Ok(s) = read_source_from_path(&path) else { continue };
+            if s.source_url.is_empty() {
+                continue;
+            }
+            let bytes =
+                std::fs::read(&path).map_err(|e| format!("reading {}: {e}", path.display()))?;
+            by_url.entry(s.source_url).or_default().push((path, hex_sha256(&bytes)));
+        }
+    }
+
+    let mut groups = Vec::new();
+    for (url, mut copies) in by_url {
+        if copies.len() < 2 {
+            continue;
+        }
+        copies.sort_by(|a, b| a.0.cmp(&b.0));
+        let kept = rel_to(&cfg.vault_root, &copies[0].0);
+        let mut parked = Vec::new();
+        for (path, sha256) in &copies[1..] {
+            let from = rel_to(&cfg.vault_root, path);
+            let rec = dispose_duplicate(
+                cfg,
+                &layout,
+                path,
+                &from,
+                sha256,
+                format!("url:{url}"),
+                &ledger_path,
+                &log_path,
+                dry_run,
+            )?;
+            parked.push(rec);
+        }
+        groups.push(LegacyDupGroup { url, kept, parked });
+    }
+    Ok(groups)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/ovp-intake/tests/intake_e2e.rs
+++ b/crates/ovp-intake/tests/intake_e2e.rs
@@ -383,3 +383,89 @@ fn reserved_tags_skip_terminally_and_force_past_the_size_gate() {
         skip_rec.note
     );
 }
+
+// -- legacy URL dedup (pre-intake copies) ------------------------------------
+
+#[test]
+fn sweep_dedups_against_pre_intake_processed_sources() {
+    // The intake ledger only reaches back to its go-live; a source processed
+    // BEFORE intake existed has no Ingested record. Re-clipping its URL must
+    // still park as a duplicate — the processed tree is the dedup authority
+    // the ledger can't be.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let processed = root.join("50-Inbox/03-Processed/2026-04");
+    std::fs::create_dir_all(&processed).unwrap();
+    std::fs::write(
+        processed.join("2026-04-05_Legacy Article.md"),
+        clip("Legacy Article", "https://e.x/legacy", LONG_BODY),
+    )
+    .unwrap();
+
+    let clippings = root.join("Clippings");
+    std::fs::create_dir_all(&clippings).unwrap();
+    std::fs::write(
+        clippings.join("reclip.md"),
+        clip("Legacy Article (reclipped)", "https://e.x/legacy", &format!("{LONG_BODY} v2")),
+    )
+    .unwrap();
+
+    let out = sweep_intake(&cfg(root), &HashSet::new(), false).unwrap();
+    assert_eq!(out.ingested.len(), 0, "{out:?}");
+    assert_eq!(out.duplicates.len(), 1);
+    assert_eq!(out.duplicates[0].dup_of.as_deref(), Some("url:https://e.x/legacy"));
+    // The legacy original stays untouched.
+    assert!(processed.join("2026-04-05_Legacy Article.md").exists());
+}
+
+#[test]
+fn park_legacy_url_duplicates_keeps_oldest_and_is_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let april = root.join("50-Inbox/03-Processed/2026-04");
+    let may = root.join("50-Inbox/03-Processed/2026-05");
+    std::fs::create_dir_all(&april).unwrap();
+    std::fs::create_dir_all(&may).unwrap();
+    // Same URL captured twice (different bytes), plus an unrelated unique.
+    std::fs::write(
+        april.join("2026-04-05_Twice.md"),
+        clip("Twice", "https://e.x/twice", LONG_BODY),
+    )
+    .unwrap();
+    std::fs::write(
+        may.join("2026-05-07_Twice.md"),
+        clip("Twice (reclip)", "https://e.x/twice", &format!("{LONG_BODY} v2")),
+    )
+    .unwrap();
+    std::fs::write(
+        may.join("2026-05-08_Unique.md"),
+        clip("Unique", "https://e.x/unique", LONG_BODY),
+    )
+    .unwrap();
+
+    // Dry-run: plans the park, moves nothing.
+    let plan = ovp_intake::park_legacy_url_duplicates(&cfg(root), true).unwrap();
+    assert_eq!(plan.len(), 1);
+    assert_eq!(plan[0].url, "https://e.x/twice");
+    assert!(plan[0].kept.contains("2026-04-05_Twice"), "oldest kept: {}", plan[0].kept);
+    assert_eq!(plan[0].parked.len(), 1);
+    assert!(may.join("2026-05-07_Twice.md").exists(), "dry-run must not move");
+    assert!(read_intake_ledger(&root.join(".ovp/intake.jsonl")).unwrap().is_empty());
+
+    // Apply: newer copy parked with a normal Duplicate ledger record.
+    let done = ovp_intake::park_legacy_url_duplicates(&cfg(root), false).unwrap();
+    assert_eq!(done.len(), 1);
+    let to = done[0].parked[0].to.as_ref().unwrap();
+    assert!(to.starts_with("50-Inbox/03-Processed/duplicates/2026-06/"), "got {to}");
+    assert!(root.join(to).exists());
+    assert!(!may.join("2026-05-07_Twice.md").exists());
+    assert!(april.join("2026-04-05_Twice.md").exists());
+    assert!(may.join("2026-05-08_Unique.md").exists(), "unique untouched");
+    let ledger = read_intake_ledger(&root.join(".ovp/intake.jsonl")).unwrap();
+    assert_eq!(ledger.len(), 1);
+    assert_eq!(ledger[0].dup_of.as_deref(), Some("url:https://e.x/twice"));
+
+    // Second run: nothing left to do (parked copies are excluded from the walk).
+    let again = ovp_intake::park_legacy_url_duplicates(&cfg(root), false).unwrap();
+    assert!(again.is_empty(), "{again:?}");
+}


### PR DESCRIPTION
User-approved follow-up to #429 ("可以 1 和 2清理一下").

**Prevention** — `sweep_intake` now folds the whole processed tree's URLs (incl. parked duplicates) into the known-URL set. The intake ledger only reaches back to its 2026-06-15 go-live; sources processed before that were invisible to `known_urls`, so re-clipping a legacy URL produced a second full copy that flowed all the way into crystal citations.

**Cleanup** — `park_legacy_url_duplicates` + `ovp2 intake-dedup-urls` (dry-run default / `--apply`): processed copies sharing a URL are parked under `duplicates/<month>/` with the normal `Duplicate` ledger record (`dup_of: url:<u>`) — exactly the disposition intake would have applied at capture time. Oldest copy kept (path order = capture order). Parked copies keep their pack and source row so claim case-ids stay resolvable: collapses the library and counts, never breaks provenance. Idempotent (parked tree excluded from the walk).

**Already run on the live vault**: 54 groups / 54 copies parked, `ovp2 index` rebuilt clean — dup rows 3→43 (11 groups were byte-identical twins already sharing one source row), processed 1455, claims unchanged (durable 1103).

Tests: intake unit 29 + e2e 13 (new: legacy-URL sweep dedup; park keeps-oldest / dry-run / apply / idempotency), ovp-daily + ovp-cli green.