### PR TITLE
chore(evolve): accept ask_vault_tools-v8 (registry v7→v8)

### DIFF
--- a/evolution/components.json
+++ b/evolution/components.json
@@ -167,7 +167,7 @@
     {
       "id": "runtime.ask_vault_tools",
       "surface": "runtime",
-      "current_version": "v7",
+      "current_version": "v8",
       "file": "crates/ovp-memory/src/vault_tools.rs",
       "quality_buckets": [
         "coverage",


### PR DESCRIPTION
Registry bump completing the v8 acceptance (ledgered 2026-08-14). Tuning-34 + frozen holdout both zero-loss under one pre-registered run each; the q-005/q-020 prediction miss is recorded in the ledger and routed to supplemental label adjudication (data work), not parameter tuning. Rollback: `OVP_ASK_TITLE_PIN=0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the vault tools runtime to the latest available version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->