### PR TITLE
fix(graph): expandable legend for the grown community count

### DIFF
--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -62,6 +62,8 @@ const MAX_QUOTE_LENGTH = 160;
  * be zoomed in further. Below this the graph reads as a labelled constellation
  * of only its most important nodes — the level-of-detail the old view lacked. */
 const LABEL_BASE_ZOOM = 1.9;
+/** Legend rows shown before the "+N more" toggle expands the full list. */
+const LEGEND_COLLAPSED_COUNT = 8;
 
 interface DsTokens {
   link: string;
@@ -199,6 +201,7 @@ export default function KnowledgeGraph({
   const [closure, setClosure] = useState<{ forId: string; detail: ClaimDetail } | null>(null);
   const [hoverId, setHoverId] = useState<string | null>(null);
   const [fullscreen, setFullscreen] = useState(false);
+  const [legendOpen, setLegendOpen] = useState(false);
   const [mode, setMode] = useState<'2d' | '3d'>('2d');
   const [no3d, setNo3d] = useState(false);
   const [dims, setDims] = useState({ w: 0, h: height });
@@ -737,8 +740,14 @@ export default function KnowledgeGraph({
   };
 
   const empty = !error && data && data.nodes.length === 0;
-  const communitiesForLegend =
-    scope === 'global' ? (data?.communities ?? []).slice(0, 8) : [];
+  // Crystal growth pushed the community count past what a fixed strip can
+  // hold (40 live communities vs the old top-8 cut) — default stays compact,
+  // the "+N" toggle opens the FULL scrollable list with member counts.
+  const allCommunities = scope === 'global' ? (data?.communities ?? []) : [];
+  const communitiesForLegend = legendOpen
+    ? allCommunities
+    : allCommunities.slice(0, LEGEND_COLLAPSED_COUNT);
+  const legendHidden = allCommunities.length - communitiesForLegend.length;
 
   return (
     <div
@@ -887,7 +896,7 @@ export default function KnowledgeGraph({
             <div className="graph-note graph-controls-hint">{t('graph.controls3d')}</div>
           )}
           {communitiesForLegend.length > 0 && (
-            <div className="graph-legend">
+            <div className={`graph-legend${legendOpen ? ' graph-legend--open' : ''}`}>
               {communitiesForLegend.map((c) => (
                 <button
                   key={c.id}
@@ -905,9 +914,21 @@ export default function KnowledgeGraph({
                   />
                   <span className="tiny">
                     {isMiscTheme(c.label) ? t('theme.unclassified') : c.label}
+                    {legendOpen ? ` · ${c.size}` : ''}
                   </span>
                 </button>
               ))}
+              {(legendHidden > 0 || legendOpen) && (
+                <button
+                  type="button"
+                  className="graph-legend-item graph-legend-toggle tiny"
+                  onClick={() => setLegendOpen((v) => !v)}
+                >
+                  {legendOpen
+                    ? t('graph.legendLess')
+                    : t('graph.legendMore', { n: legendHidden })}
+                </button>
+              )}
             </div>
           )}
           {selected && (

--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -29,6 +29,7 @@ import {
 import {
   closureNodeIds,
   isMiscTheme,
+  legendCommunities,
   radialAnchors,
   themeRoute,
   type RadialAnchors,
@@ -743,11 +744,11 @@ export default function KnowledgeGraph({
   // Crystal growth pushed the community count past what a fixed strip can
   // hold (40 live communities vs the old top-8 cut) — default stays compact,
   // the "+N" toggle opens the FULL scrollable list with member counts.
-  const allCommunities = scope === 'global' ? (data?.communities ?? []) : [];
-  const communitiesForLegend = legendOpen
-    ? allCommunities
-    : allCommunities.slice(0, LEGEND_COLLAPSED_COUNT);
-  const legendHidden = allCommunities.length - communitiesForLegend.length;
+  const { visible: communitiesForLegend, hidden: legendHidden } = legendCommunities(
+    scope === 'global' ? (data?.communities ?? []) : [],
+    legendOpen,
+    LEGEND_COLLAPSED_COUNT,
+  );
 
   return (
     <div
@@ -922,11 +923,14 @@ export default function KnowledgeGraph({
                 <button
                   type="button"
                   className="graph-legend-item graph-legend-toggle tiny"
+                  aria-expanded={legendOpen}
                   onClick={() => setLegendOpen((v) => !v)}
                 >
                   {legendOpen
                     ? t('graph.legendLess')
-                    : t('graph.legendMore', { n: legendHidden })}
+                    : legendHidden === 1
+                      ? t('graph.legendMoreOne')
+                      : t('graph.legendMore', { n: legendHidden })}
                 </button>
               )}
             </div>

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -1886,6 +1886,19 @@ body {
   gap: 0.05rem;
   max-width: 45%;
 }
+/* Expanded: the full community list scrolls inside the canvas instead of
+   covering it; a soft surface keeps rows readable over dense regions. */
+.graph-legend--open {
+  max-height: calc(100% - 3.5rem);
+  overflow-y: auto;
+  background: color-mix(in srgb, var(--surface, #faf8f4) 88%, transparent);
+  border-radius: 8px;
+  padding: 0.25rem;
+}
+.graph-legend-toggle {
+  color: var(--accent);
+  font-family: var(--mono, monospace);
+}
 .graph-legend-item {
   display: flex;
   align-items: center;

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -605,6 +605,8 @@ export const en = {
     'The model spent its whole output budget thinking — retry, or simplify the question.',
   'ask.fail.overloaded': 'The provider is overloaded — retry shortly.',
   'ask.fail.network': 'Network failure reaching the provider — check connectivity or proxy.',
+  'graph.legendMore': '+{n} more communities',
+  'graph.legendLess': 'Show fewer',
 
   // automation / schedule explainer (System)
   'auto.title': 'Automation',

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -606,6 +606,7 @@ export const en = {
   'ask.fail.overloaded': 'The provider is overloaded — retry shortly.',
   'ask.fail.network': 'Network failure reaching the provider — check connectivity or proxy.',
   'graph.legendMore': '+{n} more communities',
+  'graph.legendMoreOne': '+1 more community',
   'graph.legendLess': 'Show fewer',
 
   // automation / schedule explainer (System)

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -572,6 +572,8 @@ export const zh: Record<keyof typeof en, string> = {
   'ask.fail.budgetExhausted': '模型把输出预算都花在思考上——重试或简化问题。',
   'ask.fail.overloaded': '提供商过载——稍后重试。',
   'ask.fail.network': '连接提供商的网络失败——检查网络或代理。',
+  'graph.legendMore': '还有 {n} 个社区',
+  'graph.legendLess': '收起',
 
   // automation / schedule explainer (System)
   'auto.title': '自动化',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -573,6 +573,7 @@ export const zh: Record<keyof typeof en, string> = {
   'ask.fail.overloaded': '提供商过载——稍后重试。',
   'ask.fail.network': '连接提供商的网络失败——检查网络或代理。',
   'graph.legendMore': '还有 {n} 个社区',
+  'graph.legendMoreOne': '还有 1 个社区',
   'graph.legendLess': '收起',
 
   // automation / schedule explainer (System)

--- a/console-ui/src/lib/derive.observability.test.ts
+++ b/console-ui/src/lib/derive.observability.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   failureHintKey,
+  legendCommunities,
   scheduleFailureStrip,
   themeSourceBadge,
 } from './derive';
@@ -77,6 +78,29 @@ describe('themeSourceBadge', () => {
     expect(themeSourceBadge({ sources: 4, durable: 5, caveated: 2 })).toEqual({
       n: 4,
       single: false,
+    });
+  });
+});
+
+describe('legendCommunities', () => {
+  const ids = (n: number) => Array.from({ length: n }, (_, i) => i + 1);
+
+  it('collapsed: top-N strip and the hidden remainder', () => {
+    expect(legendCommunities([], false, 8)).toEqual({ visible: [], hidden: 0 });
+    expect(legendCommunities(ids(8), false, 8)).toEqual({ visible: ids(8), hidden: 0 });
+    expect(legendCommunities(ids(9), false, 8)).toEqual({
+      visible: ids(8),
+      hidden: 1,
+    });
+    const forty = legendCommunities(ids(40), false, 8);
+    expect(forty.visible.length).toBe(8);
+    expect(forty.hidden).toBe(32);
+  });
+
+  it('open: the full list with nothing hidden', () => {
+    expect(legendCommunities(ids(40), true, 8)).toEqual({
+      visible: ids(40),
+      hidden: 0,
     });
   });
 });

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -1452,6 +1452,18 @@ export function radialAnchors(
   return { radius, byCluster, byId };
 }
 
+/** Knowledge-graph legend rows: compact top-N strip by default, the full
+ * list when open. `hidden` drives the "+N more" toggle (0 hides it). Pure —
+ * the component only renders the returned slice. */
+export function legendCommunities<T>(
+  all: T[],
+  open: boolean,
+  collapsedCount = 8,
+): { visible: T[]; hidden: number } {
+  const visible = open ? all : all.slice(0, collapsedCount);
+  return { visible, hidden: all.length - visible.length };
+}
+
 /** Index-store health for the stage-4 repair banner. Pure so the node-env
  * tests can pin the truth table: a REBUILD in flight outranks the error
  * (the operator already acted), and only a recorded sqlite failure — not a


### PR DESCRIPTION
The knowledge graph legend hard-sliced `communities` to 8 rows; the live vault now has **40** communities, so most had no legend entry (operator: "现在知识 crystal 多了之后,graph 左边那一列只能显示前几个").

- Default stays the compact top-8 strip.
- New `+N more communities` toggle expands the **full scrollable list** (bounded to the canvas height, soft surface so rows stay readable over dense regions); expanded rows show member counts (`label · size`); `Show fewer` collapses.
- Click-to-fly per row unchanged.

Verified with Playwright screenshots on the live vault: collapsed = top 8 + `+32 more communities`; expanded = all 40 with counts. tsc clean, vitest 156/156 (display-only change; no decision logic beyond the slice/toggle).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a collapsible community legend to the knowledge graph.
  * The legend initially shows up to eight communities and can expand to display the full list.
  * Expanded entries include community sizes and a scrollable layout.
  * Added localized expand and collapse controls in English and Simplified Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->