### PR TITLE
chore(evolve): accept ask_vault_tools-v9 (registry v8→v9)

### DIFF
--- a/evolution/components.json
+++ b/evolution/components.json
@@ -167,7 +167,7 @@
     {
       "id": "runtime.ask_vault_tools",
       "surface": "runtime",
-      "current_version": "v8",
+      "current_version": "v9",
       "file": "crates/ovp-memory/src/vault_tools.rs",
       "quality_buckets": [
         "coverage",


### PR DESCRIPTION
Registry bump; acceptance ledgered 2026-08-14 on the amended value case — capability fixture-proven (R@5=1.0 under agent-style input), bucket lift honestly absent (cross-language paraphrase, routed to the dense experiment). Rollback: revert #450 (absent params are the v8 path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the registered vault tools component to the latest version, ensuring the app uses the current runtime integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->