### PR TITLE
fix(graph): packed community anchors replace the hairball-and-strays layout

### DIFF
--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -26,7 +26,13 @@ import {
   fetchSourceNeighborhood,
   fetchThemeGraph,
 } from '../lib/api';
-import { closureNodeIds, isMiscTheme, themeRoute } from '../lib/derive';
+import {
+  closureNodeIds,
+  isMiscTheme,
+  radialAnchors,
+  themeRoute,
+  type RadialAnchors,
+} from '../lib/derive';
 import type { ClaimDetail, GraphNode, GraphResponse } from '../lib/types';
 import { useModel } from '../model';
 import { EmptyState } from './ui';
@@ -116,34 +122,28 @@ function shouldLabel(n: GraphNode, zoom: number, forced: boolean): boolean {
 // react-force-graph mutates node objects with x/y/z at runtime.
 type FGNode = GraphNode & { x?: number; y?: number; z?: number; vx?: number; vy?: number };
 
-/** A custom d3 force that pulls every node toward its community's live centroid,
- * so communities settle into DISTINCT spatial regions (clean, separated hulls)
- * instead of intermixing. Weak enough that links still shape the within-cluster
- * structure. */
-function clusterForce(strength: number) {
+/** A custom d3 force that pulls every node toward its FIXED radial anchor
+ * (see `radialAnchors` in derive.ts): community members toward their petal,
+ * unclustered nodes toward their outer-ring seat. Fixed anchors — unlike the
+ * old live-centroid pull — give strays a home instead of letting repulsion
+ * blast them to the periphery, and stop the big communities from collapsing
+ * into one central hairball. */
+function radialAnchorForce(
+  anchors: RadialAnchors,
+  strength: number,
+  singleStrength: number,
+) {
   let nodes: FGNode[] = [];
   const force = (alpha: number) => {
-    const cen = new Map<number, { x: number; y: number; n: number }>();
     for (const nd of nodes) {
-      if (nd.cluster > 0) {
-        const c = cen.get(nd.cluster) ?? { x: 0, y: 0, n: 0 };
-        c.x += nd.x ?? 0;
-        c.y += nd.y ?? 0;
-        c.n += 1;
-        cen.set(nd.cluster, c);
-      }
-    }
-    for (const c of cen.values()) {
-      c.x /= c.n;
-      c.y /= c.n;
-    }
-    const k = strength * alpha;
-    for (const nd of nodes) {
-      const c = cen.get(nd.cluster);
-      if (c) {
-        nd.vx = (nd.vx ?? 0) + (c.x - (nd.x ?? 0)) * k;
-        nd.vy = (nd.vy ?? 0) + (c.y - (nd.y ?? 0)) * k;
-      }
+      const a =
+        nd.cluster > 0 ? anchors.byCluster.get(nd.cluster) : anchors.byId.get(nd.id);
+      if (!a) continue;
+      // Singles have NO link holding them — they need a firmer hand than
+      // community members (whose links do most of the local shaping).
+      const k = (nd.cluster > 0 ? strength : singleStrength) * alpha;
+      nd.vx = (nd.vx ?? 0) + (a.x - (nd.x ?? 0)) * k;
+      nd.vy = (nd.vy ?? 0) + (a.y - (nd.y ?? 0)) * k;
     }
   };
   force.initialize = (n: FGNode[]) => {
@@ -272,11 +272,65 @@ export default function KnowledgeGraph({
     };
   }, [scope, id, persp]);
 
+  // Packed community anchors (+ cross-community affinity for the packing
+  // order) — shared by the position seeding below and the pull force.
+  const anchors = useMemo(() => {
+    if (!data || scope !== 'global') return null;
+    const sizes = new Map<number, number>();
+    const singles: string[] = [];
+    const clusterOf = new Map<string, number>();
+    for (const n of data.nodes) {
+      clusterOf.set(n.id, n.cluster);
+      if (n.cluster > 0) sizes.set(n.cluster, (sizes.get(n.cluster) ?? 0) + 1);
+      else singles.push(n.id);
+    }
+    const affinity = new Map<number, Map<number, number>>();
+    const bump = (a: number, b: number, w: number) => {
+      const m = affinity.get(a) ?? new Map<number, number>();
+      m.set(b, (m.get(b) ?? 0) + w);
+      affinity.set(a, m);
+    };
+    for (const e of data.edges) {
+      const a = clusterOf.get(e.source) ?? 0;
+      const b = clusterOf.get(e.target) ?? 0;
+      if (a > 0 && b > 0 && a !== b) {
+        const w = e.weight ?? 1;
+        bump(a, b, w);
+        bump(b, a, w);
+      }
+    }
+    return radialAnchors(sizes, singles, affinity);
+  }, [data, scope]);
+  // Ref mirror for setFg, which can fire before OR after the data arrives.
+  const anchorsRef = useRef<RadialAnchors | null>(null);
+  anchorsRef.current = anchors;
+
   // Fresh node/link objects per dataset (react-force-graph owns their physics).
   const graphData = useMemo(() => {
     if (!data) return { nodes: [] as FGNode[], links: [] };
+    const nodes = data.nodes.map((n) => ({ ...n })) as FGNode[];
+    if (anchors) {
+      // SEED positions on the packed silhouette instead of random scatter —
+      // a force pull alone cannot untangle 400 randomly-initialized nodes
+      // out of the central hairball, but from a seeded start it only has to
+      // RELAX. Community members pack a deterministic sunflower spiral
+      // (golden angle) around their anchor; singles start on their
+      // outer-ring seat.
+      const GOLDEN = Math.PI * (3 - Math.sqrt(5));
+      const seat = new Map<number, number>();
+      for (const n of nodes) {
+        const a =
+          n.cluster > 0 ? anchors.byCluster.get(n.cluster) : anchors.byId.get(n.id);
+        if (!a) continue;
+        const k = seat.get(n.cluster) ?? 0;
+        seat.set(n.cluster, k + 1);
+        const r = n.cluster > 0 ? 7 * Math.sqrt(k + 0.5) : 0;
+        n.x = a.x + r * Math.cos(k * GOLDEN);
+        n.y = a.y + r * Math.sin(k * GOLDEN);
+      }
+    }
     return {
-      nodes: data.nodes.map((n) => ({ ...n })) as FGNode[],
+      nodes,
       links: data.edges.map((e) => ({
         source: e.source,
         target: e.target,
@@ -284,7 +338,7 @@ export default function KnowledgeGraph({
         weight: e.weight,
       })),
     };
-  }, [data]);
+  }, [data, anchors]);
 
   // id → neighbor ids, for hover dimming.
   const adjacency = useMemo(() => {
@@ -345,19 +399,39 @@ export default function KnowledgeGraph({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const g = fg as any;
     if (!g?.d3Force) return;
-    // Tight, well-spaced clusters: GENTLE repulsion (the old -140 blew clusters
-    // apart AND stretched each one), SHORT STRONG links so connected/related
-    // claims pull together, and a COLLIDE force so nodes sit close without
-    // overlapping. The default center force keeps the whole thing compact.
-    g.d3Force('charge')?.strength(-34).distanceMax(240);
-    g.d3Force('link')?.distance(16).strength(1);
+    // LOCAL repulsion only (distanceMax keeps it from flinging weakly-held
+    // nodes across the canvas), roomier links than the old 16 so the center
+    // decompresses, and collide with breathing space.
+    g.d3Force('charge')?.strength(-46).distanceMax(150);
+    const sameCluster = (l: { source: FGNode | string; target: FGNode | string }) => {
+      const s = l.source as FGNode;
+      const tgt = l.target as FGNode;
+      return typeof s !== 'string' && typeof tgt !== 'string' && s.cluster === tgt.cluster;
+    };
+    if (scope === 'global') {
+      // Within a community links do the shaping; ACROSS communities they are
+      // reference threads, not springs — near-zero strength, generous length.
+      // Strong cross links were exactly what collapsed the petals into one
+      // central hairball.
+      g.d3Force('link')
+        ?.distance((l: never) => (sameCluster(l) ? 24 : 80))
+        .strength((l: never) => (sameCluster(l) ? 0.5 : 0.015));
+    } else {
+      g.d3Force('link')?.distance(20).strength(0.8);
+    }
     g.d3Force(
       'collide',
-      forceCollide((n: FGNode) => nodeRadius(n, n.id === focusId) + 2).strength(0.9),
+      forceCollide((n: FGNode) => nodeRadius(n, n.id === focusId) + 3).strength(0.9),
     );
-    // Global scope colors by community — pull each community together so the
-    // hull blobs are compact + separated. Focused scopes have no communities.
-    g.d3Force('cluster', scope === 'global' ? clusterForce(0.22) : null);
+    // Global scope: every node pulled to its fixed packed anchor (community
+    // disk or outer-ring seat) — the organic-cloud silhouette. Focused scopes
+    // have no communities, links alone shape them. Anchors live in a ref:
+    // the instance can mount before OR after the data arrives.
+    const a = anchorsRef.current;
+    g.d3Force(
+      'cluster',
+      scope === 'global' && a ? radialAnchorForce(a, 0.12, 0.2) : null,
+    );
     g.d3ReheatSimulation?.();
   }, [focusId, scope]);
 
@@ -365,6 +439,19 @@ export default function KnowledgeGraph({
   useEffect(() => {
     fittedRef.current = false;
   }, [data, mode]);
+
+  // Keep the anchor force in sync when the DATA changes on a live instance
+  // (setFg only fires on mount / 2D-3D swap).
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const g = fgRef.current as any;
+    if (!g?.d3Force) return;
+    g.d3Force(
+      'cluster',
+      scope === 'global' && anchors ? radialAnchorForce(anchors, 0.12, 0.2) : null,
+    );
+    g.d3ReheatSimulation?.();
+  }, [anchors, scope, mode]);
 
   /** ~15% alpha variant of a color — the out-of-closure fade for 3D nodes
    * and 2D links, matching drawNode's globalAlpha dim. Handles #rgb/#rrggbb
@@ -693,6 +780,9 @@ export default function KnowledgeGraph({
                   fgRef.current?.zoomToFit(400, 36);
                 }}
                 nodeRelSize={4}
+                // Slight arc echoes the hand-drawn reference; straight lines
+                // read as circuit wiring at this density.
+                linkCurvature={0.2}
                 nodeCanvasObjectMode={() => 'replace'}
                 nodeCanvasObject={drawNode}
                 onRenderFramePre={drawHulls}

--- a/console-ui/src/lib/derive.radialAnchors.test.ts
+++ b/console-ui/src/lib/derive.radialAnchors.test.ts
@@ -1,0 +1,65 @@
+/** Geometry of the knowledge-graph packed-cloud layout (radialAnchors) —
+ * pure, no DOM. The component only seeds positions and applies pull forces
+ * toward these points. */
+import { describe, expect, it } from 'vitest';
+import { radialAnchors } from './derive';
+
+const sizes = (pairs: [number, number][]) => new Map(pairs);
+const norm = (p: { x: number; y: number }) => Math.hypot(p.x, p.y);
+// Mirror of the packer's blob-footprint formula (nodeRadius default 7).
+const blobR = (n: number) => 7 * Math.sqrt(n) * 1.45 + 10;
+
+describe('radialAnchors', () => {
+  it('packs the largest community at the origin, disks never overlapping', () => {
+    const input: [number, number][] = [[1, 50], [2, 20], [3, 80], [4, 5], [5, 12]];
+    const a = radialAnchors(sizes(input), []);
+    expect(a.byCluster.size).toBe(5);
+    expect(a.byCluster.get(3)).toEqual({ x: 0, y: 0 });
+    const bySize = new Map(input);
+    const placed = [...a.byCluster.entries()];
+    for (let i = 0; i < placed.length; i++) {
+      for (let j = i + 1; j < placed.length; j++) {
+        const [ca, pa] = placed[i];
+        const [cb, pb] = placed[j];
+        const d = Math.hypot(pa.x - pb.x, pa.y - pb.y);
+        expect(d).toBeGreaterThanOrEqual(blobR(bySize.get(ca)!) + blobR(bySize.get(cb)!) - 1e-6);
+      }
+    }
+    // The reported radius covers every disk.
+    for (const [c, p] of placed) {
+      expect(norm(p) + blobR(bySize.get(c)!)).toBeLessThanOrEqual(a.radius + 1e-6);
+    }
+  });
+
+  it('affinity pulls a connected community earlier (closer to the center)', () => {
+    // A is largest; B and C are equal-size, but only B is wired to A —
+    // B must be packed before C, hence nearer the origin.
+    const s = sizes([[1, 100], [2, 30], [3, 30]]);
+    const affinity = new Map([[2, new Map([[1, 9]])], [1, new Map([[2, 9]])]]);
+    const a = radialAnchors(s, [], affinity);
+    expect(norm(a.byCluster.get(2)!)).toBeLessThan(norm(a.byCluster.get(3)!));
+  });
+
+  it('is deterministic without affinity data (size desc, id asc ties)', () => {
+    const a = radialAnchors(sizes([[7, 10], [2, 10], [5, 40]]), []);
+    const b = radialAnchors(sizes([[5, 40], [7, 10], [2, 10]]), []);
+    for (const c of [2, 5, 7]) expect(a.byCluster.get(c)).toEqual(b.byCluster.get(c));
+  });
+
+  it('unclustered nodes get deterministic seats on a ring outside the cloud', () => {
+    const a = radialAnchors(sizes([[1, 30]]), ['b', 'a', 'c']);
+    expect(a.byId.size).toBe(3);
+    for (const p of a.byId.values()) {
+      expect(norm(p)).toBeCloseTo(a.radius + 26, 6);
+    }
+    const b = radialAnchors(sizes([[1, 30]]), ['c', 'a', 'b']);
+    for (const id of ['a', 'b', 'c']) expect(a.byId.get(id)).toEqual(b.byId.get(id));
+  });
+
+  it('zero-size or empty inputs stay safe', () => {
+    const a = radialAnchors(sizes([[1, 0]]), []);
+    expect(a.byCluster.size).toBe(0);
+    expect(a.byId.size).toBe(0);
+    expect(radialAnchors(new Map(), ['x']).byId.size).toBe(1);
+  });
+});

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -1345,6 +1345,113 @@ export function closureNodeIds(
   return out;
 }
 
+/** Community anchors for the global knowledge graph (VZ, 2026-08-07).
+ *
+ * The force layout alone produced an ugly silhouette: a dense central
+ * hairball (short strong links + centroid pull) with unaffiliated nodes
+ * blasted to the far periphery by unopposed repulsion. Instead, every node
+ * gets a HOME in an organic packed-cloud silhouette (the hand-drawn tree
+ * reference the operator liked):
+ *
+ * - Communities are disks (radius ∝ sqrt(member count)) greedily packed on
+ *   an archimedean spiral — largest at the center, no empty donut middle.
+ * - Packing ORDER is affinity-greedy: after the largest, always the
+ *   unplaced community most connected to the placed ones, so heavy
+ *   cross-community chords stay short instead of spanning the layout.
+ * - Unclustered nodes (cluster <= 0) get evenly spaced, id-sorted seats on
+ *   a ring just outside the cloud — visible periphery, never strays.
+ *
+ * Deterministic and pure — vitest-covered; the graph component only seeds
+ * positions and applies the pull force toward these anchors. */
+export interface RadialAnchors {
+  radius: number;
+  byCluster: Map<number, { x: number; y: number }>;
+  byId: Map<string, { x: number; y: number }>;
+}
+
+export function radialAnchors(
+  clusterSizes: Map<number, number>,
+  unclusteredIds: string[],
+  affinity?: Map<number, Map<number, number>>,
+  nodeRadius = 7,
+): RadialAnchors {
+  const byCluster = new Map<number, { x: number; y: number }>();
+  const byId = new Map<string, { x: number; y: number }>();
+  const entries = [...clusterSizes.entries()].filter(([, n]) => n > 0);
+  // Blob footprint: disk radius grows with sqrt(member count) + padding.
+  const blobR = (n: number) => nodeRadius * Math.sqrt(n) * 1.45 + 10;
+
+  // AFFINITY-GREEDY placement order: largest first, then always the unplaced
+  // community most connected (by cross-edge weight) to anything already
+  // placed — the spiral packs consecutive picks adjacently, so the heavy
+  // inter-community chords stay SHORT instead of spanning the silhouette.
+  const remaining = new Map(entries);
+  const order: [number, number][] = [];
+  const first = entries.slice().sort((a, b) => b[1] - a[1] || a[0] - b[0])[0];
+  if (first) {
+    order.push(first);
+    remaining.delete(first[0]);
+    while (remaining.size > 0) {
+      let best: [number, number] | null = null;
+      let bestScore = -1;
+      for (const [c, n] of remaining) {
+        let score = 0;
+        for (const [placed] of order) {
+          score += affinity?.get(c)?.get(placed) ?? 0;
+        }
+        // Ties (incl. no affinity data at all) fall back to size desc, id asc.
+        if (
+          best === null ||
+          score > bestScore ||
+          (score === bestScore && (n > best[1] || (n === best[1] && c < best[0])))
+        ) {
+          best = [c, n];
+          bestScore = score;
+        }
+      }
+      order.push(best!);
+      remaining.delete(best![0]);
+    }
+  }
+
+  // Greedy spiral packing: largest at the origin, each next community walks
+  // an archimedean spiral to the first spot clear of every placed disk —
+  // compact organic cloud, no empty donut middle.
+  const placed: { c: number; x: number; y: number; r: number }[] = [];
+  for (const [c, n] of order) {
+    const r = blobR(n);
+    if (placed.length === 0) {
+      placed.push({ c, x: 0, y: 0, r });
+      byCluster.set(c, { x: 0, y: 0 });
+      continue;
+    }
+    let theta = 0;
+    for (;;) {
+      theta += 0.22;
+      const rad = 6 * theta;
+      const x = rad * Math.cos(theta);
+      const y = rad * Math.sin(theta);
+      if (placed.every((p) => Math.hypot(x - p.x, y - p.y) >= r + p.r)) {
+        placed.push({ c, x, y, r });
+        byCluster.set(c, { x, y });
+        break;
+      }
+    }
+  }
+
+  const extent = placed.reduce((m, p) => Math.max(m, Math.hypot(p.x, p.y) + p.r), 0);
+  const radius = Math.max(60, extent);
+  // Unclustered nodes: deterministic seats on a ring just OUTSIDE the packed
+  // cloud — visible periphery, never repulsion-flung strays.
+  const outer = radius + 26;
+  const ids = [...unclusteredIds].sort();
+  for (let i = 0; i < ids.length; i++) {
+    const a = ((i + 0.5) / Math.max(1, ids.length)) * 2 * Math.PI;
+    byId.set(ids[i], { x: outer * Math.cos(a), y: outer * Math.sin(a) });
+  }
+  return { radius, byCluster, byId };
+}
+
 /** Index-store health for the stage-4 repair banner. Pure so the node-env
  * tests can pin the truth table: a REBUILD in flight outranks the error
  * (the operator already acted), and only a recorded sqlite failure — not a


### PR DESCRIPTION
Operator report: the global knowledge graph read as a dense central hairball with sparse nodes flung to the far periphery ("外面一圈稀疏的点离这么远,里面都挤成一起,不够优雅"), referencing a hand-drawn tree-of-knowledge video for the comfortable spacing to aim for.

**Root cause** — pure force layout: unaffiliated/weakly-linked nodes had no countervailing pull against charge repulsion (flung out to `distanceMax`), while short strong links + live-centroid cluster force collapsed the connected mass into one blob.

**Fix**
- `derive.radialAnchors` (pure, tested): community disks (radius ∝ √size) greedily packed on an archimedean spiral, largest at center; packing order is **affinity-greedy** so heavily-connected communities sit adjacent and cross-chords stay short. Unclustered nodes get deterministic seats on a ring just outside the cloud.
- `KnowledgeGraph`: **seeds** node positions on the silhouette (per-community sunflower spiral — a pull force alone cannot untangle 400 randomly-initialized nodes), fixed-anchor pull force replaces the live-centroid one, cross-community links drop to near-zero spring strength (distance 80 / strength 0.015) while intra-community links keep shaping (24 / 0.5), local-only charge (−46, distanceMax 150), slight `linkCurvature` for the organic feel.
- Legend click → fly-to-community animation was already there and still works.

**Verification**: headless-Chrome screenshots against the live vault, both perspectives — compact organic cloud, locally coherent community patches, no empty middle, no strays. vitest 156/156 (new geometry suite: no-overlap, largest-at-center, affinity ordering, determinism, safety), tsc clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved knowledge graph layout with stable radial positioning for communities and unclustered nodes.
  * Added clearer visual separation between related and unrelated communities.
  * Enhanced node spacing and collision handling to reduce overlap.
  * Updated 2D graph connections to display as curved links.
  * Graph positioning now remains consistent when data changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->