### PR TITLE
feat(knowledge): chat on this knowledge (theme-grounded chat dock)

### DIFF
--- a/console-ui/src/components/FocusChatPanel.tsx
+++ b/console-ui/src/components/FocusChatPanel.tsx
@@ -1,10 +1,14 @@
-/** Source-grounded chat dock — lives on `/library/:sha`, not a jump to Ask.
+/** Focus-grounded chat dock — lives on the focused page, not a jump to Ask.
  *
- * Product model: the user is reading a source; chat auto-injects body +
- * memory + crystal on the server via `focus_source`. Sessions are the same
- * `.ovp/chats` spine as Ask, tagged with focus metadata for unified history.
+ * Two focus targets share one dock:
+ * - source (`/library/:sha`): server injects body + memory + crystal via
+ *   `focus_source`.
+ * - theme (`/knowledge/theme/:t`): server injects topic page + active claims
+ *   + cited sources via `focus_theme`.
+ * Sessions are the same `.ovp/chats` spine as Ask, tagged with focus
+ * metadata for unified history.
  */
-import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useI18n, type MsgKey } from '../i18n';
 import {
@@ -100,8 +104,8 @@ interface Turn {
   errorKey: MsgKey | null;
 }
 
-function genChatId(): string {
-  return `src-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+function genChatId(prefix: string): string {
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
 function errorKeyFor(err: unknown): MsgKey {
@@ -117,28 +121,31 @@ function errorKeyFor(err: unknown): MsgKey {
   return 'ask.errGeneric';
 }
 
-export interface SourceChatPanelProps {
-  sha: string;
+export type ChatFocusTarget =
+  | { kind: 'source'; sha: string }
+  | { kind: 'theme'; theme: string };
+
+export interface FocusChatPanelProps {
+  focus: ChatFocusTarget;
   title: string;
-  cardCount: number;
-  unitCount: number;
-  claimCount: number;
+  /** Compact, already-localized context meta line ("8 cards · 12 units · …"). */
+  metaLine: string;
   open: boolean;
   onClose: () => void;
   /** Optional session stem from URL (`?chat=`) to resume. */
   resumeChat?: string | null;
 }
 
-export default function SourceChatPanel({
-  sha,
+export default function FocusChatPanel({
+  focus,
   title,
-  cardCount,
-  unitCount,
-  claimCount,
+  metaLine,
   open,
   onClose,
   resumeChat = null,
-}: SourceChatPanelProps) {
+}: FocusChatPanelProps) {
+  const sha = focus.kind === 'source' ? focus.sha : null;
+  const themeName = focus.kind === 'theme' ? focus.theme : null;
   const { t, lang } = useI18n();
   const navigate = useNavigate();
   const [turns, setTurns] = useState<Turn[]>([]);
@@ -154,7 +161,8 @@ export default function SourceChatPanel({
   const askStatusRef = useRef<boolean | null>(null);
 
   const toTurn = (question: string, answer: string, chat: string | null, extra?: Partial<AskResponse>): Turn => {
-    const citations = groundCitesOnSource(citationsFromAnswerText(answer), sha);
+    const raw = citationsFromAnswerText(answer);
+    const citations = sha ? groundCitesOnSource(raw, sha) : raw;
     return {
       question: displayUserQuestion(question),
       errorKey: null,
@@ -171,7 +179,15 @@ export default function SourceChatPanel({
 
   const refreshRecents = () => {
     fetchChats()
-      .then((all) => setRecents(all.filter((c) => c.focus_source === sha).slice(0, 8)))
+      .then((all) =>
+        setRecents(
+          all
+            .filter((c) =>
+              sha ? c.focus_source === sha : c.focus_theme === themeName,
+            )
+            .slice(0, 8),
+        ),
+      )
       .catch(() => setRecents([]));
   };
 
@@ -185,7 +201,7 @@ export default function SourceChatPanel({
       .catch(() => {
         /* submit re-reads */
       });
-  }, [open, sha]);
+  }, [open, sha, themeName]);
 
   // Resume a saved session from deep link or recent list.
   useEffect(() => {
@@ -219,7 +235,7 @@ export default function SourceChatPanel({
     return () => {
       cancelled = true;
     };
-  }, [open, resumeChat, sha]);
+  }, [open, resumeChat, sha, themeName]);
 
   useEffect(() => {
     if (!open) return;
@@ -313,23 +329,21 @@ export default function SourceChatPanel({
         })
         .catch(() => askStatusRef.current ?? false);
       if (agent && !chat) {
-        chat = genChatId();
+        chat = genChatId(sha ? 'src' : 'thm');
         setSessionChat(chat);
       }
       setPollChat(agent ? chat : null);
       return postAsk(question, {
         chat,
         history,
-        focus_source: sha,
+        ...(sha ? { focus_source: sha } : { focus_theme: themeName! }),
       });
     })()
       .then((response) => {
-        const citations = groundCitesOnSource(
-          response.citations?.length
-            ? response.citations
-            : citationsFromAnswerText(response.answer),
-          sha,
-        );
+        const rawCites = response.citations?.length
+          ? response.citations
+          : citationsFromAnswerText(response.answer);
+        const citations = sha ? groundCitesOnSource(rawCites, sha) : rawCites;
         setTurns((prev) =>
           prev.map((turn, i) =>
             i === prev.length - 1
@@ -366,11 +380,9 @@ export default function SourceChatPanel({
     }
   };
 
-  const seeds: MsgKey[] = [
-    'source.chatSeed1',
-    'source.chatSeed2',
-    'source.chatSeed3',
-  ];
+  const seeds: MsgKey[] = sha
+    ? ['source.chatSeed1', 'source.chatSeed2', 'source.chatSeed3']
+    : ['theme.chatSeed1', 'theme.chatSeed2', 'theme.chatSeed3'];
 
   const chatDate = (entry: ChatEntry) =>
     entry.mtime > 0
@@ -380,28 +392,20 @@ export default function SourceChatPanel({
         )
       : entry.name;
 
-  const packSummary = useMemo(
-    () =>
-      t('source.chatPackSummary', {
-        cards: cardCount,
-        units: unitCount,
-        claims: claimCount,
-      }),
-    [t, cardCount, unitCount, claimCount],
-  );
+
 
   return (
     <aside
       className={`source-chat-panel${open ? '' : ' is-hidden'}`}
-      aria-label={t('source.chatPanelTitle')}
+      aria-label={t(sha ? 'source.chatPanelTitle' : 'theme.chatPanelTitle')}
       aria-hidden={!open}
       hidden={!open}
     >
       <header className="source-chat-head">
         <div>
-          <h3 style={{ margin: 0 }}>{t('source.chatPanelTitle')}</h3>
+          <h3 style={{ margin: 0 }}>{t(sha ? 'source.chatPanelTitle' : 'theme.chatPanelTitle')}</h3>
           <p className="tiny muted" style={{ margin: '0.2rem 0 0' }}>
-            {t('source.chatGroundedIn')}{' '}
+            {t(sha ? 'source.chatGroundedIn' : 'theme.chatGroundedIn')}{' '}
             <strong title={title}>{title.length > 48 ? `${title.slice(0, 48)}…` : title}</strong>
           </p>
         </div>
@@ -413,7 +417,7 @@ export default function SourceChatPanel({
           )}
           {viewingSaved && (
             <button type="button" className="tiny" onClick={startNew}>
-              {t('source.chatNewOnSource')}
+              {t(sha ? 'source.chatNewOnSource' : 'theme.chatNewOnTheme')}
             </button>
           )}
           <Link
@@ -431,14 +435,8 @@ export default function SourceChatPanel({
 
       {/* Context is injected server-side — UI only shows a compact meta line,
           never the raw body/memory/crystal dump. */}
-      <div className="source-chat-pack" title={packSummary}>
-        <span className="source-chat-meta mono tiny">
-          {t('source.chatMetaLine', {
-            cards: cardCount,
-            units: unitCount,
-            claims: claimCount,
-          })}
-        </span>
+      <div className="source-chat-pack" title={metaLine}>
+        <span className="source-chat-meta mono tiny">{metaLine}</span>
         <span className="tiny muted source-chat-pack-hint">{t('source.chatPackHint')}</span>
       </div>
 
@@ -467,7 +465,7 @@ export default function SourceChatPanel({
       <div className="source-chat-thread" ref={threadRef}>
         {turns.length === 0 && (
           <div className="source-chat-empty">
-            <p className="sm">{t('source.chatEmpty')}</p>
+            <p className="sm">{t(sha ? 'source.chatEmpty' : 'theme.chatEmpty')}</p>
             <ul className="example-list">
               {seeds.map((key) => (
                 <li key={key}>
@@ -543,7 +541,7 @@ export default function SourceChatPanel({
             ref={composerRef}
             data-omnibox-suppress
             value={draft}
-            placeholder={t('source.chatPlaceholder')}
+            placeholder={t(sha ? 'source.chatPlaceholder' : 'theme.chatPlaceholder')}
             onChange={(e) => setDraft(e.target.value)}
             onKeyDown={onKey}
             disabled={pending}

--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -28,6 +28,7 @@ import {
 } from '../lib/api';
 import {
   closureNodeIds,
+  groupCommunities,
   isMiscTheme,
   legendCommunities,
   radialAnchors,
@@ -715,28 +716,29 @@ export default function KnowledgeGraph({
     fg?.cameraPosition(to, node, 600);
   };
 
-  // Legend click → fly to that community's centroid so you don't have to hunt
-  // for it (2D: center + zoom; 3D: pull the camera in on the cluster).
-  const focusCommunity = (cluster: number) => {
+  // Legend click → fly to a legend row's clusterS (same-label clusters merge
+  // into one row) so you don't have to hunt for them. 2D: zoom-to-fit the
+  // member nodes; 3D: pull the camera in on their combined centroid.
+  const focusCommunities = (clusters: number[]) => {
+    const want = new Set(clusters);
     const pts = (graphData.nodes as FGNode[]).filter(
-      (n) => n.cluster === cluster && n.x != null,
+      (n) => want.has(n.cluster) && n.x != null,
     );
     if (!pts.length) return;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const fg = fgRef.current as any;
     if (!fg) return;
-    const cx = pts.reduce((s, n) => s + (n.x ?? 0), 0) / pts.length;
-    const cy = pts.reduce((s, n) => s + (n.y ?? 0), 0) / pts.length;
     setHoverId(null);
     if (mode === '3d') {
+      const cx = pts.reduce((s, n) => s + (n.x ?? 0), 0) / pts.length;
+      const cy = pts.reduce((s, n) => s + (n.y ?? 0), 0) / pts.length;
       const cz = pts.reduce((s, n) => s + (n.z ?? 0), 0) / pts.length;
       const d = Math.hypot(cx, cy, cz) || 1;
-      const dist = 110;
+      const dist = 110 + 30 * Math.sqrt(clusters.length - 1);
       const r = 1 + dist / d;
       fg.cameraPosition({ x: cx * r, y: cy * r, z: cz * r }, { x: cx, y: cy, z: cz }, 700);
     } else {
-      fg.centerAt(cx, cy, 600);
-      fg.zoom(Math.max(2.6, fg.zoom?.() ?? 2.6), 600);
+      fg.zoomToFit(600, 48, (n: FGNode) => want.has(n.cluster));
     }
   };
 
@@ -745,7 +747,7 @@ export default function KnowledgeGraph({
   // hold (40 live communities vs the old top-8 cut) — default stays compact,
   // the "+N" toggle opens the FULL scrollable list with member counts.
   const { visible: communitiesForLegend, hidden: legendHidden } = legendCommunities(
-    scope === 'global' ? (data?.communities ?? []) : [],
+    groupCommunities(scope === 'global' ? (data?.communities ?? []) : []),
     legendOpen,
     LEGEND_COLLAPSED_COUNT,
   );
@@ -900,17 +902,17 @@ export default function KnowledgeGraph({
             <div className={`graph-legend${legendOpen ? ' graph-legend--open' : ''}`}>
               {communitiesForLegend.map((c) => (
                 <button
-                  key={c.id}
+                  key={c.label}
                   type="button"
                   className="graph-legend-item"
                   title={t('graph.focusCommunity')}
-                  onClick={() => focusCommunity(c.id)}
+                  onClick={() => focusCommunities(c.ids)}
                 >
                   <span
                     className="graph-legend-dot"
                     style={{
                       background:
-                        tokens.community[(c.id - 1) % tokens.community.length],
+                        tokens.community[(c.ids[0] - 1) % tokens.community.length],
                     }}
                   />
                   <span className="tiny">

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -1895,6 +1895,12 @@ body {
   border-radius: 8px;
   padding: 0.25rem;
 }
+/* The legend is a flex column: without this, max-height makes flex SHRINK
+   the rows to fit (scrollHeight == clientHeight — nothing to scroll, rows
+   squashed) instead of overflowing into the scrollbar. */
+.graph-legend--open .graph-legend-item {
+  flex-shrink: 0;
+}
 .graph-legend-toggle {
   color: var(--accent);
   font-family: var(--mono, monospace);

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -2049,6 +2049,10 @@ body {
   top: 1rem;
   align-self: start;
 }
+.theme-chat-open {
+  width: 100%;
+  margin-bottom: 0.6rem;
+}
 .theme-rail-card {
   /* Keep the rail card from stretching taller than the viewport when the
      left column is long; graph stays reachable without scrolling the page. */

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -496,6 +496,17 @@ export const en = {
   'theme.graph': 'Theme graph',
   'theme.graphCaption':
     'This theme’s claims and the sources they cite. Click a node for a summary and an open link; hover to highlight its neighborhood.',
+  'theme.chatOnThis': 'Chat on this knowledge',
+  'theme.chatPanelTitle': 'Chat on this knowledge',
+  'theme.chatGroundedIn': 'Grounded in',
+  'theme.chatMetaLine': '{claims} claims · {sources} sources auto-included',
+  'theme.chatNewOnTheme': 'New chat on this knowledge',
+  'theme.chatEmpty':
+    'Ask about this knowledge — the topic synthesis, its claims, and their sources are already in context.',
+  'theme.chatSeed1': 'Summarize what this knowledge says, and where the sources disagree.',
+  'theme.chatSeed2': 'Which claims here rest on the weakest evidence?',
+  'theme.chatSeed3': 'What changed most recently in this theme?',
+  'theme.chatPlaceholder': 'Ask about this knowledge…',
 
   // search page + ⌘K overlay
   'search.title': 'Search',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -472,6 +472,16 @@ export const zh: Record<keyof typeof en, string> = {
   'theme.backToKnowledge': '全部主题',
   'theme.graph': '主题图谱',
   'theme.graphCaption': '本主题的主张与其引用的源。单击节点看摘要并打开；悬停高亮其邻域。',
+  'theme.chatOnThis': '就这个知识对话',
+  'theme.chatPanelTitle': '就这个知识对话',
+  'theme.chatGroundedIn': '基于',
+  'theme.chatMetaLine': '已自动带入 {claims} 条主张 · {sources} 个来源',
+  'theme.chatNewOnTheme': '就这个知识新开对话',
+  'theme.chatEmpty': '问问这块知识——主题综述、主张和来源已经在上下文里。',
+  'theme.chatSeed1': '总结这块知识讲了什么,来源之间有哪些分歧?',
+  'theme.chatSeed2': '这里哪些主张的证据最薄弱?',
+  'theme.chatSeed3': '这个主题最近有什么变化?',
+  'theme.chatPlaceholder': '问问这块知识……',
 
   // search page + ⌘K overlay
   'search.title': '搜索',

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -575,6 +575,8 @@ export interface PostAskOptions {
   history?: AskHistoryTurn[];
   /** Pin the turn to one library source (chat-on-this). */
   focus_source?: string;
+  /** Theme-grounded chat: server injects topic page + active claims. */
+  focus_theme?: string;
 }
 
 /** POST /api/ask — cited answer over the grounded evidence index. The
@@ -593,6 +595,7 @@ export async function postAsk(
   if (opts.chat) body.chat = opts.chat;
   if (opts.history && opts.history.length > 0) body.history = opts.history;
   if (opts.focus_source) body.focus_source = opts.focus_source;
+  if (opts.focus_theme) body.focus_theme = opts.focus_theme;
   const res = await fetch('/api/ask', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/console-ui/src/lib/derive.observability.test.ts
+++ b/console-ui/src/lib/derive.observability.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   failureHintKey,
+  groupCommunities,
   legendCommunities,
   scheduleFailureStrip,
   themeSourceBadge,
@@ -79,6 +80,36 @@ describe('themeSourceBadge', () => {
       n: 4,
       single: false,
     });
+  });
+});
+
+describe('groupCommunities', () => {
+  it('merges same-label clusters, summing sizes, largest cluster first', () => {
+    // Live-vault case: Louvain splits one theme across several clusters —
+    // 'Agent Harness Architecture' appeared 4× in the legend.
+    const rows = groupCommunities([
+      { id: 2, label: 'Harness', size: 16 },
+      { id: 5, label: 'Harness', size: 14 },
+      { id: 1, label: 'Memory', size: 32 },
+      { id: 9, label: 'Harness', size: 5 },
+      { id: 4, label: 'Memory', size: 11 },
+    ]);
+    expect(rows).toEqual([
+      { ids: [1, 4], label: 'Memory', size: 43 },
+      { ids: [2, 5, 9], label: 'Harness', size: 35 },
+    ]);
+  });
+
+  it('keeps distinct labels apart and sorts ties by name', () => {
+    const rows = groupCommunities([
+      { id: 1, label: 'B', size: 5 },
+      { id: 2, label: 'A', size: 5 },
+    ]);
+    expect(rows.map((r) => r.label)).toEqual(['A', 'B']);
+  });
+
+  it('empty input stays safe', () => {
+    expect(groupCommunities([])).toEqual([]);
   });
 });
 

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -1452,6 +1452,38 @@ export function radialAnchors(
   return { radius, byCluster, byId };
 }
 
+/** One knowledge-graph legend row — possibly MERGING several graph clusters.
+ * Louvain clustering is finer-grained than the theme taxonomy, so distinct
+ * clusters often share a dominant-theme label ('Agent Harness Architecture'
+ * ×4 on the live vault); one row per label matches the reader's mental model,
+ * and a click frames ALL of that label's clusters. */
+export interface LegendRow {
+  /** Cluster ids sharing the label, largest first — ids[0] drives the dot. */
+  ids: number[];
+  label: string;
+  /** Summed member count across the merged clusters. */
+  size: number;
+}
+
+/** Merge same-label communities into legend rows, total size desc. Pure. */
+export function groupCommunities(
+  communities: { id: number; label: string; size: number }[],
+): LegendRow[] {
+  const byLabel = new Map<string, LegendRow>();
+  for (const c of communities) {
+    const row = byLabel.get(c.label);
+    if (row) {
+      row.ids.push(c.id);
+      row.size += c.size;
+    } else {
+      byLabel.set(c.label, { ids: [c.id], label: c.label, size: c.size });
+    }
+  }
+  return [...byLabel.values()].sort(
+    (a, b) => b.size - a.size || a.label.localeCompare(b.label),
+  );
+}
+
 /** Knowledge-graph legend rows: compact top-N strip by default, the full
  * list when open. `hidden` drives the "+N more" toggle (0 hides it). Pure —
  * the component only renders the returned slice. */

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -376,6 +376,8 @@ export interface ChatEntry {
   mtime: number;
   /** Source sha when this session was started via Chat-on-this. */
   focus_source?: string | null;
+  /** Crystal theme when this session was started via Chat-on-this-knowledge. */
+  focus_theme?: string | null;
   focus_title?: string | null;
   /** First user question preview (truncated). */
   preview?: string | null;

--- a/console-ui/src/pages/SourceDetailPage.tsx
+++ b/console-ui/src/pages/SourceDetailPage.tsx
@@ -7,7 +7,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import KnowledgeGraph from '../components/KnowledgeGraph';
-import SourceChatPanel from '../components/SourceChatPanel';
+import FocusChatPanel from '../components/FocusChatPanel';
 import { ClaimPill, EmptyState, StatusPill } from '../components/ui';
 import { useI18n } from '../i18n';
 import {
@@ -1114,12 +1114,14 @@ export default function SourceDetailPage() {
       </div>
 
       {!STATIC_MODE && (
-        <SourceChatPanel
-          sha={source.sha256}
+        <FocusChatPanel
+          focus={{ kind: 'source', sha: source.sha256 }}
           title={title}
-          cardCount={memory.cards.length}
-          unitCount={memory.units.length}
-          claimCount={citing.length}
+          metaLine={t('source.chatMetaLine', {
+            cards: memory.cards.length,
+            units: memory.units.length,
+            claims: citing.length,
+          })}
           open={chatOpen}
           resumeChat={resumeChat}
           onClose={() => setChatOpen(false)}

--- a/console-ui/src/pages/ThemeDetailPage.tsx
+++ b/console-ui/src/pages/ThemeDetailPage.tsx
@@ -9,12 +9,14 @@
  * legacy case ids whose pack has no source sha render as plain text
  * (handoff note 5: never navigate to a 404). */
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Link, useLocation, useParams } from 'react-router-dom';
+import { Link, useLocation, useParams, useSearchParams } from 'react-router-dom';
+import FocusChatPanel from '../components/FocusChatPanel';
 import KnowledgeGraph from '../components/KnowledgeGraph';
 import { ClaimPill, EmptyState, ModelGate } from '../components/ui';
 import { useI18n } from '../i18n';
 import { fetchThemePages } from '../lib/api';
 import {
+  caseCanonicalIds,
   isMiscTheme,
   parsePageBody,
   sourcesByCase,
@@ -28,6 +30,7 @@ import type {
   ThemePagesResponse,
 } from '../lib/types';
 import { useModel } from '../model';
+import { STATIC_MODE } from '../lib/api';
 
 function TopicOverview({ theme }: { theme: string }) {
   const { t, lang } = useI18n();
@@ -237,11 +240,45 @@ function ClaimCard({
   );
 }
 
-function ThemeBody({ model, theme }: { model: IndexModel; theme: string }) {
+function ThemeBody({
+  model,
+  theme,
+  displayName,
+}: {
+  model: IndexModel;
+  theme: string;
+  displayName: string;
+}) {
   const { t, lang, setLang } = useI18n();
   const location = useLocation();
   const claims = useMemo(() => themeClaims(model.claims, theme), [model, theme]);
   const byCase = useMemo(() => sourcesByCase(model), [model]);
+  // Chat-on-this-knowledge dock (same URL contract as the source page:
+  // ?chat=1 opens empty; ?chat=<stem> resumes that session in-context).
+  const [searchParams, setSearchParams] = useSearchParams();
+  const chatParam = searchParams.get('chat');
+  const chatOpen = chatParam != null && chatParam !== '';
+  const resumeChat =
+    chatParam && chatParam !== '1' && chatParam !== 'true' ? chatParam : null;
+  const setChatOpen = (open: boolean) => {
+    setSearchParams(
+      (prev) => {
+        const p = new URLSearchParams(prev);
+        if (!open) p.delete('chat');
+        else p.set('chat', '1');
+        return p;
+      },
+      { replace: true },
+    );
+  };
+  const sourceCount = useMemo(() => {
+    const canonical = caseCanonicalIds(model);
+    const distinct = new Set<string>();
+    for (const c of claims) {
+      for (const s of c.sources) distinct.add(canonical.get(s) ?? s);
+    }
+    return distinct.size;
+  }, [model, claims]);
   // theme-pages payload carries claim_zh keyed by claim_key when
   // .ovp/crystal/claims_zh.json exists — reuse for cards (index model may not
   // splice claim_zh on every claim row yet).
@@ -374,12 +411,34 @@ function ThemeBody({ model, theme }: { model: IndexModel; theme: string }) {
         )}
       </div>
       <aside className="theme-rail">
+        {!STATIC_MODE && claims.length > 0 && (
+          <button
+            type="button"
+            className="action-btn theme-chat-open"
+            onClick={() => setChatOpen(true)}
+          >
+            {t('theme.chatOnThis')}
+          </button>
+        )}
         <div className="card theme-rail-card">
           <h3 style={{ marginBottom: '0.6rem' }}>{t('theme.graph')}</h3>
           <KnowledgeGraph scope="theme" id={theme} height={360} />
           <div className="graph-caption">{t('theme.graphCaption')}</div>
         </div>
       </aside>
+      {!STATIC_MODE && claims.length > 0 && (
+        <FocusChatPanel
+          focus={{ kind: 'theme', theme }}
+          title={displayName}
+          metaLine={t('theme.chatMetaLine', {
+            claims: claims.length,
+            sources: sourceCount,
+          })}
+          open={chatOpen}
+          resumeChat={resumeChat}
+          onClose={() => setChatOpen(false)}
+        />
+      )}
     </div>
   );
 }
@@ -412,7 +471,7 @@ export default function ThemeDetailPage() {
               {t('theme.unclassifiedNote')}
             </p>
           )}
-          <ThemeBody model={model} theme={theme} />
+          <ThemeBody model={model} theme={theme} displayName={displayName} />
         </>
       )}
     </ModelGate>

--- a/crates/ovp-memory/src/ask.rs
+++ b/crates/ovp-memory/src/ask.rs
@@ -31,12 +31,15 @@ pub struct AskHistoryTurn {
     pub answer: String,
 }
 
-/// Optional source-grounded chat tag written into the saved transcript header
-/// so Ask history and Library can show "on this source" sessions.
+/// Optional focus tag written into the saved transcript header so Ask history
+/// and the focused surface (Library source page / Knowledge theme page) can
+/// show "on this" sessions. Exactly one of `source_sha` / `theme` is set.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ChatFocusMeta {
     pub source_sha: String,
     pub title: Option<String>,
+    /// Crystal theme name for theme-grounded chats ("chat on this knowledge").
+    pub theme: Option<String>,
 }
 
 pub struct AskArgs {
@@ -566,14 +569,19 @@ fn save_or_append_chat(
 pub fn chat_file_header(ts: &str, focus: Option<&ChatFocusMeta>) -> String {
     let mut out = format!("# Ask — {ts}\n");
     if let Some(f) = focus {
+        // HTML comment cannot contain `--`; keep the list surface readable.
+        let safe = |s: &str| s.replace("--", "—");
         let sha = f.source_sha.trim();
+        let theme = f.theme.as_deref().map(str::trim).filter(|t| !t.is_empty());
         if !sha.is_empty() {
             out.push_str(&format!("<!-- ovp:focus_source={sha} -->\n"));
-            if let Some(title) = f.title.as_deref().map(str::trim).filter(|t| !t.is_empty()) {
-                // HTML comment cannot contain `--`; keep the list surface readable.
-                let safe = title.replace("--", "—");
-                out.push_str(&format!("<!-- ovp:focus_title={safe} -->\n"));
-            }
+        } else if let Some(theme) = theme {
+            out.push_str(&format!("<!-- ovp:focus_theme={} -->\n", safe(theme)));
+        }
+        if (!sha.is_empty() || theme.is_some())
+            && let Some(title) = f.title.as_deref().map(str::trim).filter(|t| !t.is_empty())
+        {
+            out.push_str(&format!("<!-- ovp:focus_title={} -->\n", safe(title)));
         }
     }
     out.push('\n');
@@ -582,9 +590,12 @@ pub fn chat_file_header(ts: &str, focus: Option<&ChatFocusMeta>) -> String {
 
 /// Parse focus metadata + first question preview from a saved chat markdown.
 /// Scans only the leading portion (cheap for /api/chats list).
-pub fn parse_chat_surface_meta(md: &str) -> (Option<String>, Option<String>, Option<String>) {
+pub fn parse_chat_surface_meta(
+    md: &str,
+) -> (Option<String>, Option<String>, Option<String>, Option<String>) {
     let head = md.get(..md.len().min(8_192)).unwrap_or(md);
     let mut focus_source = None;
+    let mut focus_theme = None;
     let mut focus_title = None;
     for line in head.lines().take(40) {
         let line = line.trim();
@@ -595,6 +606,14 @@ pub fn parse_chat_surface_meta(md: &str) -> (Option<String>, Option<String>, Opt
             let v = rest.trim();
             if !v.is_empty() {
                 focus_source = Some(v.to_string());
+            }
+        } else if let Some(rest) = line
+            .strip_prefix("<!-- ovp:focus_theme=")
+            .and_then(|s| s.strip_suffix("-->"))
+        {
+            let v = rest.trim();
+            if !v.is_empty() {
+                focus_theme = Some(v.to_string());
             }
         } else if let Some(rest) = line
             .strip_prefix("<!-- ovp:focus_title=")
@@ -620,7 +639,7 @@ pub fn parse_chat_surface_meta(md: &str) -> (Option<String>, Option<String>, Opt
                 }
             })
     });
-    (focus_source, focus_title, preview)
+    (focus_source, focus_theme, focus_title, preview)
 }
 
 fn format_chat_turn(
@@ -1370,15 +1389,36 @@ mod tests {
         let focus = ChatFocusMeta {
             source_sha: "abc123deadbeef".into(),
             title: Some("Memory as state — draft".into()),
+            theme: None,
         };
         let header = chat_file_header("1751812999", Some(&focus));
         assert!(header.contains("<!-- ovp:focus_source=abc123deadbeef -->"));
         assert!(header.contains("<!-- ovp:focus_title=Memory as state — draft -->"));
         let md = format!("{header}**Q:** What is the thesis?\n\n**A:** State over recall.\n");
-        let (sha, title, preview) = parse_chat_surface_meta(&md);
+        let (sha, theme, title, preview) = parse_chat_surface_meta(&md);
         assert_eq!(sha.as_deref(), Some("abc123deadbeef"));
+        assert_eq!(theme, None);
         assert_eq!(title.as_deref(), Some("Memory as state — draft"));
         assert_eq!(preview.as_deref(), Some("What is the thesis?"));
+    }
+
+    #[test]
+    fn theme_focus_header_round_trips() {
+        // Theme-grounded chats ("chat on this knowledge") tag the transcript
+        // with focus_theme; `--` is sanitized for the HTML comment.
+        let focus = ChatFocusMeta {
+            source_sha: String::new(),
+            title: Some("Agent Memory".into()),
+            theme: Some("Agent Memory -- deep".into()),
+        };
+        let header = chat_file_header("2026-08-07T00:00:00Z", Some(&focus));
+        assert!(header.contains("ovp:focus_theme=Agent Memory — deep"));
+        assert!(header.contains("ovp:focus_title=Agent Memory"));
+        let (sha, theme, title, preview) = parse_chat_surface_meta(&header);
+        assert_eq!(sha, None);
+        assert_eq!(theme.as_deref(), Some("Agent Memory — deep"));
+        assert_eq!(title.as_deref(), Some("Agent Memory"));
+        assert_eq!(preview, None);
     }
 
     #[test]
@@ -1390,6 +1430,7 @@ mod tests {
         let focus = ChatFocusMeta {
             source_sha: "sha-focus-1".into(),
             title: Some("Focused Source".into()),
+            theme: None,
         };
         save_agent_chat_turn_with_focus(
             &vault,
@@ -1412,8 +1453,9 @@ mod tests {
         assert_eq!(md.matches("ovp:focus_source=sha-focus-1").count(), 1);
         assert!(md.contains("**Q:** summarize this"));
         assert!(md.contains("**Q:** more?"));
-        let (sha, title, preview) = parse_chat_surface_meta(&md);
+        let (sha, theme, title, preview) = parse_chat_surface_meta(&md);
         assert_eq!(sha.as_deref(), Some("sha-focus-1"));
+        assert_eq!(theme, None);
         assert_eq!(title.as_deref(), Some("Focused Source"));
         assert_eq!(preview.as_deref(), Some("summarize this"));
         let _ = std::fs::remove_dir_all(&vault);

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -3255,6 +3255,148 @@ url: {url}\n\n\
     let meta = ChatFocusMeta {
         source_sha: sha.to_string(),
         title: source.title.clone(),
+        theme: None,
+    };
+    Some((pack, meta))
+}
+
+/// Caps for the theme-grounded chat pack — the claims ARE the content here,
+/// so the claim budget is far larger than the source pack's.
+const FOCUS_THEME_CLAIM_MAX: usize = 40;
+const FOCUS_THEME_SOURCE_MAX: usize = 24;
+
+/// Build the auto-injected context pack for "chat on this crystal theme":
+/// the grounded topic-page synthesis (when one exists) + the theme's active
+/// claims + the distinct sources they cite. Mirrors `build_source_focus_pack`.
+/// Returns None for a theme with no active claims (nothing to ground on).
+fn build_theme_focus_pack(
+    state: &AppState,
+    model: &IndexModel,
+    theme: &str,
+) -> Option<(String, ChatFocusMeta)> {
+    let mut claims: Vec<&ovp_index::ClaimRow> = model
+        .claims
+        .iter()
+        .filter(|c| {
+            c.theme.as_deref() == Some(theme)
+                && matches!(
+                    c.status,
+                    ovp_index::ClaimStatus::Durable | ovp_index::ClaimStatus::Caveated
+                )
+        })
+        .collect();
+    if claims.is_empty() {
+        return None;
+    }
+    claims.sort_by_key(|c| {
+        (
+            match c.status {
+                ovp_index::ClaimStatus::Durable => 0u8,
+                _ => 1,
+            },
+            c.claim_id.clone(),
+        )
+    });
+    let claim_total = claims.len();
+
+    // case id → source row, for the distinct-source roster.
+    let by_sha: HashMap<&str, &ovp_index::SourceRow> =
+        model.sources.iter().map(|s| (s.sha256.as_str(), s)).collect();
+    let case_to_sha: HashMap<&str, &str> = model
+        .packs
+        .iter()
+        .filter_map(|p| {
+            let case = p
+                .pack_dir
+                .trim_end_matches(['/', '\\'])
+                .rsplit(['/', '\\'])
+                .next()?;
+            Some((case, p.source_sha256.as_deref()?))
+        })
+        .collect();
+
+    let mut claims_block = String::new();
+    let mut seen_sources: Vec<&str> = Vec::new();
+    for c in claims.iter().take(FOCUS_THEME_CLAIM_MAX) {
+        let key = c
+            .claim_key
+            .as_deref()
+            .filter(|k| !k.is_empty())
+            .unwrap_or(c.claim_id.as_str());
+        let status = match c.status {
+            ovp_index::ClaimStatus::Durable => "durable",
+            _ => "caveated",
+        };
+        claims_block.push_str(&format!("- [claim:{key}] ({status}) {}\n", c.claim.trim()));
+        for case in &c.sources {
+            if let Some(sha) = case_to_sha.get(case.as_str())
+                && !seen_sources.contains(sha)
+            {
+                seen_sources.push(sha);
+            }
+        }
+    }
+    let claim_note = if claim_total > FOCUS_THEME_CLAIM_MAX {
+        format!("…({} more claims omitted)\n", claim_total - FOCUS_THEME_CLAIM_MAX)
+    } else {
+        String::new()
+    };
+
+    let mut sources_block = String::new();
+    let source_n = seen_sources.len();
+    for sha in seen_sources.iter().take(FOCUS_THEME_SOURCE_MAX) {
+        let title = by_sha
+            .get(*sha)
+            .and_then(|s| s.title.as_deref())
+            .filter(|t| !t.trim().is_empty())
+            .unwrap_or("(untitled)");
+        sources_block.push_str(&format!("- [source:{sha}] {title}\n"));
+    }
+    if sources_block.is_empty() {
+        sources_block.push_str("(no linked sources)\n");
+    }
+
+    // Grounded topic-page synthesis, when crystal-theme-pages has woven one.
+    let page_block = ovp_domain::crystal::theme_pages::ThemePagesFile::load(
+        &state
+            .vault_root
+            .join(".ovp")
+            .join("crystal")
+            .join("theme_pages.json"),
+    )
+    .ok()
+    .flatten()
+    .and_then(|f| f.pages.into_iter().find(|p| p.label == theme))
+    .map(|p| {
+        let mut out = String::new();
+        for sec in &p.sections {
+            out.push_str(&format!("### {}\n{}\n\n", sec.heading, sec.body));
+        }
+        out
+    })
+    .filter(|s| !s.trim().is_empty())
+    .unwrap_or_else(|| "(no synthesized topic page yet — reason from the claims)\n".into());
+
+    let pack = format!(
+        "[FOCUS CONTEXT — theme-grounded chat]\n\
+You are answering questions about ONE crystal knowledge theme. Prefer the \
+material below (topic-page synthesis, active claims, their sources). Cite \
+with [claim:…] or [source:…] when used. Vault-wide tools are allowed for \
+comparison, but the primary answer must stay grounded in this theme.\n\n\
+## Theme\n\
+{theme}\n\n\
+## Topic page\n\
+{page_block}\n\
+## Active claims ({claim_total})\n\
+{claims_block}{claim_note}\n\
+## Cited sources ({source_n})\n\
+{sources_block}"
+    );
+
+    let meta = ChatFocusMeta {
+        source_sha: String::new(),
+        title: Some(theme.to_string()),
+        theme: Some(theme.to_string()),
     };
     Some((pack, meta))
 }
@@ -3894,11 +4036,28 @@ fn handle_ask(
         .map(str::trim)
         .filter(|s| !s.is_empty() && s.len() <= 128)
         .map(str::to_string);
-    let focus_built = focus_source.as_deref().and_then(|sha| {
-        state
-            .current_model()
-            .and_then(|model| build_source_focus_pack(state, &model, sha))
-    });
+    // Theme-grounded variant ("chat on this knowledge"): claims + topic page
+    // instead of one document. focus_source wins when both are sent.
+    let focus_theme = parsed
+        .get("focus_theme")
+        .and_then(|s| s.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty() && s.len() <= 256)
+        .map(str::to_string);
+    let focus_built = focus_source
+        .as_deref()
+        .and_then(|sha| {
+            state
+                .current_model()
+                .and_then(|model| build_source_focus_pack(state, &model, sha))
+        })
+        .or_else(|| {
+            focus_theme.as_deref().and_then(|theme| {
+                state
+                    .current_model()
+                    .and_then(|model| build_theme_focus_pack(state, &model, theme))
+            })
+        });
     let focus_meta = focus_built.as_ref().map(|(_, m)| m.clone());
     // Agent path: full pack + user question as one user message (tools still
     // available). Legacy path: pack goes in context_prefix so retrieval still
@@ -4833,14 +4992,18 @@ fn handle_chats_list(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
     let list: Vec<serde_json::Value> = rows
         .into_iter()
         .map(|(mtime, name, path)| {
-            let (focus_source, focus_title, preview) = std::fs::read_to_string(&path)
-                .ok()
-                .map(|md| parse_chat_surface_meta(&md))
-                .unwrap_or((None, None, None));
+            let (focus_source, focus_theme, focus_title, preview) =
+                std::fs::read_to_string(&path)
+                    .ok()
+                    .map(|md| parse_chat_surface_meta(&md))
+                    .unwrap_or((None, None, None, None));
             let mut obj = serde_json::json!({ "name": name, "mtime": mtime });
             if let Some(map) = obj.as_object_mut() {
                 if let Some(sha) = focus_source {
                     map.insert("focus_source".into(), serde_json::json!(sha));
+                }
+                if let Some(theme) = focus_theme {
+                    map.insert("focus_theme".into(), serde_json::json!(theme));
                 }
                 if let Some(title) = focus_title {
                     map.insert("focus_title".into(), serde_json::json!(title));
@@ -5599,6 +5762,51 @@ mod tests {
         };
         ovp_index::write_evidence(&vault, &evidence).unwrap();
         vault
+    }
+
+    #[test]
+    fn theme_focus_pack_grounds_on_claims_sources_and_topic_page() {
+        let vault = portal_vault(
+            "theme-focus",
+            "50-Inbox/03-Processed/good.md",
+            "# Good\n\nbody text\n",
+        );
+        std::fs::create_dir_all(vault.join(".ovp/crystal")).unwrap();
+        std::fs::write(
+            vault.join(".ovp/crystal/theme_pages.json"),
+            serde_json::json!({
+                "schema": "ovp.theme_pages/v1",
+                "pages": [{
+                    "community_id": 1,
+                    "label": "memory",
+                    "label_zh": "",
+                    "claim_keys": ["c01"],
+                    "sections": [{
+                        "heading": "Overview",
+                        "body": "Filesystems act as memory [claim:c01]."
+                    }]
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let st = state(vault, None);
+        let model = st.current_model().expect("fixture model");
+
+        let (pack, meta) =
+            build_theme_focus_pack(&st, &model, "memory").expect("theme has claims");
+        // Claims block with status + stable key fallback (claim_id here).
+        assert!(pack.contains("[claim:c01] (durable)"), "{pack}");
+        // Distinct-source roster resolved case -> sha -> title.
+        assert!(pack.contains("[source:aaaa1111] Good Article"), "{pack}");
+        // Topic-page synthesis included verbatim.
+        assert!(pack.contains("Filesystems act as memory [claim:c01]."));
+        // Meta tags the transcript as theme-focused, never source-focused.
+        assert_eq!(meta.theme.as_deref(), Some("memory"));
+        assert!(meta.source_sha.is_empty());
+
+        // A theme with no active claims has nothing to ground on.
+        assert!(build_theme_focus_pack(&st, &model, "no-such-theme").is_none());
     }
 
     #[test]


### PR DESCRIPTION
Operator ask (#1 of the trio): Knowledge 页面也增加 chat on this.

**Where it lives**: the theme detail page (`/knowledge/theme/:t`) — the page where "this knowledge" is a concrete thing. The Knowledge home stays clean (whole-crystal chat is what Ask already is).

**Server** — `focus_theme` on POST /api/ask mirrors `focus_source`: `build_theme_focus_pack` injects (1) the grounded topic-page synthesis when `crystal-theme-pages` has woven one, (2) the theme's active claims — durable first, capped at 40 with an honest `(N more omitted)` note, (3) the distinct sources they cite. `focus_source` wins if both are sent.

**Transcripts** — `ChatFocusMeta.theme`, `ovp:focus_theme` header marker, parsed back by `parse_chat_surface_meta`, exposed on `/api/chats` → theme sessions get their own recents rail on the theme page, exactly like source sessions on the library page.

**SPA** — `SourceChatPanel` generalized into `FocusChatPanel` (discriminated `focus` target; source behavior unchanged including cite-grounding onto the library page). Theme page gets the **Chat on this knowledge** button above the graph rail + the dock with the same `?chat=` URL contract, theme-specific seeds/placeholder, and a `{claims} claims · {sources} sources` meta line (canonical-URL distinct count).

**Tests**: theme-focus header round-trip (ovp-memory 162), `theme_focus_pack_grounds_on_claims_sources_and_topic_page` (ovp-server 75), SPA tsc clean + vitest 161/161. Playwright live verify: dock opens grounded in 'Agent memory & retrieval' with '232 claims · 239 sources auto-included'.