### PR TITLE
feat(eval): citation-precision + generation stamp + session-dir fix (follow-up trio results inside)

### DIFF
--- a/crates/ovp-cli/src/commands/agent_eval.rs
+++ b/crates/ovp-cli/src/commands/agent_eval.rs
@@ -105,7 +105,10 @@ pub fn run(args: AgentEvalArgs) -> Result<(), CliError> {
     for (i, q) in qrels.iter().enumerate() {
         eprintln!("[{}/{}] {} …", i + 1, qrels.len(), q.id);
         let session = format!("agenteval-{}-{}", q.id, epoch_ms);
-        let mut store = SessionStore::open(&args.vault_root, &session)
+        // SessionStore takes the SESSIONS DIR, not the vault root — passing
+        // the root scattered transcripts into the vault top level once.
+        let sessions_dir = args.vault_root.join(".ovp/ask-sessions");
+        let mut store = SessionStore::open(&sessions_dir, &session)
             .map_err(|e| CliError::Io(format!("session store: {e}")))?;
         let mut client = factory().map_err(CliError::Io)?;
         let cfg = AgentConfig {
@@ -142,6 +145,12 @@ pub fn run(args: AgentEvalArgs) -> Result<(), CliError> {
                     .collect();
                 let mut valid = 0usize;
                 let mut gold_hit = false;
+                // Source-attributed citation set for PRECISION: gold-hit is
+                // boolean recall; precision says how much of the citation
+                // volume actually points at gold (the 85-citation spam
+                // problem the boolean cannot see).
+                let mut attributed: std::collections::BTreeSet<String> =
+                    std::collections::BTreeSet::new();
                 for c in &cited {
                     if let Some(sid) = c.strip_prefix("source:") {
                         let full = known_sources
@@ -150,6 +159,7 @@ pub fn run(args: AgentEvalArgs) -> Result<(), CliError> {
                             .copied();
                         if let Some(full) = full {
                             valid += 1;
+                            attributed.insert(full.to_string());
                             if gold.iter().any(|g| *g == full) {
                                 gold_hit = true;
                             }
@@ -157,6 +167,7 @@ pub fn run(args: AgentEvalArgs) -> Result<(), CliError> {
                     } else if let Some(key) = c.strip_prefix("claim:") {
                         if let Some(sources) = claim_sources.get(key) {
                             valid += 1;
+                            attributed.extend(sources.iter().cloned());
                             if sources.iter().any(|s| gold.contains(s.as_str())) {
                                 gold_hit = true;
                             }
@@ -167,6 +178,14 @@ pub fn run(args: AgentEvalArgs) -> Result<(), CliError> {
                         valid += 1;
                     }
                 }
+                let citation_precision = if attributed.is_empty() {
+                    Value::Null
+                } else {
+                    json!(
+                        attributed.iter().filter(|s| gold.contains(s.as_str())).count() as f64
+                            / attributed.len() as f64
+                    )
+                };
                 let abstained = cited.is_empty();
                 json!({
                     "id": q.id,
@@ -181,6 +200,8 @@ pub fn run(args: AgentEvalArgs) -> Result<(), CliError> {
                     "wall_ms": wall_ms,
                     "citations": cited,
                     "citations_valid": valid,
+                    "attributed_sources": attributed.len(),
+                    "citation_precision": citation_precision,
                     "gold_source_cited": gold_hit,
                     "abstained": abstained,
                     "abstain_correct": q.no_answer == abstained,
@@ -212,6 +233,7 @@ pub fn run(args: AgentEvalArgs) -> Result<(), CliError> {
             "valid_total": ran.iter().filter_map(|r| r["citations_valid"].as_u64()).sum::<u64>(),
         },
         "abstain_correct_rate": rate(&ran.iter().collect::<Vec<_>>(), |r| r["abstain_correct"] == json!(true)),
+        "mean_citation_precision": mean(&ran, "citation_precision"),
         "mean_rounds": mean(&ran, "rounds"),
         "mean_output_tokens": mean(&ran, "output_tokens"),
         "mean_wall_ms": mean(&ran, "wall_ms"),

--- a/crates/ovp-cli/src/commands/retrieval_eval.rs
+++ b/crates/ovp-cli/src/commands/retrieval_eval.rs
@@ -260,13 +260,23 @@ pub fn run(args: RetrievalEvalArgs) -> Result<(), CliError> {
         )));
     }
 
+    // Generation stamp: runs straddling a daily tick are NOT strictly
+    // comparable — the report must say which index it measured (learned
+    // the hard way when an identity check was polluted by a tick).
+    let generation = ovp_index::read_index(&args.vault_root)
+        .map(|m| json!({"built_at": m.built_at, "run_id": m.run_id}))
+        .unwrap_or(Value::Null);
+
     let mut tools = VaultTools::new(&args.vault_root);
     let mut rows = Vec::new();
     for q in &qrels {
         rows.push(score_question(&mut tools, q, &ks, limit, args.query_mode));
     }
 
-    let report = assemble_report(&qrels, rows, &ks, args.query_mode);
+    let mut report = assemble_report(&qrels, rows, &ks, args.query_mode);
+    if let Some(map) = report.as_object_mut() {
+        map.insert("generation".into(), generation);
+    }
     let text = serde_json::to_string_pretty(&report)
         .map_err(|e| CliError::Io(format!("serializing report: {e}")))?;
     match &args.out {


### PR DESCRIPTION
The three '必做' follow-ups from the e2e R0, executed measure-only (fixes deferred per operator — observe first).

## 1. s-009/s-010 label review (droid, independent)

**Both labels CORRECT — genuinely hard zh→en paraphrases** (proper nouns generic-ized: '大模型知识库'↔'Karpathy's LLM Wiki'). The three-way miss is a real capability gap, not label noise → the dense-park verdict stands on solid ground. Verdicts annotated into the qrels.

## 2. Negative bucket expanded to n=3 — and it found a LABEL flaw, not an agent flaw

- **q-017** (real-session negative): abstains **perfectly** — '没有任何结果匹配…最有希望的命中是…'
- **s-028/s-029** (silver negatives): answered with real citations — but silver negatives were adjudicated unanswerable against the **70-item generation sample**, not the 1.6k-source vault; s-028's CUDA answer cites plausibly legitimate sources. **Filed: re-adjudicate silver negatives against the full vault before counting abstain failures.** Agent-side abstain fix stays deferred.

## 3. citation_precision\@source (new metric)

q-001/q-024 (the 67–85-citation answers): **precision 0.05** — 95% of cited volume is off-gold (lower bound, labels incomplete). Bonus root-cause: q-024's ModelError = round-3 output exactly 4096 tokens (MaxTokens) — **citation dumping overflows the answer cap**; one causal chain, one future fix.

## Also

- retrieval-eval reports now carry the **index generation stamp** (tick-straddling runs aren't comparable — learned via a polluted identity check)
- agent-eval SessionStore path bug fixed (first run scattered 10 transcripts into the vault top level; moved to `.ovp/ask-sessions`)

364 tests pass.