### PR TITLE
chore(evolve): accept ask_vault_tools-v7 (registry v6→v7)

### DIFF
--- a/evolution/components.json
+++ b/evolution/components.json
@@ -167,7 +167,7 @@
     {
       "id": "runtime.ask_vault_tools",
       "surface": "runtime",
-      "current_version": "v6",
+      "current_version": "v7",
       "file": "crates/ovp-memory/src/vault_tools.rs",
       "quality_buckets": [
         "coverage",


### PR DESCRIPTION
Registry bump completing the v7 acceptance, ledgered 2026-08-14. Evidence: gold-44 verbatim (production path) union source R@20 0.29→0.33, 4 wins/31 ties/0 losses, zero bucket regressions; `OVP_ASK_QUERY_STRIP=0` kill-switch identity with v6 verified exactly. Rollback instant via env.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the vault tools runtime to the latest supported version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->