### PR TITLE
fix(ask): one citation resolver — server receipts on replay + unit/card resolution

### DIFF
--- a/console-ui/src/components/FocusChatPanel.tsx
+++ b/console-ui/src/components/FocusChatPanel.tsx
@@ -23,6 +23,7 @@ import {
 import { isReactImeComposing } from '../lib/ime';
 import { MarkdownView, type CiteMarks } from '../lib/markdown';
 import {
+  applyMemoryTitles,
   displayUserQuestion,
   groundCitesOnSource,
   parseChatTranscript,
@@ -109,6 +110,9 @@ export interface FocusChatPanelProps {
   title: string;
   /** Compact, already-localized context meta line ("8 cards · 12 units · …"). */
   metaLine: string;
+  /** Readable titles for unit/card cite chips (canonical id → snippet) —
+   * the source page builds this from its memory payload. */
+  citeTitles?: Map<string, string> | null;
   open: boolean;
   onClose: () => void;
   /** Optional session stem from URL (`?chat=`) to resume. */
@@ -119,6 +123,7 @@ export default function FocusChatPanel({
   focus,
   title,
   metaLine,
+  citeTitles = null,
   open,
   onClose,
   resumeChat = null,
@@ -141,7 +146,8 @@ export default function FocusChatPanel({
 
   const toTurn = (question: string, answer: string, chat: string | null, extra?: Partial<AskResponse>): Turn => {
     const raw = citationsFromAnswerText(answer);
-    const citations = sha ? groundCitesOnSource(raw, sha) : raw;
+    const grounded = sha ? groundCitesOnSource(raw, sha) : raw;
+    const citations = citeTitles ? applyMemoryTitles(grounded, citeTitles) : grounded;
     return {
       question: displayUserQuestion(question),
       errorKey: null,
@@ -201,6 +207,7 @@ export default function FocusChatPanel({
                 stopped_reason: turn.stopped_reason,
                 turn_id: turn.turn_id,
                 tool_trace: turn.tool_trace,
+                ...(turn.citations?.length ? { citations: turn.citations } : {}),
               }),
             ),
           );
@@ -273,6 +280,7 @@ export default function FocusChatPanel({
                 stopped_reason: turn.stopped_reason,
                 turn_id: turn.turn_id,
                 tool_trace: turn.tool_trace,
+                ...(turn.citations?.length ? { citations: turn.citations } : {}),
               }),
             ),
           );
@@ -322,7 +330,10 @@ export default function FocusChatPanel({
         const rawCites = response.citations?.length
           ? response.citations
           : citationsFromAnswerText(response.answer);
-        const citations = sha ? groundCitesOnSource(rawCites, sha) : rawCites;
+        const grounded = sha ? groundCitesOnSource(rawCites, sha) : rawCites;
+        const citations = citeTitles
+          ? applyMemoryTitles(grounded, citeTitles)
+          : grounded;
         setTurns((prev) =>
           prev.map((turn, i) =>
             i === prev.length - 1

--- a/console-ui/src/lib/chatTranscript.test.ts
+++ b/console-ui/src/lib/chatTranscript.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
+  applyMemoryTitles,
+  buildMemoryTitleMap,
   citationsInOrder,
   groundCitesOnSource,
   parseChatFocus,
@@ -146,5 +148,40 @@ describe('savedReplayPlan — replay source + error priority', () => {
     expect(savedReplayPlan(null, 0).kind).toBe('loadError');
     // …but a live audit session still replays even without markdown.
     expect(savedReplayPlan(null, 3).kind).toBe('session');
+  });
+});
+
+describe('memory titles on replayed citation chips', () => {
+  const memory = {
+    cards: [{ id: 'c-1', title: 'The Leverage Card' }],
+    units: [
+      { unit_id: 'u-011-ecc4bc16', text: 'fallback text', quote: '基金与国际投行签TRS合同,付Swap Spread换每日2倍收益现金流', line: 14 },
+      { unit_id: 'u-empty', text: '  ', quote: '', line: null },
+    ],
+  };
+
+  it('buildMemoryTitleMap keys canonical ids, prefers quotes, skips empties', () => {
+    const m = buildMemoryTitleMap(memory);
+    expect(m.get('unit:u-011-ecc4bc16')).toContain('基金与国际投行签TRS合同');
+    expect(m.get('card:c-1')).toBe('The Leverage Card');
+    expect(m.has('unit:u-empty')).toBe(false);
+  });
+
+  it('applyMemoryTitles fills bare-id chips, never overwrites real titles', () => {
+    // Operator report 2026-08-07: chips read "u-011-ecc4bc16" — the raw id.
+    const m = buildMemoryTitleMap(memory);
+    const out = applyMemoryTitles(
+      [
+        { id: 'unit:u-011-ecc4bc16', title: 'unit:u-011-ecc4bc16' },
+        { id: 'unit:u-011-ecc4bc16', title: 'u-011-ecc4bc16' },
+        { id: 'card:c-1', title: 'Server-provided real title' },
+        { id: 'unit:u-unknown', title: 'unit:u-unknown' },
+      ],
+      m,
+    );
+    expect(out[0].title).toContain('TRS');
+    expect(out[1].title).toContain('TRS');
+    expect(out[2].title).toBe('Server-provided real title');
+    expect(out[3].title).toBe('unit:u-unknown');
   });
 });

--- a/console-ui/src/lib/chatTranscript.ts
+++ b/console-ui/src/lib/chatTranscript.ts
@@ -69,6 +69,43 @@ export function groundCitesOnSource<
   });
 }
 
+/** Human-readable titles for a focused source's memory layer, keyed by
+ * canonical cite id (`unit:<id>` / `card:<id>`). Units title with their
+ * verbatim quote (else text) snippet — the evidence sidecar isn't loaded in
+ * the SPA, but a focused session's `/api/source/:sha` payload carries it. */
+export function buildMemoryTitleMap(memory: {
+  cards: { id?: string; title: string }[];
+  units: { unit_id: string; text: string; quote: string; line: number | null }[];
+}): Map<string, string> {
+  const clip = (s: string, n = 90) => {
+    const t = s.trim().replace(/\s+/g, ' ');
+    return t.length > n ? `${t.slice(0, n - 1)}…` : t;
+  };
+  const out = new Map<string, string>();
+  for (const u of memory.units) {
+    const body = u.quote.trim() || u.text.trim();
+    if (!body) continue;
+    out.set(`unit:${u.unit_id}`, clip(body));
+  }
+  for (const c of memory.cards) {
+    if (c.id && c.title.trim()) out.set(`card:${c.id}`, clip(c.title, 90));
+  }
+  return out;
+}
+
+/** Fill readable titles into citation chips whose title degraded to the raw
+ * id (replay builds citations from answer text alone — server receipts have
+ * titles, reconstructed ones don't). Never overwrites a real title. */
+export function applyMemoryTitles<
+  T extends { id: string; title?: string | null },
+>(cites: T[], titles: Map<string, string>): T[] {
+  return cites.map((c) => {
+    const bare = !c.title || c.title === c.id || c.id.endsWith(`:${c.title}`);
+    const better = titles.get(c.id);
+    return bare && better ? { ...c, title: better } : c;
+  });
+}
+
 /** Replay-source decision for a saved chat (`/ask/chat/:id`) — pure, so the
  * error-priority matrix is testable without rendering:
  * - audit session has turns → replay those (richest: trails + stop reasons);

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -358,6 +358,9 @@ export interface AskSessionTurn {
   question: string;
   answer: string;
   stopped_reason: string;
+  /** Server-resolved citation receipts (same resolver as live answers).
+   * Absent only on pre-consolidation servers — clients then reconstruct. */
+  citations?: AskCitation[];
   tool_trace: AskTraceEntry[];
 }
 

--- a/console-ui/src/pages/AskPage.citations.test.ts
+++ b/console-ui/src/pages/AskPage.citations.test.ts
@@ -140,3 +140,14 @@ describe('tolerant + legacy citation resolution', () => {
     expect(c.link_target).toBeNull();
   });
 });
+
+describe('modern unit/card ids never shadow real titles', () => {
+  it('lookup returns null for non-path unit ids (receipt title must win)', () => {
+    // 2026-08-07 regression: humanizeLegacyPath('u-006-b13dec99') returned
+    // the id itself, and lookup results outrank c.title in citationTitle —
+    // masking server-resolved quote titles on every replay surface.
+    const lookup = makeCitationTitleLookup({ sources: [], claims: [] });
+    expect(lookup('unit', 'u-006-b13dec99')).toBeNull();
+    expect(lookup('card', '40-Resources/Reader/good:0')).not.toBeUndefined();
+  });
+});

--- a/console-ui/src/pages/AskPage.tsx
+++ b/console-ui/src/pages/AskPage.tsx
@@ -21,6 +21,7 @@ import {
   fetchAskStatus,
   fetchChatMarkdown,
   fetchChats,
+  fetchSourceDetail,
   postAsk,
 } from '../lib/api';
 import { useModel } from '../model';
@@ -28,6 +29,8 @@ import {
   citationsInOrder,
   citeLinkTarget,
   displayUserQuestion,
+  applyMemoryTitles,
+  buildMemoryTitleMap,
   groundCitesOnSource,
   normalizeCiteToken,
   parseChatTranscript,
@@ -227,8 +230,13 @@ export function makeCitationTitleLookup(
       if (hit) {
         return { title: hit.title || null, link: `/library/${hit.sha256}` };
       }
+      // Only LEGACY ids embed a note path. A modern id (u-NNN-hash) fed
+      // through the humanizer comes back as itself — and a lookup result
+      // SHADOWS real titles from server receipts (2026-08-07 raw-id
+      // regression: every downstream fix was masked right here).
+      if (!body.includes('/')) return null;
       const human = humanizeLegacyPath(body);
-      return human ? { title: human } : null;
+      return human && human !== body ? { title: human } : null;
     }
     return null;
   };
@@ -788,11 +796,26 @@ export default function AskPage() {
       // replay-read failure must not kill the page.
       fetchAskSession(openChat).catch(() => ({ turns: [] })),
     ])
-      .then(([md, session]) => {
+      .then(async ([md, session]) => {
         if (cancelled || openChatRef.current !== openChat) return;
         const plan = savedReplayPlan(md, session.turns.length);
-        const ground = (cites: AskCitation[]) =>
-          plan.focus.sha ? groundCitesOnSource(cites, plan.focus.sha) : cites;
+        // Focused session: the source's memory payload supplies readable
+        // titles for unit/card chips (replay reconstructs citations from
+        // text alone, so without this they degrade to raw ids — operator
+        // report 2026-08-07). Best-effort; chips fall back to ids.
+        let memoryTitles: Map<string, string> | null = null;
+        if (plan.focus.sha && (plan.kind === 'session' || plan.kind === 'markdown')) {
+          memoryTitles = await fetchSourceDetail(plan.focus.sha)
+            .then((d) => buildMemoryTitleMap(d.memory))
+            .catch(() => null);
+          if (cancelled || openChatRef.current !== openChat) return;
+        }
+        const ground = (cites: AskCitation[]) => {
+          const grounded = plan.focus.sha
+            ? groundCitesOnSource(cites, plan.focus.sha)
+            : cites;
+          return memoryTitles ? applyMemoryTitles(grounded, memoryTitles) : grounded;
+        };
         if (plan.kind === 'loadError') {
           setSavedError(t('ask.chatLoadError'));
           setSavedTurns([]);
@@ -810,9 +833,11 @@ export default function AskPage() {
               errorKey: null,
               response: {
                 answer: turn.answer,
-                citations: ground(
-                  citationsFromAnswerText(turn.answer, citeLookupRef.current),
-                ),
+                // Server receipts are authoritative (one resolver for live +
+                // replay); text reconstruction only covers older servers.
+                citations: turn.citations?.length
+                  ? turn.citations
+                  : ground(citationsFromAnswerText(turn.answer, citeLookupRef.current)),
                 verified: null,
                 context_hits: 0,
                 chat: openChat,

--- a/console-ui/src/pages/SourceDetailPage.tsx
+++ b/console-ui/src/pages/SourceDetailPage.tsx
@@ -33,6 +33,7 @@ import {
   themeRoute,
   type LibraryFilter,
 } from '../lib/derive';
+import { buildMemoryTitleMap } from '../lib/chatTranscript';
 import { isReactImeComposing } from '../lib/ime';
 import { MarkdownView, sourceImageCandidates } from '../lib/markdown';
 import { companionLinks, isPrimarilyEnglish } from '../lib/sourceLinks';
@@ -1117,6 +1118,7 @@ export default function SourceDetailPage() {
         <FocusChatPanel
           focus={{ kind: 'source', sha: source.sha256 }}
           title={title}
+          citeTitles={buildMemoryTitleMap(memory)}
           metaLine={t('source.chatMetaLine', {
             cards: memory.cards.length,
             units: memory.units.length,

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -462,7 +462,7 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
             &ovp_domain::vault_layout::VaultLayout::new(),
         );
         let citations = match read_index(&state.vault_root).ok() {
-            Some(m) => ovp_memory::receipts::agent_citations(&done.answer, &m, &records),
+            Some(m) => ovp_memory::receipts::agent_citations(&done.answer, &m, &records, ovp_index::read_evidence(&state.vault_root).ok().as_ref()),
             None => ovp_memory::receipts::agent_citations_unindexed(&done.answer, &records),
         };
         let verified = citations.iter().filter(|c| c["verified"] == true).count();
@@ -590,7 +590,7 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
         &ovp_domain::vault_layout::VaultLayout::new(),
     );
     let citations = match tools.index_snapshot().as_deref() {
-        Some(m) => ovp_memory::receipts::agent_citations(&outcome.answer, m, &records),
+        Some(m) => ovp_memory::receipts::agent_citations(&outcome.answer, m, &records, ovp_index::read_evidence(&state.vault_root).ok().as_ref()),
         None => ovp_memory::receipts::agent_citations_unindexed(&outcome.answer, &records),
     };
     // A racing process completed this keyed turn between the preflight

--- a/crates/ovp-memory/src/receipts.rs
+++ b/crates/ovp-memory/src/receipts.rs
@@ -5,6 +5,7 @@
 
 use crate::verify::citations_in_order;
 use ovp_domain::crystal::DurableRecord;
+use ovp_index::evidence::EvidenceModel;
 use ovp_index::IndexModel;
 
 /// Models decorate citation ids in the wild — `[source:<sha> Some Title]`,
@@ -86,6 +87,7 @@ pub fn agent_citations(
     answer: &str,
     model: &IndexModel,
     records: &[DurableRecord],
+    evidence: Option<&EvidenceModel>,
 ) -> Vec<serde_json::Value> {
     citations_in_order(answer)
         .into_iter()
@@ -131,6 +133,66 @@ pub fn agent_citations(
                         "kind": "source",
                         "title": title,
                         "link_target": hit.map(|s| format!("/library/{}", s.sha256)),
+                        "verified": hit.is_some(),
+                    })
+                }
+                // Units/cards live in the evidence sidecar — the sidecar rows
+                // carry their source sha, so resolution needs NO focus
+                // context (2026-08-07 operator report: every surface that
+                // reconstructed these client-side showed raw ids; resolve
+                // them HERE, once). Fail-closed on ambiguity, like claims.
+                "unit" => {
+                    let hits: Vec<_> = evidence
+                        .map(|ev| ev.units.iter().filter(|u| u.unit_id == id).collect())
+                        .unwrap_or_default();
+                    let hit = (hits.len() == 1).then(|| hits[0]);
+                    let title = hit
+                        .map(|u| {
+                            let body = if u.quote.trim().is_empty() { &u.text } else { &u.quote };
+                            body.trim().chars().take(120).collect::<String>()
+                        })
+                        .filter(|t| !t.is_empty())
+                        .or(decorated);
+                    let link = hit.and_then(|u| {
+                        u.source_sha256
+                            .as_deref()
+                            .map(|sha| format!("/library/{sha}?tab=memory"))
+                    });
+                    serde_json::json!({
+                        "id": stable_id,
+                        "kind": "unit",
+                        "title": title,
+                        "link_target": link,
+                        "verified": hit.is_some(),
+                    })
+                }
+                "card" => {
+                    // Evidence card ids are already `card:`-prefixed; markers
+                    // appear both bare and doubled in the wild — accept
+                    // either, resolution stays exact.
+                    let hits: Vec<_> = evidence
+                        .map(|ev| {
+                            ev.cards
+                                .iter()
+                                .filter(|c| c.id == stable_id || c.id == id)
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let hit = (hits.len() == 1).then(|| hits[0]);
+                    let title = hit
+                        .map(|c| c.title.trim().chars().take(120).collect::<String>())
+                        .filter(|t| !t.is_empty())
+                        .or(decorated);
+                    let link = hit.and_then(|c| {
+                        c.source_sha256
+                            .as_deref()
+                            .map(|sha| format!("/library/{sha}?tab=memory"))
+                    });
+                    serde_json::json!({
+                        "id": stable_id,
+                        "kind": "card",
+                        "title": title,
+                        "link_target": link,
                         "verified": hit.is_some(),
                     })
                 }

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -4364,8 +4364,9 @@ fn handle_ask_agent(
                     &vault_root,
                     &VaultLayout::new(),
                 );
+                let evidence = ovp_index::read_evidence(&vault_root).ok();
                 let citations = match read_index(&vault_root).ok() {
-                    Some(m) => agent_citations(&done.answer, &m, &records),
+                    Some(m) => agent_citations(&done.answer, &m, &records, evidence.as_ref()),
                     None => agent_citations_unindexed(&done.answer, &records),
                 };
                 // Export REPAIR: a committed turn whose chat save failed
@@ -4559,8 +4560,9 @@ fn handle_ask_agent(
             // the model actually saw. No snapshot (unindexed vault) → source
             // citations resolve as unverified, honestly.
             let snapshot = tools.index_snapshot();
+            let evidence_for_receipts = ovp_index::read_evidence(&vault_root).ok();
             let citations = match snapshot.as_deref() {
-                Some(m) => agent_citations(&outcome.answer, m, &records),
+                Some(m) => agent_citations(&outcome.answer, m, &records, evidence_for_receipts.as_ref()),
                 None => agent_citations_unindexed(&outcome.answer, &records),
             };
             let coverage = tools.coverage();
@@ -4720,6 +4722,17 @@ fn handle_ask_session(state: &AppState, path: &str) -> Response<std::io::Cursor<
             );
         }
     };
+    // Server-resolved citation receipts per turn — the SAME resolver as the
+    // live answer path. Replay surfaces must never reconstruct citations
+    // from answer text with weaker data (2026-08-07 operator report: every
+    // client-side reconstruction showed raw unit ids / dead links; this is
+    // the one-resolver consolidation).
+    let records = ovp_api_projection::readers::load_active_records(
+        &state.vault_root,
+        &VaultLayout::new(),
+    );
+    let model = state.current_model();
+    let evidence = state.current_evidence();
     let turns: Vec<serde_json::Value> = store
         .completed_turns()
         .into_iter()
@@ -4738,11 +4751,16 @@ fn handle_ask_session(state: &AppState, path: &str) -> Response<std::io::Cursor<
             // Transcript may hold the full focus pack (model input). Product
             // surfaces only the human question after `[USER QUESTION]`.
             let visible_q = user_visible_ask_question(&question);
+            let citations = match model.as_deref() {
+                Some(m) => agent_citations(&answer, m, &records, evidence.as_deref()),
+                None => agent_citations_unindexed(&answer, &records),
+            };
             serde_json::json!({
                 "turn_id": turn_id,
                 "question": visible_q,
                 "answer": answer,
                 "stopped_reason": stopped_reason,
+                "citations": citations,
                 "tool_trace": trail,
             })
         })
@@ -5762,6 +5780,37 @@ mod tests {
         };
         ovp_index::write_evidence(&vault, &evidence).unwrap();
         vault
+    }
+
+    #[test]
+    fn agent_citations_resolve_units_and_cards_via_evidence() {
+        // The one-resolver consolidation (2026-08-07): unit/card cites get
+        // titles + memory-tab links from the evidence sidecar — no focus
+        // context needed, fail-closed on unknown ids.
+        let vault = portal_vault(
+            "citations-evidence",
+            "50-Inbox/03-Processed/good.md",
+            "# Good\n\nbody\n",
+        );
+        let model = ovp_index::read_index(&vault).unwrap();
+        let evidence = ovp_index::read_evidence(&vault).unwrap();
+        let cits = agent_citations(
+            "[unit:u-001] [card:40-Resources/Reader/good:0] [unit:u-nope]",
+            &model,
+            &[],
+            Some(&evidence),
+        );
+        assert_eq!(cits[0]["kind"], "unit");
+        assert_eq!(cits[0]["title"], "the exact quote");
+        assert_eq!(cits[0]["link_target"], "/library/aaaa1111?tab=memory");
+        assert_eq!(cits[0]["verified"], true);
+        assert_eq!(cits[1]["kind"], "card");
+        assert_eq!(cits[1]["title"], "Card One");
+        assert_eq!(cits[1]["link_target"], "/library/aaaa1111?tab=memory");
+        assert_eq!(cits[1]["verified"], true);
+        // Unknown unit: honest non-receipt, no fabricated link.
+        assert_eq!(cits[2]["verified"], false);
+        assert_eq!(cits[2]["link_target"], serde_json::Value::Null);
     }
 
     #[test]
@@ -7630,7 +7679,7 @@ mod tests {
         // A real (fixture-built) index: agent_citations only reads sources.
         let vault = portal_vault("agent-ambig", "50-Inbox/03-Processed/good.md", "body\n");
         let model = read_index(&vault).unwrap();
-        let cits = agent_citations("[claim:ck-a] [claim:ck-c]", &model, &records);
+        let cits = agent_citations("[claim:ck-a] [claim:ck-c]", &model, &records, None);
         let a = &cits[0];
         assert_eq!(a["verified"], true, "the key resolved uniquely");
         assert!(a["link_target"].is_null(), "shared claim_id anchor must be omitted");
@@ -7645,6 +7694,7 @@ mod tests {
              [claim: <ck-c> trailing words] [claim:xxxx]",
             &model,
             &records,
+            None,
         );
         assert_eq!(decorated[0]["verified"], true, "title-decorated sha resolves");
         assert_eq!(decorated[0]["link_target"], "/library/aaaa1111");


### PR DESCRIPTION
Operator asked the right question after unit chips STILL showed raw ids: 为什么反复出类似的问题,组件重用或者什么地方出问题了吧 — and yes, it was structural, not another one-off:

**Why this class recurred** — citation resolution was duplicated across 4 surfaces (live receipts, Ask replay, dock replay, MCP) with different data available to each, and the canonical resolver itself couldn't do units/cards. Every incident got a local patch; the next surface hit the same hole. Worse, a client-side 'humanizer' turned modern unit ids into themselves and its result **outranked** real titles — silently masking both previous fixes.

**Consolidation**
1. `agent_citations` (the one server resolver) gains `unit:`/`card:` arms — title = verbatim quote / card title, link = owning source's memory tab (evidence rows carry their source sha, so no focus context is needed), fail-closed on ambiguous or unknown ids. All call sites (HTTP live+replay, MCP) pass the evidence model.
2. `GET /api/ask/session` now returns per-turn `citations` from that same resolver. Ask page + chat dock prefer server receipts; text reconstruction remains only as fallback for legacy markdown chats / older servers.
3. The shadow bug: the client lookup's unit/card arm returns null for non-path (modern) ids instead of echoing the id, so receipt titles can never be masked again.

Earlier commits on this branch (focus grounding, savedReplayPlan, claim_id+key lookup, memory-title fallback) remain as the legacy-chat fallback layer, all tested.

**Tests**: server resolver matrix (quote title, memory-tab link, verified flags, unknown → fail-closed), ovp-server 76 / ovp-memory 162 / mcp 10; SPA tsc clean, vitest 172/172 incl. the shadow regression. **Live verify on the exact reported session**: all 8 unit chips now show verbatim quotes with Open→ links.