### PR TITLE
chore(evolve): accept ask_vault_tools-v6 (registry v5→v6)

### DIFF
--- a/evolution/components.json
+++ b/evolution/components.json
@@ -167,7 +167,7 @@
     {
       "id": "runtime.ask_vault_tools",
       "surface": "runtime",
-      "current_version": "v5",
+      "current_version": "v6",
       "file": "crates/ovp-memory/src/vault_tools.rs",
       "quality_buckets": [
         "coverage",


### PR DESCRIPTION
Registry bump completing the v6 acceptance. Evidence + decision recorded in the vault evolution ledger (2026-08-14):

- **Eval set**: R0 gold-44 qrels (`.run/retrieval-eval/qrels-gold`, droid-adjudicated)
- **Own surface**: search_sources source R@20 **0.00 → 0.35** (terms mode) / 0.00 → 0.28 (verbatim)
- **Guardrails**: exact 0.56=0.56, meta 0.50=0.50 unchanged with the lane on; zero own-surface regressions; generation guard + `OVP_ASK_FTS=0` kill switch pinned by fixtures
- **Rollback**: `OVP_ASK_FTS=0` (instant) or revert PR #440

Noted in the ledger: the v6 acceptance run also surfaced a **v5 evidence-fusion regression** (strong title-scan hits buried by the cards/units bm25 flood on 4/44 questions, 0.67–1.00 → 0.00). That is not attributable to the sources lane and will get its own candidate spec.