### PR TITLE
fix(graph): legend scroll + same-label cluster merge

### DIFF
--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -28,6 +28,7 @@ import {
 } from '../lib/api';
 import {
   closureNodeIds,
+  groupCommunities,
   isMiscTheme,
   legendCommunities,
   radialAnchors,
@@ -715,28 +716,29 @@ export default function KnowledgeGraph({
     fg?.cameraPosition(to, node, 600);
   };
 
-  // Legend click → fly to that community's centroid so you don't have to hunt
-  // for it (2D: center + zoom; 3D: pull the camera in on the cluster).
-  const focusCommunity = (cluster: number) => {
+  // Legend click → fly to a legend row's clusterS (same-label clusters merge
+  // into one row) so you don't have to hunt for them. 2D: zoom-to-fit the
+  // member nodes; 3D: pull the camera in on their combined centroid.
+  const focusCommunities = (clusters: number[]) => {
+    const want = new Set(clusters);
     const pts = (graphData.nodes as FGNode[]).filter(
-      (n) => n.cluster === cluster && n.x != null,
+      (n) => want.has(n.cluster) && n.x != null,
     );
     if (!pts.length) return;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const fg = fgRef.current as any;
     if (!fg) return;
-    const cx = pts.reduce((s, n) => s + (n.x ?? 0), 0) / pts.length;
-    const cy = pts.reduce((s, n) => s + (n.y ?? 0), 0) / pts.length;
     setHoverId(null);
     if (mode === '3d') {
+      const cx = pts.reduce((s, n) => s + (n.x ?? 0), 0) / pts.length;
+      const cy = pts.reduce((s, n) => s + (n.y ?? 0), 0) / pts.length;
       const cz = pts.reduce((s, n) => s + (n.z ?? 0), 0) / pts.length;
       const d = Math.hypot(cx, cy, cz) || 1;
-      const dist = 110;
+      const dist = 110 + 30 * Math.sqrt(clusters.length - 1);
       const r = 1 + dist / d;
       fg.cameraPosition({ x: cx * r, y: cy * r, z: cz * r }, { x: cx, y: cy, z: cz }, 700);
     } else {
-      fg.centerAt(cx, cy, 600);
-      fg.zoom(Math.max(2.6, fg.zoom?.() ?? 2.6), 600);
+      fg.zoomToFit(600, 48, (n: FGNode) => want.has(n.cluster));
     }
   };
 
@@ -745,7 +747,7 @@ export default function KnowledgeGraph({
   // hold (40 live communities vs the old top-8 cut) — default stays compact,
   // the "+N" toggle opens the FULL scrollable list with member counts.
   const { visible: communitiesForLegend, hidden: legendHidden } = legendCommunities(
-    scope === 'global' ? (data?.communities ?? []) : [],
+    groupCommunities(scope === 'global' ? (data?.communities ?? []) : []),
     legendOpen,
     LEGEND_COLLAPSED_COUNT,
   );
@@ -900,17 +902,17 @@ export default function KnowledgeGraph({
             <div className={`graph-legend${legendOpen ? ' graph-legend--open' : ''}`}>
               {communitiesForLegend.map((c) => (
                 <button
-                  key={c.id}
+                  key={c.label}
                   type="button"
                   className="graph-legend-item"
                   title={t('graph.focusCommunity')}
-                  onClick={() => focusCommunity(c.id)}
+                  onClick={() => focusCommunities(c.ids)}
                 >
                   <span
                     className="graph-legend-dot"
                     style={{
                       background:
-                        tokens.community[(c.id - 1) % tokens.community.length],
+                        tokens.community[(c.ids[0] - 1) % tokens.community.length],
                     }}
                   />
                   <span className="tiny">

--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -28,6 +28,7 @@ import {
 } from '../lib/api';
 import {
   closureNodeIds,
+  focusBounds,
   groupCommunities,
   isMiscTheme,
   legendCommunities,
@@ -730,13 +731,18 @@ export default function KnowledgeGraph({
     if (!fg) return;
     setHoverId(null);
     if (mode === '3d') {
-      const cx = pts.reduce((s, n) => s + (n.x ?? 0), 0) / pts.length;
-      const cy = pts.reduce((s, n) => s + (n.y ?? 0), 0) / pts.length;
-      const cz = pts.reduce((s, n) => s + (n.z ?? 0), 0) / pts.length;
-      const d = Math.hypot(cx, cy, cz) || 1;
-      const dist = 110 + 30 * Math.sqrt(clusters.length - 1);
+      // Distance from the SPATIAL bounds of the selected nodes — a cluster
+      // count would under-shoot for two far-apart clusters or one wide one.
+      const b = focusBounds(pts);
+      if (!b) return;
+      const d = Math.hypot(b.x, b.y, b.z) || 1;
+      const dist = Math.max(110, b.radius * 2.4);
       const r = 1 + dist / d;
-      fg.cameraPosition({ x: cx * r, y: cy * r, z: cz * r }, { x: cx, y: cy, z: cz }, 700);
+      fg.cameraPosition(
+        { x: b.x * r, y: b.y * r, z: b.z * r },
+        { x: b.x, y: b.y, z: b.z },
+        700,
+      );
     } else {
       fg.zoomToFit(600, 48, (n: FGNode) => want.has(n.cluster));
     }

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -1895,6 +1895,12 @@ body {
   border-radius: 8px;
   padding: 0.25rem;
 }
+/* The legend is a flex column: without this, max-height makes flex SHRINK
+   the rows to fit (scrollHeight == clientHeight — nothing to scroll, rows
+   squashed) instead of overflowing into the scrollbar. */
+.graph-legend--open .graph-legend-item {
+  flex-shrink: 0;
+}
 .graph-legend-toggle {
   color: var(--accent);
   font-family: var(--mono, monospace);

--- a/console-ui/src/lib/derive.observability.test.ts
+++ b/console-ui/src/lib/derive.observability.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   failureHintKey,
+  groupCommunities,
   legendCommunities,
   scheduleFailureStrip,
   themeSourceBadge,
@@ -79,6 +80,36 @@ describe('themeSourceBadge', () => {
       n: 4,
       single: false,
     });
+  });
+});
+
+describe('groupCommunities', () => {
+  it('merges same-label clusters, summing sizes, largest cluster first', () => {
+    // Live-vault case: Louvain splits one theme across several clusters —
+    // 'Agent Harness Architecture' appeared 4× in the legend.
+    const rows = groupCommunities([
+      { id: 2, label: 'Harness', size: 16 },
+      { id: 5, label: 'Harness', size: 14 },
+      { id: 1, label: 'Memory', size: 32 },
+      { id: 9, label: 'Harness', size: 5 },
+      { id: 4, label: 'Memory', size: 11 },
+    ]);
+    expect(rows).toEqual([
+      { ids: [1, 4], label: 'Memory', size: 43 },
+      { ids: [2, 5, 9], label: 'Harness', size: 35 },
+    ]);
+  });
+
+  it('keeps distinct labels apart and sorts ties by name', () => {
+    const rows = groupCommunities([
+      { id: 1, label: 'B', size: 5 },
+      { id: 2, label: 'A', size: 5 },
+    ]);
+    expect(rows.map((r) => r.label)).toEqual(['A', 'B']);
+  });
+
+  it('empty input stays safe', () => {
+    expect(groupCommunities([])).toEqual([]);
   });
 });
 

--- a/console-ui/src/lib/derive.observability.test.ts
+++ b/console-ui/src/lib/derive.observability.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   failureHintKey,
+  focusBounds,
   groupCommunities,
   legendCommunities,
   scheduleFailureStrip,
@@ -86,13 +87,14 @@ describe('themeSourceBadge', () => {
 describe('groupCommunities', () => {
   it('merges same-label clusters, summing sizes, largest cluster first', () => {
     // Live-vault case: Louvain splits one theme across several clusters —
-    // 'Agent Harness Architecture' appeared 4× in the legend.
+    // 'Agent Harness Architecture' appeared 4× in the legend. Input order is
+    // deliberately NOT size-desc: the ids contract must not trust the caller.
     const rows = groupCommunities([
-      { id: 2, label: 'Harness', size: 16 },
-      { id: 5, label: 'Harness', size: 14 },
-      { id: 1, label: 'Memory', size: 32 },
       { id: 9, label: 'Harness', size: 5 },
+      { id: 5, label: 'Harness', size: 14 },
       { id: 4, label: 'Memory', size: 11 },
+      { id: 2, label: 'Harness', size: 16 },
+      { id: 1, label: 'Memory', size: 32 },
     ]);
     expect(rows).toEqual([
       { ids: [1, 4], label: 'Memory', size: 43 },
@@ -110,6 +112,30 @@ describe('groupCommunities', () => {
 
   it('empty input stays safe', () => {
     expect(groupCommunities([])).toEqual([]);
+  });
+});
+
+describe('focusBounds', () => {
+  it('centroid + bounding radius cover far-apart clusters', () => {
+    // Two clusters 200 apart: the radius must reach both, so the 3D camera
+    // frames them (a cluster-count heuristic under-shot exactly here).
+    const b = focusBounds([
+      { x: -100, y: 0, z: 0 },
+      { x: 100, y: 0, z: 0 },
+    ])!;
+    expect(b).toEqual({ x: 0, y: 0, z: 0, radius: 100 });
+    const wide = focusBounds([
+      { x: 0, y: 0 },
+      { x: 0, y: 300 },
+      { x: 0, y: 600 },
+    ])!;
+    expect(wide.y).toBe(300);
+    expect(wide.radius).toBe(300);
+  });
+
+  it('a single point has zero radius; empty input is null', () => {
+    expect(focusBounds([{ x: 5, y: -2, z: 1 }])).toEqual({ x: 5, y: -2, z: 1, radius: 0 });
+    expect(focusBounds([])).toBeNull();
   });
 });
 

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -1452,6 +1452,38 @@ export function radialAnchors(
   return { radius, byCluster, byId };
 }
 
+/** One knowledge-graph legend row — possibly MERGING several graph clusters.
+ * Louvain clustering is finer-grained than the theme taxonomy, so distinct
+ * clusters often share a dominant-theme label ('Agent Harness Architecture'
+ * ×4 on the live vault); one row per label matches the reader's mental model,
+ * and a click frames ALL of that label's clusters. */
+export interface LegendRow {
+  /** Cluster ids sharing the label, largest first — ids[0] drives the dot. */
+  ids: number[];
+  label: string;
+  /** Summed member count across the merged clusters. */
+  size: number;
+}
+
+/** Merge same-label communities into legend rows, total size desc. Pure. */
+export function groupCommunities(
+  communities: { id: number; label: string; size: number }[],
+): LegendRow[] {
+  const byLabel = new Map<string, LegendRow>();
+  for (const c of communities) {
+    const row = byLabel.get(c.label);
+    if (row) {
+      row.ids.push(c.id);
+      row.size += c.size;
+    } else {
+      byLabel.set(c.label, { ids: [c.id], label: c.label, size: c.size });
+    }
+  }
+  return [...byLabel.values()].sort(
+    (a, b) => b.size - a.size || a.label.localeCompare(b.label),
+  );
+}
+
 /** Knowledge-graph legend rows: compact top-N strip by default, the full
  * list when open. `hidden` drives the "+N more" toggle (0 hides it). Pure —
  * the component only renders the returned slice. */

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -1452,6 +1452,35 @@ export function radialAnchors(
   return { radius, byCluster, byId };
 }
 
+/** Centroid + bounding radius of a 3D fly-to target — the camera distance
+ * must come from the SPATIAL extent of the selected nodes (two far-apart
+ * clusters, or one wide cluster, must both fit the viewport), never from
+ * the cluster count. Pure — vitest-covered. */
+export function focusBounds(
+  pts: { x?: number; y?: number; z?: number }[],
+): { x: number; y: number; z: number; radius: number } | null {
+  if (pts.length === 0) return null;
+  let cx = 0;
+  let cy = 0;
+  let cz = 0;
+  for (const p of pts) {
+    cx += p.x ?? 0;
+    cy += p.y ?? 0;
+    cz += p.z ?? 0;
+  }
+  cx /= pts.length;
+  cy /= pts.length;
+  cz /= pts.length;
+  let radius = 0;
+  for (const p of pts) {
+    radius = Math.max(
+      radius,
+      Math.hypot((p.x ?? 0) - cx, (p.y ?? 0) - cy, (p.z ?? 0) - cz),
+    );
+  }
+  return { x: cx, y: cy, z: cz, radius };
+}
+
 /** One knowledge-graph legend row — possibly MERGING several graph clusters.
  * Louvain clustering is finer-grained than the theme taxonomy, so distinct
  * clusters often share a dominant-theme label ('Agent Harness Architecture'
@@ -1470,7 +1499,10 @@ export function groupCommunities(
   communities: { id: number; label: string; size: number }[],
 ): LegendRow[] {
   const byLabel = new Map<string, LegendRow>();
-  for (const c of communities) {
+  // Size-desc walk (stable id tie-break) ENFORCES the ids-largest-first
+  // contract instead of trusting the caller's order.
+  const ordered = [...communities].sort((a, b) => b.size - a.size || a.id - b.id);
+  for (const c of ordered) {
     const row = byLabel.get(c.label);
     if (row) {
       row.ids.push(c.id);


### PR DESCRIPTION
Round 2 on the expanded legend (operator screenshots):

**Scroll dead** — `.graph-legend` is a flex column; with `max-height` set, flex *shrank* the rows to fit instead of overflowing (measured: `scrollHeight == clientHeight == 502`, `scrollTop` stuck at 0). `flex-shrink: 0` on rows restores real overflow → scrollbar works (measured after: 552 > 502, scrollTop moves).

**Labels repeated up to 4×** — Louvain clusters are finer-grained than the theme taxonomy, so distinct clusters share a dominant-theme label ('Agent Harness Architecture' ×4). Not a data bug — a display collision. New pure `groupCommunities()` merges same-label clusters into one legend row (summed member count, ids largest-first); clicking a row now frames **all** of that label's clusters (2D `zoomToFit` with a node filter; 3D combined-centroid camera fly, distance scaled by cluster count).

Live verify via Playwright on the real vault: 40 clusters → **23 unique rows**, zero duplicates, scrolling works. vitest 161/161 (new groupCommunities suite), tsc clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Knowledge graph legends now combine communities that share the same label, making large graphs easier to interpret.
  * Selecting a legend entry can now focus all matching clusters together in both 2D and 3D views.

* **Improvements**
  * 3D graph focusing automatically adjusts the viewing distance for selections containing multiple clusters.
  * Legend items retain their height in narrow panels, enabling smoother vertical scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->