### PR TITLE
feat(ask): sources_fts ranked lane + retrieval-eval R0 design

### DIFF
--- a/crates/ovp-memory/src/vault_tools.rs
+++ b/crates/ovp-memory/src/vault_tools.rs
@@ -1,5 +1,7 @@
-//! Read-only vault tools for the ask-agent runtime (candidate
-//! `ask_vault_tools-v6`).
+//! Read-only vault tools for the ask-agent runtime (accepted candidate
+//! `ask_vault_tools-v5`; the sources fts lane ships under the PENDING
+//! candidate `ask_vault_tools-v6` — registry stays at v5 until its live
+//! qrels gate passes and the decision is ledgered).
 //!
 //! The public functions in this module are the shared projection API: they
 //! depend only on explicit vault/index/ledger inputs and never on executor
@@ -605,7 +607,7 @@ pub fn tool_definitions() -> Vec<ToolDef> {
     vec![
         tool_def(
             "search_sources",
-            "Search source metadata by title, URL, path, or tags ONLY. Does not search article bodies; use search_fulltext. Does not search the reader-pack evidence layer; use search_evidence.",
+            "Search source METADATA only — title, author, URL, path, tags, and entities. Does not search article bodies; use search_fulltext. Does not search the reader-pack evidence layer; use search_evidence. When the local search index is available (result lane: fts), terms are tokenized (unspaced Chinese runs auto-expand into character bigrams) and relevance-matched across all metadata fields, so multi-term and cross-field queries work; hits matched only by the index carry match_reason: index. Without the index (lane: scan), the WHOLE query must appear as one substring in a single field (title/URL/path/author) or tag.",
             json!({
                 "type": "object",
                 "properties": {
@@ -3687,9 +3689,18 @@ mod tests {
                 .as_str()
         };
         let sources = description("search_sources");
-        assert!(sources.contains("title, URL, path, or tags ONLY"));
+        assert!(sources.contains("METADATA only"));
+        assert!(sources.contains("author"));
+        assert!(sources.contains("entities"));
         assert!(sources.contains("search_fulltext"));
         assert!(sources.contains("search_evidence"));
+        // v6 candidate: the index-backed lane makes multi-term/cross-field
+        // metadata queries work — the description must state BOTH lanes and
+        // the scan lane's whole-query substring constraint.
+        assert!(sources.contains("lane: fts"));
+        assert!(sources.contains("match_reason: index"));
+        assert!(sources.contains("lane: scan"));
+        assert!(sources.contains("WHOLE query"));
         let evidence = description("search_evidence");
         assert!(evidence.contains("pack title and card titles"));
         assert!(evidence.contains("OR-matched"));

--- a/crates/ovp-memory/src/vault_tools.rs
+++ b/crates/ovp-memory/src/vault_tools.rs
@@ -1,5 +1,5 @@
 //! Read-only vault tools for the ask-agent runtime (candidate
-//! `ask_vault_tools-v2`).
+//! `ask_vault_tools-v5`).
 //!
 //! The public functions in this module are the shared projection API: they
 //! depend only on explicit vault/index/ledger inputs and never on executor
@@ -275,7 +275,36 @@ impl VaultTools {
                 let model = self.cached_index().map_err(|e| {
                     DispatchError::Unavailable(format!("source index unavailable: {e}"))
                 })?;
-                Ok(search_sources(&model, &query, limit))
+                // bm25 rank from the sources FTS surface (sha256 keys,
+                // deduped preserving order); the fts query uses the SAME
+                // capped term list the scan lane matches on. The scan lane's
+                // whole-query substring match cannot see multi-term queries
+                // ("手写 transformer") that fts token-matches across fields.
+                // None (no shadow / stale generation / kill switch) = v4 scan.
+                let fts_rank = shadow_reader_for(&self.vault_root, &model).and_then(|reader| {
+                    let capped_query = tokenize_search_terms(&query).join(" ");
+                    reader
+                        .fts_search(
+                            ovp_index::sqlite::FtsSurface::Sources,
+                            &capped_query,
+                            FTS_SOURCES_FETCH,
+                        )
+                        .ok()
+                        .map(|ranked| {
+                            let mut seen = BTreeSet::new();
+                            ranked
+                                .into_iter()
+                                .map(|hit| hit.id)
+                                .filter(|id| seen.insert(id.clone()))
+                                .collect::<Vec<_>>()
+                        })
+                });
+                Ok(search_sources_ranked(
+                    &model,
+                    &query,
+                    limit,
+                    fts_rank.as_deref(),
+                ))
             }
             ParsedCall::SearchEvidence { query, limit } => {
                 let model = self.cached_index().map_err(|e| {
@@ -728,6 +757,19 @@ pub fn load_active_records(vault_root: &Path) -> Result<Vec<DurableRecord>, Stri
 /// tag-only matches are added because the v1 tool contract includes tag text
 /// in its search surface while `Query.term` intentionally searches fields.
 pub fn search_sources(model: &IndexModel, query: &str, limit: usize) -> Value {
+    search_sources_ranked(model, query, limit, None)
+}
+
+/// [`search_sources`] with an optional bm25 rank from the sources FTS
+/// surface: fts-ranked ids lead by relevance; scan-only extras (whole-query
+/// substring matches fts tokenization cannot see) keep their v4 relative
+/// order after them — union, never a recall loss. Mirrors the claims lane.
+fn search_sources_ranked(
+    model: &IndexModel,
+    query: &str,
+    limit: usize,
+    fts_rank: Option<&[String]>,
+) -> Value {
     let limit = limit.clamp(1, MAX_SEARCH_LIMIT);
     let query_lower = query.to_lowercase();
     let hits = run_query(
@@ -752,6 +794,27 @@ pub fn search_sources(model: &IndexModel, query: &str, limit: usize) -> Value {
         }
     }
 
+    let lane = if fts_rank.is_some() { "fts" } else { "scan" };
+    if let Some(rank) = fts_rank {
+        // The generation guard makes ghosts (fts id absent from the live
+        // model) near-impossible, but a ghost must not eat a result slot
+        // below the limit — membership-filter before fusing.
+        let known: BTreeSet<&str> = model.sources.iter().map(|s| s.sha256.as_str()).collect();
+        let mut fused: Vec<String> = Vec::new();
+        let mut in_fused = BTreeSet::new();
+        for id in rank {
+            if known.contains(id.as_str()) && in_fused.insert(id.clone()) {
+                fused.push(id.clone());
+            }
+        }
+        for id in ids {
+            if in_fused.insert(id.clone()) {
+                fused.push(id);
+            }
+        }
+        ids = fused;
+    }
+
     let mut truncated = ids.len() > limit;
     let mut hits = ids
         .into_iter()
@@ -760,7 +823,7 @@ pub fn search_sources(model: &IndexModel, query: &str, limit: usize) -> Value {
         .map(|source| source_search_hit(source, &query_lower))
         .collect::<Vec<_>>();
     truncated |= cap_aggregate(&mut hits);
-    json!({"hits": hits, "truncated": truncated})
+    json!({"hits": hits, "truncated": truncated, "lane": lane})
 }
 
 fn push_search_term(
@@ -1043,6 +1106,10 @@ fn claim_rank_key(claim_key: Option<&str>, claim_id: &str, status: &str) -> Stri
 /// aggregation — generous, so a few hot packs cannot eat the cap and hide
 /// other matching packs behind an honest-looking result.
 const FTS_EVIDENCE_FETCH: usize = MAX_SEARCH_LIMIT * 4;
+
+/// Sources FTS fetch — no pack aggregation on this surface, so 2× the display
+/// cap suffices (parity with the claims lane's fetch).
+const FTS_SOURCES_FETCH: usize = MAX_SEARCH_LIMIT * 2;
 
 /// The evidence lane's raw inputs plus a SATURATION flag: when either
 /// surface returned exactly the fetch cap, deeper matches may exist beyond
@@ -2688,8 +2755,18 @@ fn source_search_hit(source: &SourceRow, query_lower: &str) -> Value {
         .is_some_and(|value| value.to_lowercase().contains(query_lower))
     {
         "rel_path"
-    } else {
+    } else if source
+        .tags
+        .iter()
+        .chain(source.tags_inferred.iter())
+        .any(|tag| tag.to_lowercase().contains(query_lower))
+    {
         "tag"
+    } else {
+        // Reachable only via the fts lane: a token/bigram match (bm25 over
+        // title+author+url+tags+entities) with no whole-query substring in
+        // any field the scan checks. Naming a field here would be a lie.
+        "index"
     };
     let mut out = Map::new();
     out.insert("source_id".into(), json!(source.sha256));
@@ -3371,6 +3448,47 @@ mod tests {
         assert_eq!(out["hits"][0]["match_reason"], "title");
     }
 
+    /// fts rank leads by bm25 relevance; the substring-only extra (absent
+    /// from the shadow's rank) appends after — union, never a recall loss.
+    /// A ghost id the live model no longer knows is dropped BEFORE the
+    /// limit, so it can never eat a result slot.
+    #[test]
+    fn sources_fts_rank_leads_with_substring_extras() {
+        let first = source("aaaa1111", "Retrieval notes, part one", None, None);
+        let second = source("bbbb2222", "Deep retrieval survey", None, None);
+        let model = fixture_model(vec![first, second], vec![], vec![]);
+
+        // v4 scan lane: model order, honestly labelled.
+        let scan = search_sources(&model, "retrieval", 10);
+        assert_eq!(scan["lane"], json!("scan"));
+        let ids: Vec<_> = scan["hits"]
+            .as_array()
+            .expect("hits")
+            .iter()
+            .map(|h| h["source_id"].clone())
+            .collect();
+        assert_eq!(ids, vec![json!("aaaa1111"), json!("bbbb2222")]);
+
+        let rank = vec!["ghost9999".to_string(), "bbbb2222".to_string()];
+        let out = search_sources_ranked(&model, "retrieval", 10, Some(&rank));
+        assert_eq!(out["lane"], json!("fts"));
+        let ids: Vec<_> = out["hits"]
+            .as_array()
+            .expect("hits")
+            .iter()
+            .map(|h| h["source_id"].clone())
+            .collect();
+        assert_eq!(ids, vec![json!("bbbb2222"), json!("aaaa1111")]);
+
+        // limit=1 with the ghost first in rank: the ghost must not consume
+        // the only slot, and the dropped scan extra must read truncated.
+        let out = search_sources_ranked(&model, "retrieval", 1, Some(&rank));
+        let hits = out["hits"].as_array().expect("hits");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0]["source_id"], "bbbb2222");
+        assert_eq!(out["truncated"], json!(true));
+    }
+
     fn fixture_model(
         sources: Vec<SourceRow>,
         packs: Vec<PackRow>,
@@ -3811,7 +3929,12 @@ mod tests {
         );
         let temp = tempfile::tempdir().expect("tempdir");
         let model = fixture_model(
-            vec![],
+            vec![source(
+                "dddd4444",
+                "手写 Transformer 求职笔记",
+                None,
+                None,
+            )],
             vec![simple_pack(
                 "40-Resources/Reader/alpha",
                 "Alpha pack",
@@ -3848,6 +3971,21 @@ mod tests {
         assert_eq!(hits[0]["pack_title"], "Alpha pack");
         assert_eq!(hits[0]["matched_via"], json!("cards"));
 
+        // Sources surface: a multi-term query ("手写 求职") is structurally
+        // invisible to the scan lane's whole-query substring match — only
+        // the fts token lane can reach this title. The reason must not name
+        // a field the scan never matched.
+        let out = ok_json(call(
+            &mut tools,
+            "search_sources",
+            json!({"query": "手写 求职"}),
+        ));
+        assert_eq!(out["lane"], json!("fts"));
+        let hits = out["hits"].as_array().expect("hits");
+        assert_eq!(hits.len(), 1, "fts-only source hit must surface: {out}");
+        assert_eq!(hits[0]["source_id"], "dddd4444");
+        assert_eq!(hits[0]["match_reason"], "index");
+
         // Generation guard: when the JSON projections move on but the shadow
         // kept last-good (failed rebuild), the lane must fall back — serving
         // a stale corpus's rankings for the current model is worse than the
@@ -3859,6 +3997,13 @@ mod tests {
         // the shadow still stamps the old generation and must not serve.
         let mut fresh = VaultTools::new(temp.path());
         let out = ok_json(call(&mut fresh, "search_evidence", json!({"query": "深度检索"})));
+        assert_eq!(out["lane"], json!("scan"), "stale shadow must not serve");
+        assert_eq!(out["hits"].as_array().expect("hits").len(), 0);
+        let out = ok_json(call(
+            &mut fresh,
+            "search_sources",
+            json!({"query": "手写 求职"}),
+        ));
         assert_eq!(out["lane"], json!("scan"), "stale shadow must not serve");
         assert_eq!(out["hits"].as_array().expect("hits").len(), 0);
     }

--- a/crates/ovp-memory/src/vault_tools.rs
+++ b/crates/ovp-memory/src/vault_tools.rs
@@ -1,5 +1,5 @@
 //! Read-only vault tools for the ask-agent runtime (candidate
-//! `ask_vault_tools-v5`).
+//! `ask_vault_tools-v6`).
 //!
 //! The public functions in this module are the shared projection API: they
 //! depend only on explicit vault/index/ledger inputs and never on executor
@@ -275,14 +275,18 @@ impl VaultTools {
                 let model = self.cached_index().map_err(|e| {
                     DispatchError::Unavailable(format!("source index unavailable: {e}"))
                 })?;
-                // bm25 rank from the sources FTS surface (sha256 keys,
-                // deduped preserving order); the fts query uses the SAME
-                // capped term list the scan lane matches on. The scan lane's
-                // whole-query substring match cannot see multi-term queries
-                // ("手写 transformer") that fts token-matches across fields.
-                // None (no shadow / stale generation / kill switch) = v4 scan.
-                let fts_rank = shadow_reader_for(&self.vault_root, &model).and_then(|reader| {
-                    let capped_query = tokenize_search_terms(&query).join(" ");
+                // bm25 rank from the sources FTS surface (candidate
+                // `ask_vault_tools-v6`): sha256 keys, deduped preserving
+                // order. The scan lane's whole-query substring match cannot
+                // see multi-term queries ("手写 transformer") that fts
+                // token-matches across fields. The capped tokenizer's drop
+                // flag travels with the lane — a distinct term the fts query
+                // never searched must surface as query_terms_truncated, not
+                // read as a clean complete miss. None (no shadow / stale
+                // generation / kill switch) = v5 scan path.
+                let fts = shadow_reader_for(&self.vault_root, &model).and_then(|reader| {
+                    let (terms, terms_capped) = tokenize_search_terms_capped(&query);
+                    let capped_query = terms.join(" ");
                     reader
                         .fts_search(
                             ovp_index::sqlite::FtsSurface::Sources,
@@ -291,20 +295,22 @@ impl VaultTools {
                         )
                         .ok()
                         .map(|ranked| {
+                            let saturated = ranked.len() == FTS_SOURCES_FETCH;
                             let mut seen = BTreeSet::new();
-                            ranked
+                            let rank: Vec<String> = ranked
                                 .into_iter()
                                 .map(|hit| hit.id)
                                 .filter(|id| seen.insert(id.clone()))
-                                .collect::<Vec<_>>()
+                                .collect();
+                            SourcesFtsLane {
+                                rank,
+                                saturated,
+                                terms,
+                                terms_capped,
+                            }
                         })
                 });
-                Ok(search_sources_ranked(
-                    &model,
-                    &query,
-                    limit,
-                    fts_rank.as_deref(),
-                ))
+                Ok(search_sources_ranked(&model, &query, limit, fts))
             }
             ParsedCall::SearchEvidence { query, limit } => {
                 let model = self.cached_index().map_err(|e| {
@@ -760,15 +766,26 @@ pub fn search_sources(model: &IndexModel, query: &str, limit: usize) -> Value {
     search_sources_ranked(model, query, limit, None)
 }
 
+/// The sources lane's bm25 rank plus its honesty flags: `saturated` when
+/// the fetch cap came back exactly full (deeper matches may exist), and the
+/// capped term list the fts query ACTUALLY searched — a dropped distinct
+/// term must surface in the result, never read as a clean miss.
+struct SourcesFtsLane {
+    rank: Vec<String>,
+    saturated: bool,
+    terms: Vec<String>,
+    terms_capped: bool,
+}
+
 /// [`search_sources`] with an optional bm25 rank from the sources FTS
 /// surface: fts-ranked ids lead by relevance; scan-only extras (whole-query
-/// substring matches fts tokenization cannot see) keep their v4 relative
+/// substring matches fts tokenization cannot see) keep their v5 relative
 /// order after them — union, never a recall loss. Mirrors the claims lane.
 fn search_sources_ranked(
     model: &IndexModel,
     query: &str,
     limit: usize,
-    fts_rank: Option<&[String]>,
+    fts: Option<SourcesFtsLane>,
 ) -> Value {
     let limit = limit.clamp(1, MAX_SEARCH_LIMIT);
     let query_lower = query.to_lowercase();
@@ -794,17 +811,23 @@ fn search_sources_ranked(
         }
     }
 
-    let lane = if fts_rank.is_some() { "fts" } else { "scan" };
-    if let Some(rank) = fts_rank {
+    let lane = if fts.is_some() { "fts" } else { "scan" };
+    let mut fts_saturated = false;
+    let mut terms_capped = false;
+    let mut capped_terms: Vec<String> = Vec::new();
+    if let Some(fts) = fts {
+        fts_saturated = fts.saturated;
+        terms_capped = fts.terms_capped;
+        capped_terms = fts.terms;
         // The generation guard makes ghosts (fts id absent from the live
         // model) near-impossible, but a ghost must not eat a result slot
         // below the limit — membership-filter before fusing.
         let known: BTreeSet<&str> = model.sources.iter().map(|s| s.sha256.as_str()).collect();
         let mut fused: Vec<String> = Vec::new();
         let mut in_fused = BTreeSet::new();
-        for id in rank {
+        for id in fts.rank {
             if known.contains(id.as_str()) && in_fused.insert(id.clone()) {
-                fused.push(id.clone());
+                fused.push(id);
             }
         }
         for id in ids {
@@ -815,7 +838,7 @@ fn search_sources_ranked(
         ids = fused;
     }
 
-    let mut truncated = ids.len() > limit;
+    let mut truncated = ids.len() > limit || fts_saturated || terms_capped;
     let mut hits = ids
         .into_iter()
         .take(limit)
@@ -823,7 +846,9 @@ fn search_sources_ranked(
         .map(|source| source_search_hit(source, &query_lower))
         .collect::<Vec<_>>();
     truncated |= cap_aggregate(&mut hits);
-    json!({"hits": hits, "truncated": truncated, "lane": lane})
+    let mut out = json!({"hits": hits, "truncated": truncated, "lane": lane});
+    annotate_capped_terms(&mut out, terms_capped, &capped_terms);
+    out
 }
 
 fn push_search_term(
@@ -3469,9 +3494,16 @@ mod tests {
             .collect();
         assert_eq!(ids, vec![json!("aaaa1111"), json!("bbbb2222")]);
 
-        let rank = vec!["ghost9999".to_string(), "bbbb2222".to_string()];
-        let out = search_sources_ranked(&model, "retrieval", 10, Some(&rank));
+        let lane = || SourcesFtsLane {
+            rank: vec!["ghost9999".to_string(), "bbbb2222".to_string()],
+            saturated: false,
+            terms: vec!["retrieval".to_string()],
+            terms_capped: false,
+        };
+        let out = search_sources_ranked(&model, "retrieval", 10, Some(lane()));
         assert_eq!(out["lane"], json!("fts"));
+        assert_eq!(out["truncated"], json!(false));
+        assert_eq!(out.get("query_terms_truncated"), None);
         let ids: Vec<_> = out["hits"]
             .as_array()
             .expect("hits")
@@ -3482,11 +3514,43 @@ mod tests {
 
         // limit=1 with the ghost first in rank: the ghost must not consume
         // the only slot, and the dropped scan extra must read truncated.
-        let out = search_sources_ranked(&model, "retrieval", 1, Some(&rank));
+        let out = search_sources_ranked(&model, "retrieval", 1, Some(lane()));
         let hits = out["hits"].as_array().expect("hits");
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0]["source_id"], "bbbb2222");
         assert_eq!(out["truncated"], json!(true));
+    }
+
+    /// The fts lane's honesty flags fold into the result: a term the capped
+    /// tokenizer dropped surfaces as query_terms_truncated (a source
+    /// matching only that term must not read as a clean complete miss), and
+    /// a fetch-cap-saturated rank reads truncated because deeper matches
+    /// may exist past the cap.
+    #[test]
+    fn sources_fts_cap_and_saturation_read_truncated() {
+        let row = source("aaaa1111", "Retrieval notes", None, None);
+        let model = fixture_model(vec![row], vec![], vec![]);
+
+        let capped = SourcesFtsLane {
+            rank: vec!["aaaa1111".to_string()],
+            saturated: false,
+            terms: vec!["retrieval".to_string()],
+            terms_capped: true,
+        };
+        let out = search_sources_ranked(&model, "retrieval", 10, Some(capped));
+        assert_eq!(out["truncated"], json!(true));
+        assert_eq!(out["query_terms_truncated"], json!(true));
+        assert_eq!(out["query_terms_used"], json!(["retrieval"]));
+
+        let saturated = SourcesFtsLane {
+            rank: vec!["aaaa1111".to_string()],
+            saturated: true,
+            terms: vec!["retrieval".to_string()],
+            terms_capped: false,
+        };
+        let out = search_sources_ranked(&model, "retrieval", 10, Some(saturated));
+        assert_eq!(out["truncated"], json!(true));
+        assert_eq!(out.get("query_terms_truncated"), None);
     }
 
     fn fixture_model(

--- a/docs/design/retrieval-eval.md
+++ b/docs/design/retrieval-eval.md
@@ -1,0 +1,103 @@
+# Retrieval Eval(检索评测:qrels + trace)
+
+状态:R0 方案。填 [storage-read-model.md](storage-read-model.md) §2 里
+"中文 Recall@20 / nDCG 需先建中英混合 qrels" 这个空位。
+
+关联:[ask-vault-agent.md](ask-vault-agent.md)(A0 契约不动;评测对象是当前
+`ask_vault_tools-v5` 工具面,不是旧 `ovp-rag` 的 concept-slug Recall@K——那套
+只覆盖 evergreen 概念页,与 Ask 生产路径零交集)。
+
+---
+
+## 1. 为什么是第一优先级
+
+后续每一项检索改造(chunks 表、query plan、reranker、dense)都需要回答
+"改了之后哪个 cohort 变好、哪个变坏"。没有 qrels,所有"提升"不可证伪;
+有了 qrels,才允许按 process rule(无价值实验不加持久层)推进。
+
+现状可用的评测资产只有 `.run/a3d-eval/` 的 8 问 paired eval(agent vs
+legacy,一次性验收默认翻转用),既无分级相关性也无 cohort 分桶。
+
+## 2. 数据:gold 50–80 起步,不是 300
+
+- **来源**:真实 ask-sessions transcript(`.ovp/ask-sessions/*.jsonl`,
+  已有 40+ 会话)经确定性摘要(digest)→ LLM 起草(silver)→ 人工晋级(gold)。
+  草稿由便宜模型批量产出,`confidence: needs_review` 强制;晋级 gold 必须
+  operator 亲验 relevant 对象确实承载/不承载答案。
+- **规模纪律**:第一版 gold 50–80 条。300 条是数周标注量,单人 dogfood
+  产品撑不起,烂尾风险 > 统计增益。桶结构保留、每桶缩量,桶内不足 5 条时
+  该桶指标只报不判。
+- 流水在 `.run/retrieval-eval/`(gitignored);晋级后的 gold qrels 入库到
+  `crates/ovp-retrieval-eval/fixtures/`(或先 `docs/eval/qrels/`,定实现时选)。
+
+## 3. qrel 记录 schema
+
+```json
+{
+  "schema": "ovp.retrieval_eval.qrel/v1",
+  "id": "q-001",
+  "question": "原问题全文",
+  "source_session": "ask-session id(可溯源)",
+  "language": "zh | en | mixed",
+  "class": "exact | paraphrase | claim_evidence | compare | recent | source_scoped | meta | negative",
+  "relevant": [
+    {"surface": "source|claim|card|unit|chunk", "id": "…", "grade": 3, "why": "…"}
+  ],
+  "no_answer": false,
+  "confidence": "gold | needs_review"
+}
+```
+
+分级语义(区分 source recall 与 answer-bearing recall,不可合并):
+
+- **3** = answer-bearing:该对象直接承载答案(unit / chunk / 具体 card);
+- **2** = 导航相关:card / claim / section,能引到证据;
+- **1** = 主题相关 source:找对了文章,不保证内含答案。
+
+`negative` class + `no_answer: true` 是一等公民:库里没有的问题,正确行为是
+带 coverage 声明的 abstain,不是硬答。
+
+## 4. 指标:分桶,不设单一综合分
+
+按 `class × language` 分桶各报:
+
+| 层 | 指标 |
+|---|---|
+| 候选召回 | Recall@10/@20;answer-bearing(grade 3)Recall@20 单列 |
+| 排序 | MRR@10、nDCG@10、Precision@5 |
+| Agent 行为 | citation precision(服务端已验)、no-answer accuracy、平均搜索轮数、重复 query 率 |
+| 成本 | 每问工具调用数、扫描字节、token |
+
+聚合平均会掩盖"semantic 桶变好、exact-ID 桶退化"这类换血式回归——所以
+验收永远看桶,不看总分。
+
+## 5. Trace:扩展现有 transcript,不另造 observability
+
+`agent_transcript.rs` 已有 turn 原子性 / 完整工具原始结果 / token 记账。
+评测需要补的只有检索内部事件(只记 ID、rank、参数、latency、
+projection generation,**不复制候选正文**——`ToolCalled.content` 已存全量):
+
+```text
+retrieval_snapshot_opened / lane_finished / fusion_finished / coverage_evaluated
+```
+
+重放约束:同一 projection generation + 同一配置 → 确定性重放。
+
+## 6. 验收门(R0 完成的定义)
+
+1. gold ≥ 50 条,8 桶每桶 ≥ 3 条,negative ≥ 6 条;
+2. `retrieval-eval` 命令可对当前 v5 工具面跑出分桶 baseline 并落盘;
+3. 任一失败问题能定位到层:候选生成 / 融合 / Agent 行为;
+4. 每条 gold 可溯源到真实 session 或标注记录。
+
+## 7. 后续改造的立项条件(用本评测触发,不用先验)
+
+| 改造 | 触发条件 |
+|---|---|
+| chunks 表 + heading-aware source_map | body-only 桶 Recall@20 低于阈值(storage-read-model §T2 已规划) |
+| query plan / 多查询并行 | compare/multi-part 桶 subtask 覆盖不足 |
+| reranker | 候选进了 top-50 但 Precision@5 差(precision 问题,非 recall 问题) |
+| dense embedding | lexical+fts 之后 paraphrase 桶仍显著 miss |
+
+任何一项在触发条件出现前不立项——900 万页语料的工程先验不按原剂量搬到
+1.6k sources 的单机产品上。

--- a/evolution/candidates/ask_vault_tools-v6.json
+++ b/evolution/candidates/ask_vault_tools-v6.json
@@ -1,0 +1,28 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "ask_vault_tools-v6",
+  "base_version": "v5",
+  "target_version": "v6",
+  "surface": "runtime",
+  "component": "runtime.ask_vault_tools",
+  "hypothesis": "RUNTIME surface, one retrieval upgrade completing the v5 arc: the sources_fts surface (built and parity-verified since stage 3c, ZERO production callers until now) becomes an index-backed bm25 lane under search_sources, with the v5 scan lane kept as the always-available fallback. Today search_sources matches the WHOLE query as one lowercase substring over title/url/rel_path/author (run_query) plus a tag-substring sweep — a multi-term query ('手写 transformer', '<author> retrieval') whose terms hit different fields or are non-contiguous in one field is structurally invisible, and CJK multi-term queries fail silently. v6: when the shadow is available and generation-current, search_sources retrieves over sources_fts (bm25 top-k over title+author+url+tags+entities, CJK unigram+bigram analyzer) and fuses: fts rank leads by relevance, scan-only substring extras append after in their v5 relative order (union, never a recall loss — same fusion shape as the v5 claims lane). Fts-only hits report match_reason: index (naming a scan field would be a lie). The fts query uses tokenize_search_terms_capped; a dropped distinct term surfaces as query_terms_truncated and folds into truncated, and a fetch-cap-saturated rank also reads truncated. When the shadow is missing, stale, or OVP_ASK_FTS=0, the tool takes the exact v5 path. Predicted: multi-term and cross-field source lookup becomes possible; with the fts lane off, matching and ordering semantics are exactly v5 while the result carries the additive lane field.",
+  "predicted_delta": {
+    "coverage": "fixture replay (falsifiable now): a multi-term CJK query whose terms are non-contiguous in the title — 0 hits under v5's whole-query substring scan — returns the correct source under v6 with the shadow present; with the shadow absent, v5 fixtures pass unmodified (fallback is the v5 code path). Live gate (retrieval-eval qrels, docs/design/retrieval-eval.md): source-surface Recall@10 on the exact and meta buckets must not regress vs the v5 scan baseline, and the paraphrase/mixed-language buckets' source recall should improve; measured when the R0 gold set lands, else rollback via kill switch.",
+    "operational_reliability": "zero new failure modes on missing/stale shadow (lane falls back, result says so); OVP_ASK_FTS=0 restores v5 behavior without a rebuild; a capped or saturated fts query can no longer masquerade as a complete miss."
+  },
+  "guardrails": {
+    "accepted_without_quote": 0,
+    "fallback_is_v5": "with no shadow db, a stale generation, an analyzer-stamp mismatch, or OVP_ASK_FTS=0, search_sources executes the v5 matching and ordering code path — results carry the additive v6 fields (lane: scan) but all prior fixtures pass against the fallback lane",
+    "lane_honesty": "every search_sources result carries lane: fts|scan; fts-only hits carry match_reason: index instead of falsely naming a scan field",
+    "coverage_semantics_unchanged": "truncated, query_terms_truncated, and the executor's coverage accounting keep their v5 meanings; the fts lane ADDS truncation causes (term cap, fetch saturation) and must never remove one",
+    "result_shape_compatible": "hit fields are a superset of v5's (additive lane field and the index match_reason value only) — the agent prompt contract and portal consumers parse unchanged",
+    "read_only": "the fts lane opens the shadow read-only; ask can never write or rebuild the projection"
+  },
+  "eval_plan": {
+    "replay_set": "unit fixtures: multi-term CJK query non-contiguous in the title → correct source via fts lane, 0 hits via scan lane; fts rank leads with scan-only extras appended; a ghost id absent from the live model is dropped before the limit and cannot eat a result slot; term-capped query annotates query_terms_truncated and reads truncated; fetch-saturated rank reads truncated; shadow-absent and stale-generation runs produce v5-identical results with lane: scan; OVP_ASK_FTS=0 forces scan lane. All prior fixtures pass unmodified. Live qrels (retrieval-eval R0 gold set) are the quality gate before this candidate is recorded accepted.",
+    "paired_sources": 0,
+    "soak": false
+  },
+  "rollback": "Set OVP_ASK_FTS=0 (instant, no rebuild, shared with the v5 lanes) or revert the lane dispatch — the scan path preserves v5 matching/ordering semantics (result shape gains only additive fields); no persisted state, no prompt-namespace dependency.",
+  "ablation_required": false
+}

--- a/evolution/components.json
+++ b/evolution/components.json
@@ -167,7 +167,7 @@
     {
       "id": "runtime.ask_vault_tools",
       "surface": "runtime",
-      "current_version": "v5",
+      "current_version": "v6",
       "file": "crates/ovp-memory/src/vault_tools.rs",
       "quality_buckets": [
         "coverage",

--- a/evolution/components.json
+++ b/evolution/components.json
@@ -167,7 +167,7 @@
     {
       "id": "runtime.ask_vault_tools",
       "surface": "runtime",
-      "current_version": "v6",
+      "current_version": "v5",
       "file": "crates/ovp-memory/src/vault_tools.rs",
       "quality_buckets": [
         "coverage",


### PR DESCRIPTION
## What

**R0 of the retrieval track** (design: `docs/design/retrieval-eval.md`, added in this PR).

1. **`sources_fts` wired into `search_sources`** — the surface existed since stage 3c with zero production callers; `search_sources` still ran a whole-query substring scan, so multi-term / cross-field queries ("手写 transformer", author+topic) were structurally invisible. Mirrors the v5 claims lane: bm25 rank leads, scan-only substring extras append after (union, never a recall loss), same generation guard and `OVP_ASK_FTS=0` kill switch. Fts-only hits report `match_reason: index`.
2. **Evolution governance** — the lane ships under the **pending** candidate `ask_vault_tools-v6` (`ovp2 evolve validate` passes). Registry stays at **v5** until the live qrels gate passes and the decision is ledgered.
3. **Honesty flags** — the fts query uses the capped tokenizer; dropped distinct terms surface as `query_terms_truncated`, and both the term cap and fetch saturation fold into `truncated`. Tool description now states both lanes (model-facing contract).
4. **`docs/design/retrieval-eval.md`** — qrel schema (graded relevance separating source recall from answer-bearing recall), bucketed metrics with no composite score, gold 50–80 scope, and trigger conditions gating later changes (chunks table / query plan / reranker / dense) on measured cohort failures.

## Verification

- 165 ovp-memory tests pass (new: fusion order, ghost-id slot protection, cap/saturation truncation, fts-only e2e over a real shadow DB, stale-generation fallback).
- Local codex review: round 1 found 2 P1 (governance bypass, silent term cap) — both fixed; round 2 found 2 P2 (premature registry bump, stale tool contract) — both fixed. No open findings.

## Not in this PR

Gold qrels promotion (operator review of the 40 drafts in `.run/retrieval-eval/`), the `retrieval-eval` command, and the v6 acceptance decision — those are the next changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Source searches can use faster, relevance-ranked results when an eligible search index is available.
  * Search results now indicate how matches were found and whether query terms were truncated.
  * Existing scan-based results remain available as a fallback for broader coverage.

* **Documentation**
  * Added retrieval evaluation guidance covering relevance metrics, multilingual testing, tracing, and acceptance criteria.
  * Documented search behavior, limitations, compatibility safeguards, and rollback options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->