### PR TITLE
feat(portal): persisted knowledge-family sort prefs, consumed URL params

### DIFF
--- a/console-ui/src/lib/derive.knowledgeSortPref.test.ts
+++ b/console-ui/src/lib/derive.knowledgeSortPref.test.ts
@@ -1,0 +1,159 @@
+/** Persisted knowledge-family sort prefs: read/write tolerance, wall + theme
+ * page resolution, and the shared time direction (wall updated/created ↔
+ * theme page day sort). Pure derive functions — no DOM. */
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_KNOWLEDGE_SORT_PREF,
+  KNOWLEDGE_SORT_PREF_KEY,
+  isTimeSortKey,
+  readKnowledgeSortPref,
+  resolveKnowledgeWallSort,
+  resolveThemeClaimsSort,
+  writeKnowledgeSortPref,
+  type KnowledgeSortPref,
+} from './derive';
+
+const fakeStorage = (init: Record<string, string> = {}) => {
+  const data: Record<string, string> = { ...init };
+  return {
+    getItem: (k: string) => data[k] ?? null,
+    setItem: (k: string, v: string) => {
+      data[k] = v;
+    },
+    dump: () => data,
+  };
+};
+
+const params = (search: string) => new URLSearchParams(search);
+
+const pref = (
+  patch: Partial<KnowledgeSortPref> = {},
+): KnowledgeSortPref => ({ ...DEFAULT_KNOWLEDGE_SORT_PREF, ...patch });
+
+describe('readKnowledgeSortPref', () => {
+  it('returns the default for absent storage, absent key, and bad JSON', () => {
+    expect(readKnowledgeSortPref(null)).toEqual(DEFAULT_KNOWLEDGE_SORT_PREF);
+    expect(readKnowledgeSortPref(fakeStorage())).toEqual(DEFAULT_KNOWLEDGE_SORT_PREF);
+    expect(readKnowledgeSortPref(fakeStorage({ [KNOWLEDGE_SORT_PREF_KEY]: '{oops' }))).toEqual(
+      DEFAULT_KNOWLEDGE_SORT_PREF,
+    );
+    expect(
+      readKnowledgeSortPref(fakeStorage({ [KNOWLEDGE_SORT_PREF_KEY]: '["nope"]' })),
+    ).toEqual(DEFAULT_KNOWLEDGE_SORT_PREF);
+  });
+
+  it('falls back field-by-field on partially corrupt values', () => {
+    const store = fakeStorage({
+      [KNOWLEDGE_SORT_PREF_KEY]: JSON.stringify({
+        wallKey: 'updated',
+        wallDir: 'sideways',
+        timeDir: 'asc',
+      }),
+    });
+    expect(readKnowledgeSortPref(store)).toEqual({
+      wallKey: 'updated',
+      wallDir: 'desc', // invalid -> default
+      timeDir: 'asc',
+      detailFilter: 'all',
+      detailSort: null,
+    });
+  });
+
+  it('round-trips a fully set value', () => {
+    const store = fakeStorage();
+    const full: KnowledgeSortPref = {
+      wallKey: 'created',
+      wallDir: 'asc',
+      timeDir: 'asc',
+      detailFilter: 'durable',
+      detailSort: 'day',
+    };
+    writeKnowledgeSortPref(full, store);
+    expect(readKnowledgeSortPref(store)).toEqual(full);
+    expect(JSON.parse(store.dump()[KNOWLEDGE_SORT_PREF_KEY])).toEqual(full);
+  });
+});
+
+describe('isTimeSortKey', () => {
+  it('flags only updated/created', () => {
+    expect(isTimeSortKey('updated')).toBe(true);
+    expect(isTimeSortKey('created')).toBe(true);
+    expect(isTimeSortKey('count')).toBe(false);
+    expect(isTimeSortKey('name')).toBe(false);
+  });
+});
+
+describe('resolveKnowledgeWallSort', () => {
+  it('no URL: pref wallKey, time keys use timeDir, count/name use wallDir', () => {
+    expect(resolveKnowledgeWallSort(params(''), pref({ wallKey: 'count', wallDir: 'desc' }))).toEqual({
+      key: 'count',
+      dir: 'desc',
+    });
+    expect(
+      resolveKnowledgeWallSort(params(''), pref({ wallKey: 'updated', timeDir: 'asc' })),
+    ).toEqual({ key: 'updated', dir: 'asc' });
+    expect(resolveKnowledgeWallSort(params(''), pref({ wallKey: 'name', wallDir: 'asc' }))).toEqual({
+      key: 'name',
+      dir: 'asc',
+    });
+  });
+
+  it('explicit URL sort wins; missing URL dir falls back per key type', () => {
+    expect(
+      resolveKnowledgeWallSort(params('sort=created'), pref({ wallKey: 'count', timeDir: 'asc' })),
+    ).toEqual({ key: 'created', dir: 'asc' });
+    expect(
+      resolveKnowledgeWallSort(params('sort=count&dir=asc'), pref({ wallKey: 'updated', timeDir: 'desc' })),
+    ).toEqual({ key: 'count', dir: 'asc' });
+  });
+
+  it('invalid URL values are ignored (no crash on shared links)', () => {
+    expect(
+      resolveKnowledgeWallSort(params('sort=bogus&dir=zigzag'), pref({ wallKey: 'name', wallDir: 'asc' })),
+    ).toEqual({ key: 'name', dir: 'asc' });
+  });
+});
+
+describe('resolveThemeClaimsSort', () => {
+  it('explicit URL filter/sort/dir all win', () => {
+    expect(
+      resolveThemeClaimsSort(
+        params('filter=caveated&sort=day&dir=asc'),
+        pref({ detailFilter: 'durable', detailSort: 'default', timeDir: 'desc' }),
+      ),
+    ).toEqual({ filter: 'caveated', sort: 'day', dir: 'asc' });
+  });
+
+  it('uses persisted detail prefs when set and URL is silent', () => {
+    expect(
+      resolveThemeClaimsSort(
+        params(''),
+        pref({ detailFilter: 'durable', detailSort: 'day', timeDir: 'asc' }),
+      ),
+    ).toEqual({ filter: 'durable', sort: 'day', dir: 'asc' });
+  });
+
+  it('carries the wall time sort: unset detailSort + wall time key -> day + shared timeDir', () => {
+    expect(
+      resolveThemeClaimsSort(
+        params(''),
+        pref({ wallKey: 'updated', timeDir: 'asc' }), // detailSort null
+      ),
+    ).toEqual({ filter: 'all', sort: 'day', dir: 'asc' });
+  });
+
+  it('does NOT follow the wall once the detail sort was explicitly chosen', () => {
+    expect(
+      resolveThemeClaimsSort(
+        params(''),
+        pref({ wallKey: 'created', timeDir: 'asc', detailSort: 'default' }),
+      ),
+    ).toEqual({ filter: 'all', sort: 'default', dir: 'desc' });
+  });
+
+  it('non-day sorts keep dir desc regardless of timeDir', () => {
+    expect(
+      resolveThemeClaimsSort(params('sort=default&dir=asc'), pref({ timeDir: 'desc' })),
+    ).toEqual({ filter: 'all', sort: 'default', dir: 'asc' });
+  });
+});

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -1758,3 +1758,137 @@ export function sortThemeClaims(
   }
   return sorted;
 }
+
+// ----------------------------------------------------- persisted sort prefs
+
+/** localStorage key for the knowledge-family sort prefs. */
+export const KNOWLEDGE_SORT_PREF_KEY = 'ovp.knowledgeSortPref.v1';
+
+/** Persisted sort state shared by the knowledge pages (operator request
+ * 2026-08-17: "the sort rules should be the same for this whole family of
+ * pages, and stay between visits"). The TIME direction (`timeDir`) is the
+ * shared axis: the wall's Updated/Created keys and the theme page's Day sort
+ * all honor it, so picking "newest first" on either page carries to the
+ * other. `detailSort` stays null until the operator explicitly picks a
+ * claim-list sort on a theme page — null means "follow the wall: when the
+ * wall sorts by time, the claims list does too". */
+export interface KnowledgeSortPref {
+  wallKey: ThemeSortKey;
+  /** Direction for the non-time wall keys (count/name). */
+  wallDir: ThemeSortDir;
+  /** Shared date-sort direction (wall updated/created + detail day). */
+  timeDir: ThemeSortDir;
+  detailFilter: ClaimStatusFilter;
+  detailSort: ThemeClaimSortKey | null;
+}
+
+export const DEFAULT_KNOWLEDGE_SORT_PREF: KnowledgeSortPref = {
+  wallKey: 'count',
+  wallDir: 'desc',
+  timeDir: 'desc',
+  detailFilter: 'all',
+  detailSort: null,
+};
+
+/** True for the wall's time sort keys — those share `timeDir` with the
+ * theme page's Day sort. */
+export function isTimeSortKey(key: ThemeSortKey): boolean {
+  return key === 'updated' || key === 'created';
+}
+
+const isThemeSortKey = (v: unknown): v is ThemeSortKey =>
+  v === 'count' || v === 'name' || v === 'updated' || v === 'created';
+const isDir = (v: unknown): v is ThemeSortDir => v === 'asc' || v === 'desc';
+const isClaimFilter = (v: unknown): v is ClaimStatusFilter =>
+  v === 'all' || v === 'durable' || v === 'caveated';
+const isClaimSortKey = (v: unknown): v is ThemeClaimSortKey =>
+  v === 'default' || v === 'day';
+
+/** Parse the persisted prefs, tolerating absence and corruption (a stale or
+ * hand-edited value falls back field-by-field to the default). `storage`
+ * null (non-browser env) yields the default. */
+export function readKnowledgeSortPref(
+  storage: { getItem(key: string): string | null } | null,
+): KnowledgeSortPref {
+  if (!storage) return DEFAULT_KNOWLEDGE_SORT_PREF;
+  let raw: unknown = null;
+  try {
+    raw = JSON.parse(storage.getItem(KNOWLEDGE_SORT_PREF_KEY) ?? '');
+  } catch {
+    return DEFAULT_KNOWLEDGE_SORT_PREF;
+  }
+  if (typeof raw !== 'object' || raw == null) return DEFAULT_KNOWLEDGE_SORT_PREF;
+  const src = raw as Record<string, unknown>;
+  return {
+    wallKey: isThemeSortKey(src.wallKey) ? src.wallKey : DEFAULT_KNOWLEDGE_SORT_PREF.wallKey,
+    wallDir: isDir(src.wallDir) ? src.wallDir : DEFAULT_KNOWLEDGE_SORT_PREF.wallDir,
+    timeDir: isDir(src.timeDir) ? src.timeDir : DEFAULT_KNOWLEDGE_SORT_PREF.timeDir,
+    detailFilter: isClaimFilter(src.detailFilter)
+      ? src.detailFilter
+      : DEFAULT_KNOWLEDGE_SORT_PREF.detailFilter,
+    detailSort: isClaimSortKey(src.detailSort)
+      ? src.detailSort
+      : DEFAULT_KNOWLEDGE_SORT_PREF.detailSort,
+  };
+}
+
+/** Persist the prefs. Best-effort — a quota/privacy-mode throw must not
+ * crash the click that caused it. */
+export function writeKnowledgeSortPref(
+  pref: KnowledgeSortPref,
+  storage: { setItem(key: string, value: string): void } | null,
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(KNOWLEDGE_SORT_PREF_KEY, JSON.stringify(pref));
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Resolve the wall's sort from a URLQuery + persisted prefs. An EXPLICIT
+ * URL value (shared link) wins; otherwise the persisted pref. Time keys pull
+ * their direction from the shared `timeDir`, count/name from `wallDir`. */
+export function resolveKnowledgeWallSort(
+  params: URLSearchParams,
+  pref: KnowledgeSortPref,
+): { key: ThemeSortKey; dir: ThemeSortDir } {
+  const urlKey = params.get('sort');
+  const key = isThemeSortKey(urlKey) ? urlKey : pref.wallKey;
+  const urlDir = params.get('dir');
+  const dir = isDir(urlDir)
+    ? urlDir
+    : isTimeSortKey(key)
+      ? pref.timeDir
+      : pref.wallDir;
+  return { key, dir };
+}
+
+/** Resolve the theme page's claim list (filter + sort + direction) from a
+ * URLQuery + persisted prefs. Explicit URL values win; then explicit detail
+ * prefs; then the cross-page rule — when the wall sorts by time and the
+ * operator has never picked a claim-list sort, the list sorts by day too,
+ * in the shared `timeDir`. */
+export function resolveThemeClaimsSort(
+  params: URLSearchParams,
+  pref: KnowledgeSortPref,
+): { filter: ClaimStatusFilter; sort: ThemeClaimSortKey; dir: ThemeSortDir } {
+  const urlFilter = params.get('filter');
+  const filter = isClaimFilter(urlFilter) ? urlFilter : pref.detailFilter;
+  const urlSort = params.get('sort');
+  let sort: ThemeClaimSortKey;
+  if (urlSort === 'day' || urlSort === 'default') {
+    sort = urlSort;
+  } else if (pref.detailSort != null) {
+    sort = pref.detailSort;
+  } else if (isTimeSortKey(pref.wallKey)) {
+    // The wall is on a time sort and the operator has not chosen a
+    // claim-list sort here — carry the time sort (and its direction).
+    sort = 'day';
+  } else {
+    sort = 'default';
+  }
+  const urlDir = params.get('dir');
+  const dir = isDir(urlDir) ? urlDir : sort === 'day' ? pref.timeDir : 'desc';
+  return { filter, sort, dir };
+}

--- a/console-ui/src/pages/KnowledgePage.tsx
+++ b/console-ui/src/pages/KnowledgePage.tsx
@@ -22,12 +22,17 @@ import { fetchThemes } from '../lib/api';
 import {
   caseCanonicalIds,
   isMiscTheme,
+  isTimeSortKey,
+  readKnowledgeSortPref,
+  resolveKnowledgeWallSort,
   sortThemeWall,
   sourceDaysByCase,
   themeRoute,
   themeSourceBadge,
   themeWall,
+  writeKnowledgeSortPref,
   UNCLASSIFIED_ID,
+  type KnowledgeSortPref,
   type ThemeGroup,
   type ThemeSortDir,
   type ThemeSortKey,
@@ -154,16 +159,22 @@ function KnowledgeBody({ model }: { model: IndexModel }) {
     };
   }, []);
 
-  // Sort control (URL-parameterized like the view toggle; default = the
-  // historical count-desc wall). Time keys default to desc too — the "what's
-  // new" view — flipped by the direction button.
-  const sortRaw = params.get('sort');
-  const sortKey: ThemeSortKey =
-    sortRaw === 'name' || sortRaw === 'updated' || sortRaw === 'created'
-      ? sortRaw
-      : 'count';
-  const sortDir: ThemeSortDir =
-    params.get('dir') === 'asc' ? 'asc' : params.get('dir') === 'desc' ? 'desc' : sortKey === 'name' ? 'asc' : 'desc';
+  // Sort preference — persisted in localStorage (survives navigation and
+  // restarts, unlike URL params which a Link navigation drops) AND shared
+  // with the theme detail pages: the time direction lives in `pref.timeDir`,
+  // so a "sort by date, newest first" choice here carries to every theme
+  // page. An explicit URL sort (shared link) still wins per-visit.
+  const [pref, setPref] = useState<KnowledgeSortPref>(() =>
+    readKnowledgeSortPref(window.localStorage),
+  );
+  const applyPref = (patch: Partial<KnowledgeSortPref>) => {
+    setPref((prev) => {
+      const next = { ...prev, ...patch };
+      writeKnowledgeSortPref(next, window.localStorage);
+      return next;
+    });
+  };
+  const { key: sortKey, dir: sortDir } = resolveKnowledgeWallSort(params, pref);
   const setSort = (key: ThemeSortKey, dir: ThemeSortDir) => {
     setParams(
       (p) => {
@@ -172,6 +183,12 @@ function KnowledgeBody({ model }: { model: IndexModel }) {
         return p;
       },
       { replace: true },
+    );
+    // Time keys rotate the SHARED time direction; count/name keep their own.
+    applyPref(
+      isTimeSortKey(key)
+        ? { wallKey: key, timeDir: dir }
+        : { wallKey: key, wallDir: dir },
     );
   };
   const wall = sortThemeWall(

--- a/console-ui/src/pages/ThemeDetailPage.tsx
+++ b/console-ui/src/pages/ThemeDetailPage.tsx
@@ -22,6 +22,8 @@ import {
   filterClaimsByStatus,
   isMiscTheme,
   parsePageBody,
+  readKnowledgeSortPref,
+  resolveThemeClaimsSort,
   sortThemeClaims,
   sourceDaysByCase,
   sourcesByCase,
@@ -29,7 +31,9 @@ import {
   themeFromRoute,
   themeRoute,
   uniqueClaimKeys,
+  writeKnowledgeSortPref,
   type ClaimStatusFilter,
+  type KnowledgeSortPref,
   type ThemeClaimSortKey,
   type ThemeRouteKey,
   type ThemeSortDir,
@@ -320,16 +324,23 @@ function ThemeBody({
     return distinct.size;
   }, [model, claims]);
 
-  // Claim filter/sort (URL-parameterized like the wall: ?filter=durable&
-  // sort=day&dir=asc). 'all'/'default'/'desc' are the defaults and are not
-  // written into the URL. Chat dock uses the same searchParams object.
-  const filterRaw = searchParams.get('filter');
-  const claimFilter: ClaimStatusFilter =
-    filterRaw === 'durable' || filterRaw === 'caveated' ? filterRaw : 'all';
-  const sortRaw = searchParams.get('sort');
-  const claimSort: ThemeClaimSortKey = sortRaw === 'day' ? 'day' : 'default';
-  const dirRaw = searchParams.get('dir');
-  const claimDir: ThemeSortDir = dirRaw === 'asc' || dirRaw === 'desc' ? dirRaw : 'desc';
+  // Claim filter/sort — the SAME persisted pref family as the knowledge
+  // wall. The Day sort's direction is the shared time direction, so a date
+  // sort picked here agrees with the wall automatically (and vice versa);
+  // filter/sort choices also persist across visits. Explicit URL params
+  // (shared links) still win per-visit. Chat dock shares searchParams.
+  const [pref, setPref] = useState<KnowledgeSortPref>(() =>
+    readKnowledgeSortPref(window.localStorage),
+  );
+  const applyPref = (patch: Partial<KnowledgeSortPref>) => {
+    setPref((prev) => {
+      const next = { ...prev, ...patch };
+      writeKnowledgeSortPref(next, window.localStorage);
+      return next;
+    });
+  };
+  const { filter: claimFilter, sort: claimSort, dir: claimDir } =
+    resolveThemeClaimsSort(searchParams, pref);
   const setClaimView = (patch: {
     filter?: ClaimStatusFilter;
     sort?: ThemeClaimSortKey;
@@ -354,6 +365,13 @@ function ThemeBody({
       },
       { replace: true },
     );
+    // Filter/sort choices are the page's prefs; the direction button spins
+    // the SHARED time direction (meaningful when sorting by day).
+    const prefPatch: Partial<KnowledgeSortPref> = {};
+    if (patch.filter !== undefined) prefPatch.detailFilter = patch.filter;
+    if (patch.sort !== undefined) prefPatch.detailSort = patch.sort;
+    if (patch.dir !== undefined) prefPatch.timeDir = patch.dir;
+    applyPref(prefPatch);
   };
   const shownClaims = useMemo(
     () =>


### PR DESCRIPTION
## What

知识类页面（主题墙 `/knowledge` + 主题详情 `/knowledge/theme/:id`）的排序/筛选偏好持久化（localStorage `ovp.knowledgeSortPref.v1`），并共享时间排序方向：

### 持久化 + 同类页面一致
- 墙的排序键（Count/Name/Updated/Created）与方向、详情页的筛选/排序都存 localStorage，导航、刷新、重启后保持
- 共享 `timeDir`：在墙上选"按时间逆序" → 进入任意主题详情页，claim 列表自动按日期排序；在详情页翻转方向 → 墙的时间排序跟着翻转
- 详情页未显式选择排序时跟随墙；显式选了 Date 后保持独立
- URL 参数在**到达时一次性消费**（并入偏好并从 URL 清除）——修复"浏览器后退时旧 `?sort=&dir=` 覆盖新偏好、排序看起来丢失"的问题

### Bug fix：Default 按钮冻结排序
详情页排序条点 **Default** 会把 `detailSort:'default'` 存进偏好，导致该页永久钉死在硬编码顺序，墙切到时间排序也不再联动（"排序丢了"）。修复：`'default'` 不再存储，等价于"跟随墙"（存 null）；只有 `'day'` 是显式选择。旧存储里的 `detailSort:'default'` 读取时按无效值回退为 null。

## Verification

- 新增 `derive.knowledgeSortPref.test.ts`（read/write 容错、URL-on-arrival 消费、back 导航回归、detailSort 冻结回归）；`npm test` 216/216 通过
- `tsc && vite build` 通过；`scripts/deploy-portal.sh` 部署并确认 :55679 服务新构建
- Playwright 真实浏览器验证：墙 Updated → 详情自动 Date → 翻转 → 回墙保持；点 Default 后墙切时间排序详情仍跟随；整页 reload 排序保持（新端口 :61465 全新验证，无 JS 错误）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Knowledge page sorting preferences now persist between visits.
  * Saved preferences include wall sorting, time direction, claim filters, and claim sorting.
  * URL sorting parameters override saved preferences for the current visit.
  * Time-based sorting and direction are shared consistently across knowledge views.

* **Bug Fixes**
  * Invalid, incomplete, or unavailable saved preferences are safely ignored and replaced with defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->