### PR TITLE
feat(ask): ask_vault_tools-v8 — conditional strong-title pin in evidence fusion

### DIFF
--- a/crates/ovp-memory/src/vault_tools.rs
+++ b/crates/ovp-memory/src/vault_tools.rs
@@ -1338,6 +1338,17 @@ fn fts_query_source(query: &str) -> String {
     strip_request_scaffolding(query)
 }
 
+/// v8 pin cap — fixed a priori (anti-overfit directive): at most 3 pinned
+/// slots keeps the fused top-10 majority-RRF, so body-only fts wins cannot
+/// be crowded out. NEVER tune this against the eval set.
+const MAX_TITLE_PINS: usize = 3;
+
+/// The v8 pin behind its kill switch: `OVP_ASK_TITLE_PIN=0` restores the
+/// exact v7 fusion order.
+fn title_pins_enabled() -> bool {
+    !std::env::var("OVP_ASK_TITLE_PIN").is_ok_and(|v| v == "0")
+}
+
 /// Gate for the index-backed bm25 lane (candidate `ask_vault_tools-v5`):
 /// the lane serves ONLY when the kill switch is off AND the shadow's
 /// generation stamps equal the model actually loaded — the promotion
@@ -1624,6 +1635,33 @@ fn search_evidence_fused(
                 .then_with(|| a.cmp(b))
         });
 
+        // v8 (candidate `ask_vault_tools-v8`): conditional strong-title
+        // protection. RRF punishes a single-lane hit (1/61) below mediocre
+        // both-lane packs (2/(60+r+1)) — measured burying a title #1 to
+        // fused rank 38. A title hit whose best language group matched
+        // COMPLETELY (permille == 1000 — a semantic predicate, never a
+        // tuned threshold) pins ahead of the RRF order, at most
+        // MAX_TITLE_PINS in title-lane order. Queries with no
+        // full-coverage title hit fuse exactly as v7.
+        let mut pinned: Vec<String> = Vec::new();
+        if title_pins_enabled() {
+            for ((permille, _), index, _) in &matches {
+                if *permille == 1000 && pinned.len() < MAX_TITLE_PINS {
+                    let dir = model.packs[*index].pack_dir.clone();
+                    if !pinned.contains(&dir) {
+                        pinned.push(dir);
+                    }
+                }
+            }
+        }
+        if !pinned.is_empty() {
+            let rest: Vec<String> = pack_order
+                .into_iter()
+                .filter(|pack| !pinned.contains(pack))
+                .collect();
+            pack_order = pinned.iter().cloned().chain(rest).collect();
+        }
+
         let mut title_by_pack: HashMap<String, Value> = matches
             .into_iter()
             .map(|(_, i, hit)| (model.packs[i].pack_dir.clone(), hit))
@@ -1711,6 +1749,12 @@ fn search_evidence_fused(
                     }
                 }
                 fts_detail_truncated |= detail_truncated;
+            }
+            // Transcript honesty: a pinned hit says WHY it leads the order.
+            if pinned.contains(&pack_dir) {
+                if let Some(obj) = hit.as_object_mut() {
+                    obj.insert("pinned".into(), json!(true));
+                }
             }
             ordered.push(hit);
         }
@@ -4279,6 +4323,87 @@ mod tests {
             .map(|h| h["claim_id"].clone())
             .collect();
         assert_eq!(ids, vec![json!("c-2"), json!("c-1")]);
+    }
+
+    /// The diagnosed pathology, reconstructed from the MECHANISM: a
+    /// full-coverage title #1 absent from the fts lanes loses to mediocre
+    /// both-lane packs under plain RRF (1/61 < 1/62 + 1/61); the v8 pin
+    /// puts it first and says so. Partial-coverage hits never pin.
+    #[test]
+    fn full_coverage_title_hit_pins_ahead_of_both_lane_flood() {
+        let model = fixture_model(
+            vec![],
+            vec![
+                simple_pack(
+                    "40-Resources/Reader/gold",
+                    "Needle thread guide",
+                    vec!["Complete coverage card".into()],
+                ),
+                simple_pack(
+                    "40-Resources/Reader/a",
+                    "Needle article A",
+                    vec!["Card a".into()],
+                ),
+                simple_pack(
+                    "40-Resources/Reader/b",
+                    "Needle article B",
+                    vec!["Card b".into()],
+                ),
+            ],
+            vec![],
+        );
+        let fts = EvidenceFtsLane {
+            cards: vec![
+                ovp_index::sqlite::FtsHit {
+                    id: "card:40-Resources/Reader/a:0".into(),
+                    rowid: 1,
+                    rank: -3.0,
+                },
+                ovp_index::sqlite::FtsHit {
+                    id: "card:40-Resources/Reader/b:0".into(),
+                    rowid: 2,
+                    rank: -2.0,
+                },
+            ],
+            units: vec![],
+            saturated: false,
+        };
+        // v7 math: gold (title #1, single-lane) = 1/61 loses to a (title
+        // #2 + fts #1) = 1/62 + 1/61 — the flood buries the best match.
+        let out = search_evidence_fused(&model, "needle thread", 10, Some(fts));
+        let hits = out["hits"].as_array().expect("hits");
+        assert_eq!(hits[0]["pack_title"], "Needle thread guide");
+        assert_eq!(hits[0]["pinned"], json!(true));
+        // Partial-coverage packs (needle only, permille 500) never pin.
+        assert!(hits[1].get("pinned").is_none());
+        assert!(hits[2].get("pinned").is_none());
+    }
+
+    /// The pin cap is a fixed minority: five full-coverage hits, only the
+    /// first three pin — the fused top-10 stays majority-RRF.
+    #[test]
+    fn title_pins_cap_at_three() {
+        let packs = (0..5)
+            .map(|i| {
+                simple_pack(
+                    &format!("40-Resources/Reader/p{i}"),
+                    &format!("Needle pack {i}"),
+                    vec![format!("Card {i}")],
+                )
+            })
+            .collect();
+        let model = fixture_model(vec![], packs, vec![]);
+        let fts = EvidenceFtsLane {
+            cards: vec![],
+            units: vec![],
+            saturated: false,
+        };
+        let out = search_evidence_fused(&model, "needle", 10, Some(fts));
+        let hits = out["hits"].as_array().expect("hits");
+        assert_eq!(hits.len(), 5);
+        for (i, hit) in hits.iter().enumerate() {
+            assert_eq!(hit.get("pinned").is_some(), i < 3, "hit {i}: {hit}");
+        }
     }
 
     #[test]

--- a/evolution/candidates/ask_vault_tools-v8.json
+++ b/evolution/candidates/ask_vault_tools-v8.json
@@ -1,0 +1,29 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "ask_vault_tools-v8",
+  "base_version": "v7",
+  "target_version": "v8",
+  "surface": "runtime",
+  "component": "runtime.ask_vault_tools",
+  "hypothesis": "RUNTIME surface, one fusion repair in search_evidence: conditional strong-title protection. Diagnosed (PR #447 evidence-trace + ablation, 6 degraded questions): RRF k=60 buries single-lane hits — a pack ranked 1-4 in the title lane but absent from both fts lanes scores 1/61, while dozens of mediocre packs present in both lanes score 2/(60+r+1) and overtake it, dropping strong title matches to fused rank 21-107 (separate-lane fusion measured WORSE: 70-149). v8: title-lane hits whose language-group coverage is COMPLETE (score permille == 1000 — every term of the best language group matched, a principled predicate, not a tuned threshold) are pinned: at most 3, in title-lane order, placed ahead of the RRF order; pinned hits carry an additive pinned:true field. Queries with no full-coverage title hit fuse exactly as v7 — body-only recall (fts-only golds, no title match at all) is structurally untouched. OVP_ASK_TITLE_PIN=0 restores exact v7 fusion. ANTI-OVERFIT DISCIPLINE (operator directive 2026-08-14): both parameters (cap=3, coverage==complete) are fixed a priori and MUST NOT be tuned against the eval set; acceptance is one pre-registered run; q-010/q-023 (weak title lane, a retrieval-quality problem not a fusion problem) are explicitly NOT targets and their scores carry no weight in the decision.",
+  "predicted_delta": {
+    "coverage": "the four strong-title collapses (s-005 title#1->fused38, s-001 title#3->46, q-005 title#4->21, q-020 title#4->16) return to the fused top-5; body-only fixtures unchanged; tuning-34 search_evidence per-question R@5/R@10/R@20: zero losses.",
+    "operational_reliability": "no new failure modes: pinning is a pure reordering of an already-computed result set; kill switch restores v7; pinned:true keeps transcripts explainable."
+  },
+  "guardrails": {
+    "accepted_without_quote": 0,
+    "fallback_is_v7": "OVP_ASK_TITLE_PIN=0, or any query without a full-coverage title hit, fuses byte-identically to v7",
+    "pin_is_minority": "at most 3 pinned slots — the fused top-10 stays majority-RRF, so the fts lane's body-only wins cannot be crowded out",
+    "predicate_is_principled": "the pin condition is complete best-group term coverage — a semantic property of the match, never a numeric threshold tuned against eval data",
+    "no_eval_iteration": "acceptance = ONE pre-registered tuning-34 run + ONE final frozen-holdout run; a failure sends the candidate back to design review, never into parameter adjustment against the same data",
+    "result_shape_compatible": "additive pinned:true field only",
+    "read_only": "no writes, no projection changes"
+  },
+  "eval_plan": {
+    "replay_set": "adversarial fixtures constructed from the MECHANISM (not from eval questions): (1) full-coverage title #1 absent from fts lanes + two both-lane mediocre packs -> pinned first with pinned:true; (2) five full-coverage hits -> only first three pin; (3) body-only query with zero title matches -> byte-identical v7 fusion; (4) kill switch off -> v7 fusion; all prior fixtures pass unmodified. Pre-registered acceptance: tuning-34 search_evidence per-question R@5/10/20 zero losses AND the four strong-title collapses in fused top-5; then ONE frozen-holdout run recorded in the ledger regardless of outcome.",
+    "paired_sources": 0,
+    "soak": false
+  },
+  "rollback": "Set OVP_ASK_TITLE_PIN=0 (instant, no rebuild) or revert the pin block — a pure reordering ahead of the existing RRF order, no persisted state.",
+  "ablation_required": false
+}


### PR DESCRIPTION
Candidate spec: `evolution/candidates/ask_vault_tools-v8.json` (validated). Fixes the fusion pathology diagnosed in #447.

## What

RRF k=60 buries single-lane hits: a **full-coverage** title #1 absent from both fts lanes (1/61) loses to dozens of mediocre both-lane packs (2/(60+r+1)), collapsing to fused rank 21–107. v8 pins title hits whose best language group matched **completely** (permille == 1000 — a semantic predicate, not a tuned threshold): at most 3, in title-lane order, ahead of the RRF order, marked `pinned: true`. No full-coverage hit → byte-identical v7 fusion. `OVP_ASK_TITLE_PIN=0` → exact v7.

**Anti-overfit discipline** (operator directive): cap=3 and the coverage predicate were fixed a priori in the spec; acceptance was ONE pre-registered run per set; no parameter was adjusted against eval data at any point.

## Pre-registered acceptance results

| gate | result |
|---|---|
| tuning-34, search_evidence per-question R@5/10/20 | **zero losses**, 9 wins (s-001/s-003/s-005: 0 → 1.0 at every k) |
| frozen holdout (first and only run) | **zero losses**, one generalization win (q-009 @5/@10: 0 → 0.5) |
| body-only / prior fixtures | all pass unmodified |

## Prediction miss (disclosed, not patched)

The spec predicted all four v6-era collapses would reach top-5; **q-005 and q-020 did not recover**. Forensics: their golds sit at title rank 4 behind three *other* equally-full-coverage hits that match more terms — no principled fusion change reaches them (likely an incomplete-relevance-labels issue, per the codex consult's warning). Per the `no_eval_iteration` guardrail the cap was **not** raised. This goes to the ledger as a prediction miss.

171 ovp-memory tests pass (new: mechanism-constructed pathology fixture + pin-cap minority fixture — built from the mechanism, not from eval questions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evidence search can prioritize up to three qualifying title matches ahead of other results.
  * Prioritized matches are clearly labeled as pinned.
  * The behavior can be disabled through configuration, preserving the existing search experience.
* **Bug Fixes**
  * Improved result ordering for searches with complete language coverage in title matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->