### PR TITLE
fix(ask): focused-session replay grounds citations; claim_ids resolve across re-crystallize

### DIFF
--- a/console-ui/src/components/FocusChatPanel.tsx
+++ b/console-ui/src/components/FocusChatPanel.tsx
@@ -24,6 +24,7 @@ import { isReactImeComposing } from '../lib/ime';
 import { MarkdownView, type CiteMarks } from '../lib/markdown';
 import {
   displayUserQuestion,
+  groundCitesOnSource,
   parseChatTranscript,
 } from '../lib/chatTranscript';
 import { citationsFromAnswerText } from '../pages/AskPage';
@@ -32,28 +33,6 @@ import type { AskCitation, AskProgress, AskResponse, ChatEntry } from '../lib/ty
 /** Same marker set as Ask — claim/card/unit/source + bare ck-. */
 const CITE_RE =
   /\[\s*((?:claim|card|unit|source):[^\]\n]+?|ck-[^\]\s:]+)\s*\]/g;
-
-/** Ground unit/card/source cites back onto this library page when the
- * generic index lookup has no link (common for bare unit ids). */
-function groundCitesOnSource(cites: AskCitation[], sha: string): AskCitation[] {
-  return cites.map((c) => {
-    if (c.link_target) return c;
-    const kind = c.kind || (c.id.includes(':') ? c.id.slice(0, c.id.indexOf(':')) : '');
-    if (kind === 'source') {
-      const token = c.id.slice(c.id.indexOf(':') + 1).split(/\s+/)[0] ?? '';
-      if (!token || token === sha || token.startsWith(sha.slice(0, 12))) {
-        return { ...c, link_target: `/library/${encodeURIComponent(sha)}` };
-      }
-    }
-    if (kind === 'unit' || kind === 'card') {
-      return {
-        ...c,
-        link_target: `/library/${encodeURIComponent(sha)}?tab=memory`,
-      };
-    }
-    return c;
-  });
-}
 
 function citeLookupKey(id: string): string {
   const norm = id.startsWith('ck-') ? `claim:${id}` : id;

--- a/console-ui/src/lib/chatTranscript.test.ts
+++ b/console-ui/src/lib/chatTranscript.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   citationsInOrder,
+  groundCitesOnSource,
+  parseChatFocus,
   citeLinkTarget,
   displayUserQuestion,
   normalizeCiteToken,
@@ -88,5 +90,35 @@ describe('displayUserQuestion', () => {
     expect(displayUserQuestion('What is agent memory?')).toBe(
       'What is agent memory?',
     );
+  });
+});
+
+describe('focused-session replay grounding', () => {
+  const SHA = '816380d615c63038a3aae393ecaa8a2c624045a5a03200111d46e0f860183519';
+
+  it('parseChatFocus reads the header markers', () => {
+    const md = `# Ask — ts\n<!-- ovp:focus_source=${SHA} -->\n<!-- ovp:focus_title=事关7709 -->\n\n**Q:** hi`;
+    expect(parseChatFocus(md)).toEqual({ sha: SHA, theme: null });
+    expect(parseChatFocus('# Ask\n<!-- ovp:focus_theme=Agent Memory -->\n')).toEqual({
+      sha: null,
+      theme: 'Agent Memory',
+    });
+    expect(parseChatFocus('# Ask\n\n**Q:** hi')).toEqual({ sha: null, theme: null });
+  });
+
+  it('groundCitesOnSource sends units/cards to the memory tab, keeps links', () => {
+    // Operator regression 2026-08-07: /ask/chat/src-… showed "No detail
+    // page" for every unit — the focus sha grounds them like the live dock.
+    const out = groundCitesOnSource(
+      [
+        { id: 'unit:u-004-723d01f2', kind: 'unit', link_target: null },
+        { id: `source:${SHA}`, kind: 'source', link_target: null },
+        { id: 'claim:ck-x', kind: 'claim', link_target: '/knowledge#ck-x' },
+      ],
+      SHA,
+    );
+    expect(out[0].link_target).toBe(`/library/${SHA}?tab=memory`);
+    expect(out[1].link_target).toBe(`/library/${SHA}`);
+    expect(out[2].link_target).toBe('/knowledge#ck-x');
   });
 });

--- a/console-ui/src/lib/chatTranscript.test.ts
+++ b/console-ui/src/lib/chatTranscript.test.ts
@@ -3,6 +3,7 @@ import {
   citationsInOrder,
   groundCitesOnSource,
   parseChatFocus,
+  savedReplayPlan,
   citeLinkTarget,
   displayUserQuestion,
   normalizeCiteToken,
@@ -120,5 +121,30 @@ describe('focused-session replay grounding', () => {
     expect(out[0].link_target).toBe(`/library/${SHA}?tab=memory`);
     expect(out[1].link_target).toBe(`/library/${SHA}`);
     expect(out[2].link_target).toBe('/knowledge#ck-x');
+  });
+});
+
+describe('savedReplayPlan — replay source + error priority', () => {
+  const MD = '# Ask — ts\n<!-- ovp:focus_source=abc123 -->\n\n**Q:** hi\n\n**A:** there [unit:u-1]\n';
+
+  it('audit session wins when it has turns (focus still parsed)', () => {
+    const plan = savedReplayPlan(MD, 2);
+    expect(plan.kind).toBe('session');
+    expect(plan.focus.sha).toBe('abc123');
+  });
+
+  it('falls back to markdown turns when the session is empty', () => {
+    const plan = savedReplayPlan(MD, 0);
+    expect(plan.kind).toBe('markdown');
+    expect(plan.parsedTurns).toHaveLength(1);
+    expect(plan.parsedTurns[0].question).toBe('hi');
+  });
+
+  it('markdown loaded but turn-less is EMPTY; load failure is LOAD ERROR', () => {
+    expect(savedReplayPlan('# Ask — ts\n', 0).kind).toBe('empty');
+    // Both fetches failed: must NOT masquerade as an empty-but-fine chat.
+    expect(savedReplayPlan(null, 0).kind).toBe('loadError');
+    // …but a live audit session still replays even without markdown.
+    expect(savedReplayPlan(null, 3).kind).toBe('session');
   });
 });

--- a/console-ui/src/lib/chatTranscript.ts
+++ b/console-ui/src/lib/chatTranscript.ts
@@ -43,6 +43,48 @@ export function normalizeCiteToken(token: string): string {
 /** Best-effort portal link for a citation key when replaying a saved chat
  * (no live evidence sidecar). Claims deep-link by key; cards/units have no
  * stable sha without the index. */
+/** Ground unit/card/source cites onto a focused source's library page when
+ * the generic index lookup has no link (modern unit ids have no standalone
+ * page — their home is the source's memory tab). Shared by the focus chat
+ * dock and Ask-page replay of focused sessions. */
+export function groundCitesOnSource<
+  T extends { id: string; kind?: string; link_target?: string | null },
+>(cites: T[], sha: string): T[] {
+  return cites.map((c) => {
+    if (c.link_target) return c;
+    const kind = c.kind || (c.id.includes(':') ? c.id.slice(0, c.id.indexOf(':')) : '');
+    if (kind === 'source') {
+      const token = c.id.slice(c.id.indexOf(':') + 1).split(/\s+/)[0] ?? '';
+      if (!token || token === sha || token.startsWith(sha.slice(0, 12))) {
+        return { ...c, link_target: `/library/${encodeURIComponent(sha)}` };
+      }
+    }
+    if (kind === 'unit' || kind === 'card') {
+      return {
+        ...c,
+        link_target: `/library/${encodeURIComponent(sha)}?tab=memory`,
+      };
+    }
+    return c;
+  });
+}
+
+/** Focus markers from a saved chat's header (`ovp:focus_source` /
+ * `ovp:focus_theme`) — the replay surface needs them to ground citations
+ * exactly like the live dock did. */
+export function parseChatFocus(md: string): { sha: string | null; theme: string | null } {
+  let sha: string | null = null;
+  let theme: string | null = null;
+  for (const line of md.split('\n', 40)) {
+    const l = line.trim();
+    const src = l.match(/^<!-- ovp:focus_source=(.+?) -->$/);
+    if (src) sha = src[1].trim() || null;
+    const th = l.match(/^<!-- ovp:focus_theme=(.+?) -->$/);
+    if (th) theme = th[1].trim() || null;
+  }
+  return { sha, theme };
+}
+
 export function citeLinkTarget(id: string): string | null {
   if (id.startsWith('claim:')) {
     const key = id.slice('claim:'.length);

--- a/console-ui/src/lib/chatTranscript.ts
+++ b/console-ui/src/lib/chatTranscript.ts
@@ -69,6 +69,40 @@ export function groundCitesOnSource<
   });
 }
 
+/** Replay-source decision for a saved chat (`/ask/chat/:id`) — pure, so the
+ * error-priority matrix is testable without rendering:
+ * - audit session has turns → replay those (richest: trails + stop reasons);
+ * - else markdown parses → replay the markdown turns;
+ * - else markdown LOADED but has no turns → honest "empty" state;
+ * - else (markdown load failed too) → load error, never "empty"
+ *   (CodeRabbit: a swallowed fetch failure must not masquerade as an
+ *   empty-but-fine chat).
+ * `md === null` means the markdown fetch failed. Focus markers ride along —
+ * the caller grounds citations with them. */
+export interface SavedReplayPlan {
+  focus: { sha: string | null; theme: string | null };
+  kind: 'session' | 'markdown' | 'empty' | 'loadError';
+  parsedTurns: { question: string; answer: string }[];
+}
+
+export function savedReplayPlan(
+  md: string | null,
+  sessionTurnCount: number,
+): SavedReplayPlan {
+  const focus = parseChatFocus(md ?? '');
+  if (sessionTurnCount > 0) {
+    return { focus, kind: 'session', parsedTurns: [] };
+  }
+  if (md === null) {
+    return { focus, kind: 'loadError', parsedTurns: [] };
+  }
+  const parsedTurns = parseChatTranscript(md);
+  if (parsedTurns.length === 0) {
+    return { focus, kind: 'empty', parsedTurns: [] };
+  }
+  return { focus, kind: 'markdown', parsedTurns };
+}
+
 /** Focus markers from a saved chat's header (`ovp:focus_source` /
  * `ovp:focus_theme`) — the replay surface needs them to ground citations
  * exactly like the live dock did. */

--- a/console-ui/src/pages/AskPage.citations.test.ts
+++ b/console-ui/src/pages/AskPage.citations.test.ts
@@ -11,7 +11,9 @@ import {
 const SHA = '6dc988d1d27614055ed13de8010eddbd44f107635061e25c7a6a5647f887a0a3';
 const model = {
   sources: [{ sha256: SHA, title: 'The Actual Article Title' }],
-  claims: [{ claim_key: 'ck-abc', claim: 'The claim text as indexed' }],
+  claims: [
+    { claim_id: 'agents-b001-3', claim_key: 'ck-abc', claim: 'The claim text as indexed' },
+  ],
 };
 
 describe('citationsFromAnswerText with an index lookup', () => {
@@ -28,6 +30,16 @@ describe('citationsFromAnswerText with an index lookup', () => {
   it('resolves claim keys to claim text', () => {
     const [c] = citationsFromAnswerText(
       'as shown [claim:ck-abc]',
+      makeCitationTitleLookup(model),
+    );
+    expect(c.title).toBe('The claim text as indexed');
+  });
+
+  it('resolves run-scoped claim_ids too — old transcripts cite them', () => {
+    // Operator regression 2026-08-07: a re-crystallize renumbered claim_ids
+    // and every pre-rerun chat lost its claim titles (lookup was key-only).
+    const [c] = citationsFromAnswerText(
+      'as shown [claim:agents-b001-3]',
       makeCitationTitleLookup(model),
     );
     expect(c.title).toBe('The claim text as indexed');

--- a/console-ui/src/pages/AskPage.tsx
+++ b/console-ui/src/pages/AskPage.tsx
@@ -28,7 +28,9 @@ import {
   citationsInOrder,
   citeLinkTarget,
   displayUserQuestion,
+  groundCitesOnSource,
   normalizeCiteToken,
+  parseChatFocus,
   parseChatTranscript,
 } from '../lib/chatTranscript';
 import { failureHintKey } from '../lib/derive';
@@ -172,7 +174,7 @@ function humanizeLegacyPath(path: string): string | null {
 export function makeCitationTitleLookup(
   model: {
     sources: { sha256: string; title?: string; rel_path?: string }[];
-    claims: { claim_key?: string; claim: string }[];
+    claims: { claim_id: string; claim_key?: string; claim: string }[];
   } | null,
 ): CitationTitleLookup {
   const rows = model?.sources ?? [];
@@ -182,11 +184,17 @@ export function makeCitationTitleLookup(
       .filter((s) => s.rel_path)
       .map((s) => [(s.rel_path as string).replace(/\.md$/, ''), s]),
   );
-  const claims = new Map(
-    (model?.claims ?? [])
-      .filter((c) => c.claim_key)
-      .map((c) => [c.claim_key as string, c.claim]),
-  );
+  // Both identities resolve: claim_key (ck-…, stable across runs) and the
+  // run-scoped claim_id — old transcripts cite ids from the run that was
+  // current when they were written, and a re-crystallize must not strand
+  // them (operator report 2026-08-07). Keys inserted last so they win.
+  const claims = new Map<string, string>();
+  for (const c of model?.claims ?? []) {
+    claims.set(c.claim_id, c.claim);
+  }
+  for (const c of model?.claims ?? []) {
+    if (c.claim_key) claims.set(c.claim_key, c.claim);
+  }
   const sourceRow = (token: string) => {
     const exact = bySha.get(token);
     if (exact) return exact;
@@ -767,56 +775,72 @@ export default function AskPage() {
     // Agent chats replay from the AUDIT transcript (full per-turn trails
     // survive a reload — operator finding: History lost the 复盘 detail);
     // legacy chats keep the markdown parse.
-    fetchAskSession(openChat)
-      // An older server (no session endpoint) or a replay-read failure must
-      // not kill the page — markdown replay still works.
-      .catch(() => ({ turns: [] }))
-      .then((session) => {
-        if (cancelled || openChatRef.current !== openChat) return null;
-        if (session.turns.length === 0) return fetchChatMarkdown(openChat);
-        setSavedTurns(
-          session.turns.map((turn) => ({
-            question: displayUserQuestion(turn.question),
-            errorKey: null,
-            response: {
-              answer: turn.answer,
-              citations: citationsFromAnswerText(turn.answer, citeLookupRef.current),
-              verified: null,
-              context_hits: 0,
-              chat: openChat,
-              agent: true,
-              stopped_reason: turn.stopped_reason,
-              turn_id: turn.turn_id,
-              tool_trace: turn.tool_trace,
-            },
-          })),
-        );
-        return null;
-      })
+    // Markdown FIRST: its header carries the session's focus markers
+    // (ovp:focus_source/theme), and a focused session's unit/card cites only
+    // resolve when grounded onto that source's page — exactly what the live
+    // dock did. Without this, replay showed "No detail page in this vault"
+    // for every unit (operator report 2026-08-07).
+    fetchChatMarkdown(openChat)
+      .catch(() => '')
       .then((md) => {
-        if (md == null || cancelled || openChatRef.current !== openChat) return;
-        const parsed = parseChatTranscript(md);
-        if (parsed.length === 0) {
-          setSavedError(t('ask.chatParseEmpty'));
-          setSavedTurns([]);
-          return;
-        }
-        setSavedTurns(
-          parsed.map((turn) => {
-            const citations = citationsFromAnswerText(turn.answer, citeLookupRef.current);
-            return {
-              question: turn.question,
-              errorKey: null,
-              response: {
-                answer: turn.answer,
-                citations,
-                verified: null,
-                context_hits: citations.length,
-                chat: openChat,
-              },
-            };
-          }),
-        );
+        if (cancelled || openChatRef.current !== openChat) return;
+        const focus = parseChatFocus(md);
+        const ground = (cites: AskCitation[]) =>
+          focus.sha ? groundCitesOnSource(cites, focus.sha) : cites;
+        // Agent chats replay from the AUDIT transcript; legacy chats fall
+        // back to the markdown parse. An older server (no session endpoint)
+        // or a replay-read failure must not kill the page.
+        return fetchAskSession(openChat)
+          .catch(() => ({ turns: [] }))
+          .then((session) => {
+            if (cancelled || openChatRef.current !== openChat) return;
+            if (session.turns.length > 0) {
+              setSavedTurns(
+                session.turns.map((turn) => ({
+                  question: displayUserQuestion(turn.question),
+                  errorKey: null,
+                  response: {
+                    answer: turn.answer,
+                    citations: ground(
+                      citationsFromAnswerText(turn.answer, citeLookupRef.current),
+                    ),
+                    verified: null,
+                    context_hits: 0,
+                    chat: openChat,
+                    agent: true,
+                    stopped_reason: turn.stopped_reason,
+                    turn_id: turn.turn_id,
+                    tool_trace: turn.tool_trace,
+                  },
+                })),
+              );
+              return;
+            }
+            const parsed = parseChatTranscript(md);
+            if (parsed.length === 0) {
+              setSavedError(t('ask.chatParseEmpty'));
+              setSavedTurns([]);
+              return;
+            }
+            setSavedTurns(
+              parsed.map((turn) => {
+                const citations = ground(
+                  citationsFromAnswerText(turn.answer, citeLookupRef.current),
+                );
+                return {
+                  question: turn.question,
+                  errorKey: null,
+                  response: {
+                    answer: turn.answer,
+                    citations,
+                    verified: null,
+                    context_hits: citations.length,
+                    chat: openChat,
+                  },
+                };
+              }),
+            );
+          });
       })
       .catch(() => {
         if (!cancelled && openChatRef.current === openChat) {

--- a/console-ui/src/pages/AskPage.tsx
+++ b/console-ui/src/pages/AskPage.tsx
@@ -30,8 +30,8 @@ import {
   displayUserQuestion,
   groundCitesOnSource,
   normalizeCiteToken,
-  parseChatFocus,
   parseChatTranscript,
+  savedReplayPlan,
 } from '../lib/chatTranscript';
 import { failureHintKey } from '../lib/derive';
 import { isReactImeComposing } from '../lib/ime';
@@ -779,68 +779,70 @@ export default function AskPage() {
     // (ovp:focus_source/theme), and a focused session's unit/card cites only
     // resolve when grounded onto that source's page — exactly what the live
     // dock did. Without this, replay showed "No detail page in this vault"
-    // for every unit (operator report 2026-08-07).
-    fetchChatMarkdown(openChat)
-      .catch(() => '')
-      .then((md) => {
+    // for every unit (operator report 2026-08-07). `null` = load failed —
+    // savedReplayPlan keeps that distinct from an empty chat.
+    Promise.all([
+      fetchChatMarkdown(openChat).catch(() => null),
+      // Agent chats replay from the AUDIT transcript; legacy chats fall back
+      // to the markdown parse. An older server (no session endpoint) or a
+      // replay-read failure must not kill the page.
+      fetchAskSession(openChat).catch(() => ({ turns: [] })),
+    ])
+      .then(([md, session]) => {
         if (cancelled || openChatRef.current !== openChat) return;
-        const focus = parseChatFocus(md);
+        const plan = savedReplayPlan(md, session.turns.length);
         const ground = (cites: AskCitation[]) =>
-          focus.sha ? groundCitesOnSource(cites, focus.sha) : cites;
-        // Agent chats replay from the AUDIT transcript; legacy chats fall
-        // back to the markdown parse. An older server (no session endpoint)
-        // or a replay-read failure must not kill the page.
-        return fetchAskSession(openChat)
-          .catch(() => ({ turns: [] }))
-          .then((session) => {
-            if (cancelled || openChatRef.current !== openChat) return;
-            if (session.turns.length > 0) {
-              setSavedTurns(
-                session.turns.map((turn) => ({
-                  question: displayUserQuestion(turn.question),
-                  errorKey: null,
-                  response: {
-                    answer: turn.answer,
-                    citations: ground(
-                      citationsFromAnswerText(turn.answer, citeLookupRef.current),
-                    ),
-                    verified: null,
-                    context_hits: 0,
-                    chat: openChat,
-                    agent: true,
-                    stopped_reason: turn.stopped_reason,
-                    turn_id: turn.turn_id,
-                    tool_trace: turn.tool_trace,
-                  },
-                })),
-              );
-              return;
-            }
-            const parsed = parseChatTranscript(md);
-            if (parsed.length === 0) {
-              setSavedError(t('ask.chatParseEmpty'));
-              setSavedTurns([]);
-              return;
-            }
-            setSavedTurns(
-              parsed.map((turn) => {
-                const citations = ground(
+          plan.focus.sha ? groundCitesOnSource(cites, plan.focus.sha) : cites;
+        if (plan.kind === 'loadError') {
+          setSavedError(t('ask.chatLoadError'));
+          setSavedTurns([]);
+          return;
+        }
+        if (plan.kind === 'empty') {
+          setSavedError(t('ask.chatParseEmpty'));
+          setSavedTurns([]);
+          return;
+        }
+        if (plan.kind === 'session') {
+          setSavedTurns(
+            session.turns.map((turn) => ({
+              question: displayUserQuestion(turn.question),
+              errorKey: null,
+              response: {
+                answer: turn.answer,
+                citations: ground(
                   citationsFromAnswerText(turn.answer, citeLookupRef.current),
-                );
-                return {
-                  question: turn.question,
-                  errorKey: null,
-                  response: {
-                    answer: turn.answer,
-                    citations,
-                    verified: null,
-                    context_hits: citations.length,
-                    chat: openChat,
-                  },
-                };
-              }),
+                ),
+                verified: null,
+                context_hits: 0,
+                chat: openChat,
+                agent: true,
+                stopped_reason: turn.stopped_reason,
+                turn_id: turn.turn_id,
+                tool_trace: turn.tool_trace,
+              },
+            })),
+          );
+          return;
+        }
+        setSavedTurns(
+          plan.parsedTurns.map((turn) => {
+            const citations = ground(
+              citationsFromAnswerText(turn.answer, citeLookupRef.current),
             );
-          });
+            return {
+              question: turn.question,
+              errorKey: null,
+              response: {
+                answer: turn.answer,
+                citations,
+                verified: null,
+                context_hits: citations.length,
+                chat: openChat,
+              },
+            };
+          }),
+        );
       })
       .catch(() => {
         if (!cancelled && openChatRef.current === openChat) {


### PR DESCRIPTION
Operator report: `/ask/chat/src-…` showed **No detail page in this vault** for every `[unit:…]` citation, and claim cites from older sessions stopped resolving.

Both were replay-layer gaps — the data was intact (source processed, units present in its memory):

1. **Units/cards in focused sessions** — modern unit ids have no standalone page; their home is the focus source's memory tab. The live dock grounded cites there (`groundCitesOnSource`), but opening the same session in Ask never did, even though the transcript header carries `ovp:focus_source`. Replay now fetches the markdown first, parses the focus markers (`parseChatFocus`), and applies the same grounding. `groundCitesOnSource` moved to `chatTranscript.ts` (shared, and removes an AskPage↔FocusChatPanel import-cycle risk).
2. **Claims after a re-crystallize** — the citation lookup was keyed by `claim_key` only, but transcripts cite the *run-scoped* `claim_id` that was current when written; the Aug-6 crystallize rerun renumbered them. The lookup now carries **both** identities (stable keys win collisions). Ids that genuinely ceased to exist keep the honest title fallback.

Tests: vitest 166/166 (focus-marker round-trip, grounding matrix incl. already-linked cites, claim_id resolution regression). Live playwright on the exact reported session: zero 'No detail page', every unit gets an Open→ into the source memory tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved saved-chat replay by restoring focused source and theme context.
  * Citations now correctly link to the focused source, including units, sources, and claims.
  * Added support for resolving run-specific claim citations alongside existing claim references.
* **Bug Fixes**
  * Replay remains available when audit-session data is unavailable or cannot be read.
  * Empty saved chats are distinguished from chats that fail to load.
  * Existing citation links are preserved during source grounding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->