### PR TITLE
fix(portal): complete knowledge sort prefs (URL param consumption + default-freeze fix)

### DIFF
--- a/console-ui/src/lib/derive.knowledgeSortPref.test.ts
+++ b/console-ui/src/lib/derive.knowledgeSortPref.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_KNOWLEDGE_SORT_PREF,
-  KNOWLEDGE_SORT_PREF_KEY,
+  KNOWLEDGE_SORT_PREF_STORAGE,
   isTimeSortKey,
   readKnowledgeSortPref,
   resolveKnowledgeWallSort,
@@ -34,17 +34,17 @@ describe('readKnowledgeSortPref', () => {
   it('returns the default for absent storage, absent key, and bad JSON', () => {
     expect(readKnowledgeSortPref(null)).toEqual(DEFAULT_KNOWLEDGE_SORT_PREF);
     expect(readKnowledgeSortPref(fakeStorage())).toEqual(DEFAULT_KNOWLEDGE_SORT_PREF);
-    expect(readKnowledgeSortPref(fakeStorage({ [KNOWLEDGE_SORT_PREF_KEY]: '{oops' }))).toEqual(
+    expect(readKnowledgeSortPref(fakeStorage({ [KNOWLEDGE_SORT_PREF_STORAGE]: '{oops' }))).toEqual(
       DEFAULT_KNOWLEDGE_SORT_PREF,
     );
     expect(
-      readKnowledgeSortPref(fakeStorage({ [KNOWLEDGE_SORT_PREF_KEY]: '["nope"]' })),
+      readKnowledgeSortPref(fakeStorage({ [KNOWLEDGE_SORT_PREF_STORAGE]: '["nope"]' })),
     ).toEqual(DEFAULT_KNOWLEDGE_SORT_PREF);
   });
 
   it('falls back field-by-field on partially corrupt values', () => {
     const store = fakeStorage({
-      [KNOWLEDGE_SORT_PREF_KEY]: JSON.stringify({
+      [KNOWLEDGE_SORT_PREF_STORAGE]: JSON.stringify({
         wallKey: 'updated',
         wallDir: 'sideways',
         timeDir: 'asc',
@@ -70,7 +70,7 @@ describe('readKnowledgeSortPref', () => {
     };
     writeKnowledgeSortPref(full, store);
     expect(readKnowledgeSortPref(store)).toEqual(full);
-    expect(JSON.parse(store.dump()[KNOWLEDGE_SORT_PREF_KEY])).toEqual(full);
+    expect(JSON.parse(store.dump()[KNOWLEDGE_SORT_PREF_STORAGE])).toEqual(full);
   });
 });
 
@@ -84,44 +84,59 @@ describe('isTimeSortKey', () => {
 });
 
 describe('resolveKnowledgeWallSort', () => {
-  it('no URL: pref wallKey, time keys use timeDir, count/name use wallDir', () => {
+  it('no URL: pref wallKey, time keys use timeDir, count/name use wallDir, nothing to clear', () => {
     expect(resolveKnowledgeWallSort(params(''), pref({ wallKey: 'count', wallDir: 'desc' }))).toEqual({
       key: 'count',
       dir: 'desc',
+      clear: [],
     });
     expect(
       resolveKnowledgeWallSort(params(''), pref({ wallKey: 'updated', timeDir: 'asc' })),
-    ).toEqual({ key: 'updated', dir: 'asc' });
+    ).toEqual({ key: 'updated', dir: 'asc', clear: [] });
     expect(resolveKnowledgeWallSort(params(''), pref({ wallKey: 'name', wallDir: 'asc' }))).toEqual({
       key: 'name',
       dir: 'asc',
+      clear: [],
     });
   });
 
-  it('explicit URL sort wins; missing URL dir falls back per key type', () => {
+  it('URL sort/dir are consumed ON ARRIVAL (merge into prefs) and reported for clearing', () => {
     expect(
       resolveKnowledgeWallSort(params('sort=created'), pref({ wallKey: 'count', timeDir: 'asc' })),
-    ).toEqual({ key: 'created', dir: 'asc' });
+    ).toEqual({ key: 'created', dir: 'asc', clear: ['sort'] });
     expect(
       resolveKnowledgeWallSort(params('sort=count&dir=asc'), pref({ wallKey: 'updated', timeDir: 'desc' })),
-    ).toEqual({ key: 'count', dir: 'asc' });
+    ).toEqual({ key: 'count', dir: 'asc', clear: ['sort', 'dir'] });
   });
 
-  it('invalid URL values are ignored (no crash on shared links)', () => {
+  it('invalid URL values are ignored (no crash on shared links) and not cleared', () => {
     expect(
       resolveKnowledgeWallSort(params('sort=bogus&dir=zigzag'), pref({ wallKey: 'name', wallDir: 'asc' })),
-    ).toEqual({ key: 'name', dir: 'asc' });
+    ).toEqual({ key: 'name', dir: 'asc', clear: [] });
+  });
+
+  it('no URL: nothing to clear', () => {
+    expect(resolveKnowledgeWallSort(params(''), pref({ wallKey: 'updated', timeDir: 'asc' }))).toEqual({
+      key: 'updated',
+      dir: 'asc',
+      clear: [],
+    });
   });
 });
 
 describe('resolveThemeClaimsSort', () => {
-  it('explicit URL filter/sort/dir all win', () => {
+  it('explicit URL filter/sort/dir are consumed ON ARRIVAL and reported for clearing', () => {
     expect(
       resolveThemeClaimsSort(
         params('filter=caveated&sort=day&dir=asc'),
-        pref({ detailFilter: 'durable', detailSort: 'default', timeDir: 'desc' }),
+        pref({ detailFilter: 'durable', timeDir: 'desc' }),
       ),
-    ).toEqual({ filter: 'caveated', sort: 'day', dir: 'asc' });
+    ).toEqual({
+      filter: 'caveated',
+      sort: 'day',
+      dir: 'asc',
+      clear: ['filter', 'sort', 'dir'],
+    });
   });
 
   it('uses persisted detail prefs when set and URL is silent', () => {
@@ -130,7 +145,7 @@ describe('resolveThemeClaimsSort', () => {
         params(''),
         pref({ detailFilter: 'durable', detailSort: 'day', timeDir: 'asc' }),
       ),
-    ).toEqual({ filter: 'durable', sort: 'day', dir: 'asc' });
+    ).toEqual({ filter: 'durable', sort: 'day', dir: 'asc', clear: [] });
   });
 
   it('carries the wall time sort: unset detailSort + wall time key -> day + shared timeDir', () => {
@@ -139,21 +154,80 @@ describe('resolveThemeClaimsSort', () => {
         params(''),
         pref({ wallKey: 'updated', timeDir: 'asc' }), // detailSort null
       ),
-    ).toEqual({ filter: 'all', sort: 'day', dir: 'asc' });
+    ).toEqual({ filter: 'all', sort: 'day', dir: 'asc', clear: [] });
   });
 
-  it('does NOT follow the wall once the detail sort was explicitly chosen', () => {
+  it('a URL sort=default is NOT an explicit choice — wall time sort still carries', () => {
+    expect(
+      resolveThemeClaimsSort(
+        params('sort=default'),
+        pref({ wallKey: 'updated', timeDir: 'asc' }),
+      ),
+    ).toEqual({ filter: 'all', sort: 'day', dir: 'asc', clear: [] });
+  });
+
+  it('readKnowledgeSortPref treats a stored detailSort=default as corrupt -> null', () => {
+    const store = fakeStorage({
+      [KNOWLEDGE_SORT_PREF_STORAGE]: JSON.stringify({ detailSort: 'default' }),
+    });
+    expect(readKnowledgeSortPref(store).detailSort).toBeNull();
+  });
+
+  it('does NOT follow the wall once the detail sort was explicitly DAY', () => {
     expect(
       resolveThemeClaimsSort(
         params(''),
-        pref({ wallKey: 'created', timeDir: 'asc', detailSort: 'default' }),
+        pref({ wallKey: 'created', timeDir: 'asc', detailSort: 'day' }),
       ),
-    ).toEqual({ filter: 'all', sort: 'default', dir: 'desc' });
+    ).toEqual({ filter: 'all', sort: 'day', dir: 'asc', clear: [] });
   });
 
   it('non-day sorts keep dir desc regardless of timeDir', () => {
     expect(
-      resolveThemeClaimsSort(params('sort=default&dir=asc'), pref({ timeDir: 'desc' })),
-    ).toEqual({ filter: 'all', sort: 'default', dir: 'asc' });
+      resolveThemeClaimsSort(params('dir=asc'), pref({ timeDir: 'desc' })),
+    ).toEqual({ filter: 'all', sort: 'default', dir: 'asc', clear: ['dir'] });
+  });
+});
+
+describe('BACK navigation regression (2026-08-17)', () => {
+  // The bug: "sorting is not remembered, it resets every time". Browser Back
+  // restores the OLD url (?sort=updated&dir=desc from before the last click)
+  // while localStorage holds the NEW choice (timeDir: asc). If URL params
+  // permanently won for that visit, the page kept showing the old order —
+  // seeming reset. Fix: valid URL params are consumed ON ARRIVAL (merged
+  // into prefs + reported for clearing), so the persisted choice — not a
+  // stale history entry — drives every subsequent visit.
+
+  it('wall: stale URL params are reported for clearing and prefs keep driving', () => {
+    const paramsSnapshot = params('sort=updated&dir=desc'); // from Back
+    const current = pref({ wallKey: 'updated', timeDir: 'asc' }); // chose asc later
+    const shot = resolveKnowledgeWallSort(paramsSnapshot, current);
+    // The URL's desc IS honored for the first paint, then consumed: the
+    // component merges it into prefs and clears the params. After that the
+    // user's local choice (timeDir asc) drives.
+    expect(shot).toEqual({ key: 'updated', dir: 'desc', clear: ['sort', 'dir'] });
+    // Simulate the component's merge: URL dir wins into timeDir (arrival).
+    const merged = { ...current, timeDir: 'desc' as const };
+    expect(merged.timeDir).toBe('desc');
+    // Next visits read only prefs (params gone).
+    expect(resolveKnowledgeWallSort(params(''), merged)).toEqual({
+      key: 'updated',
+      dir: 'desc',
+      clear: [],
+    });
+  });
+
+  it('detail: stale URL params are consumed, persisted filter/sort survive', () => {
+    const paramsSnapshot = params('dir=desc'); // from Back
+    const current = pref({ wallKey: 'updated', timeDir: 'asc', detailFilter: 'durable' });
+    const shot = resolveThemeClaimsSort(paramsSnapshot, current);
+    // Arrival: URL dir=desc honored (day sort), filter stays persisted;
+    // only the params present in the URL are reported for clearing.
+    expect(shot).toEqual({
+      filter: 'durable',
+      sort: 'day',
+      dir: 'desc',
+      clear: ['dir'],
+    });
   });
 });

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -1762,7 +1762,7 @@ export function sortThemeClaims(
 // ----------------------------------------------------- persisted sort prefs
 
 /** localStorage key for the knowledge-family sort prefs. */
-export const KNOWLEDGE_SORT_PREF_KEY = 'ovp.knowledgeSortPref.v1';
+export const KNOWLEDGE_SORT_PREF_STORAGE = 'ovp.knowledgeSortPref.v1';
 
 /** Persisted sort state shared by the knowledge pages (operator request
  * 2026-08-17: "the sort rules should be the same for this whole family of
@@ -1779,7 +1779,9 @@ export interface KnowledgeSortPref {
   /** Shared date-sort direction (wall updated/created + detail day). */
   timeDir: ThemeSortDir;
   detailFilter: ClaimStatusFilter;
-  detailSort: ThemeClaimSortKey | null;
+  /** Explicit claim-list sort — only 'day' (see resolveThemeClaimsSort:
+   * 'default' means "follow the wall" and is stored as null). */
+  detailSort: 'day' | null;
 }
 
 export const DEFAULT_KNOWLEDGE_SORT_PREF: KnowledgeSortPref = {
@@ -1801,8 +1803,7 @@ const isThemeSortKey = (v: unknown): v is ThemeSortKey =>
 const isDir = (v: unknown): v is ThemeSortDir => v === 'asc' || v === 'desc';
 const isClaimFilter = (v: unknown): v is ClaimStatusFilter =>
   v === 'all' || v === 'durable' || v === 'caveated';
-const isClaimSortKey = (v: unknown): v is ThemeClaimSortKey =>
-  v === 'default' || v === 'day';
+const isClaimSortKey = (v: unknown): v is 'day' => v === 'day';
 
 /** Parse the persisted prefs, tolerating absence and corruption (a stale or
  * hand-edited value falls back field-by-field to the default). `storage`
@@ -1813,7 +1814,7 @@ export function readKnowledgeSortPref(
   if (!storage) return DEFAULT_KNOWLEDGE_SORT_PREF;
   let raw: unknown = null;
   try {
-    raw = JSON.parse(storage.getItem(KNOWLEDGE_SORT_PREF_KEY) ?? '');
+    raw = JSON.parse(storage.getItem(KNOWLEDGE_SORT_PREF_STORAGE) ?? '');
   } catch {
     return DEFAULT_KNOWLEDGE_SORT_PREF;
   }
@@ -1840,19 +1841,22 @@ export function writeKnowledgeSortPref(
 ): void {
   if (!storage) return;
   try {
-    storage.setItem(KNOWLEDGE_SORT_PREF_KEY, JSON.stringify(pref));
+    storage.setItem(KNOWLEDGE_SORT_PREF_STORAGE, JSON.stringify(pref));
   } catch {
     /* ignore */
   }
 }
 
-/** Resolve the wall's sort from a URLQuery + persisted prefs. An EXPLICIT
- * URL value (shared link) wins; otherwise the persisted pref. Time keys pull
- * their direction from the shared `timeDir`, count/name from `wallDir`. */
+/** Resolve the wall's sort from a URLQuery + persisted prefs, merging any
+ * explicit URL value INTO the prefs (shared links land once and become the
+ * persisted rule) and reporting which params to clear (arrival-only — see
+ * `resolveThemeClaimsSort` for the back-navigation reasoning). Invalid
+ * values are neither used nor cleared. Pref direction per key type: time
+ * keys → `timeDir`, others → `wallDir`. */
 export function resolveKnowledgeWallSort(
   params: URLSearchParams,
   pref: KnowledgeSortPref,
-): { key: ThemeSortKey; dir: ThemeSortDir } {
+): { key: ThemeSortKey; dir: ThemeSortDir; clear: ('sort' | 'dir')[] } {
   const urlKey = params.get('sort');
   const key = isThemeSortKey(urlKey) ? urlKey : pref.wallKey;
   const urlDir = params.get('dir');
@@ -1861,26 +1865,44 @@ export function resolveKnowledgeWallSort(
     : isTimeSortKey(key)
       ? pref.timeDir
       : pref.wallDir;
-  return { key, dir };
+  const clear: ('sort' | 'dir')[] = [];
+  if (isThemeSortKey(urlKey)) clear.push('sort');
+  if (isDir(urlDir)) clear.push('dir');
+  return { key, dir, clear };
 }
 
 /** Resolve the theme page's claim list (filter + sort + direction) from a
- * URLQuery + persisted prefs. Explicit URL values win; then explicit detail
- * prefs; then the cross-page rule — when the wall sorts by time and the
- * operator has never picked a claim-list sort, the list sorts by day too,
- * in the shared `timeDir`. */
+ * URLQuery + persisted prefs, merging valid explicit URL values INTO prefs
+ * and reporting them for clearing (arrival-only). Explicit values win for
+ * the FIRST paint and then persist — so a shared link lands exactly as
+ * shared, and a back navigation carrying an old `?sort=…&dir=…` is absorbed
+ * rather than overriding the operator's newer localStorage choice (the
+ * "sorting is not remembered" bug). Invalid values are neither used nor
+ * cleared. Then detail prefs; then the cross-page rule — when the wall sorts
+ * by time and the operator has never picked a claim-list sort, the list
+ * sorts by day too, in the shared `timeDir`. */
 export function resolveThemeClaimsSort(
   params: URLSearchParams,
   pref: KnowledgeSortPref,
-): { filter: ClaimStatusFilter; sort: ThemeClaimSortKey; dir: ThemeSortDir } {
+): {
+  filter: ClaimStatusFilter;
+  sort: ThemeClaimSortKey;
+  dir: ThemeSortDir;
+  clear: ('sort' | 'dir' | 'filter')[];
+} {
   const urlFilter = params.get('filter');
   const filter = isClaimFilter(urlFilter) ? urlFilter : pref.detailFilter;
+  // 'default' is NOT a stored preference: it means "follow the wall" —
+  // storing it would freeze the list into the hardcoded order even when the
+  // wall (and the shared time axis) later switches to a time sort, which the
+  // operator experiences as "my sort got lost". Only 'day' is an explicit
+  // claim-list choice.
   const urlSort = params.get('sort');
   let sort: ThemeClaimSortKey;
-  if (urlSort === 'day' || urlSort === 'default') {
-    sort = urlSort;
-  } else if (pref.detailSort != null) {
-    sort = pref.detailSort;
+  if (urlSort === 'day') {
+    sort = 'day';
+  } else if (pref.detailSort === 'day') {
+    sort = 'day';
   } else if (isTimeSortKey(pref.wallKey)) {
     // The wall is on a time sort and the operator has not chosen a
     // claim-list sort here — carry the time sort (and its direction).
@@ -1890,5 +1912,9 @@ export function resolveThemeClaimsSort(
   }
   const urlDir = params.get('dir');
   const dir = isDir(urlDir) ? urlDir : sort === 'day' ? pref.timeDir : 'desc';
-  return { filter, sort, dir };
+  const clear: ('sort' | 'dir' | 'filter')[] = [];
+  if (isClaimFilter(urlFilter)) clear.push('filter');
+  if (urlSort === 'day') clear.push('sort'); // 'default' is not a stored pref
+  if (isDir(urlDir)) clear.push('dir');
+  return { filter, sort, dir, clear };
 }

--- a/console-ui/src/pages/KnowledgePage.tsx
+++ b/console-ui/src/pages/KnowledgePage.tsx
@@ -11,7 +11,7 @@
  * so the hash resolves through the model and forwards to
  * /knowledge/theme/:t#<claim_id> where the card scrolls into view. */
 import { Link, Navigate, useLocation, useSearchParams } from 'react-router-dom';
-import { lazy, Suspense, useEffect, useState } from 'react';
+import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import KnowledgeGraph from '../components/KnowledgeGraph';
 // Terrain pulls in three.js (~500KB) — load it only when the Terrain tab is
 // selected so it stays out of the initial portal bundle.
@@ -163,7 +163,11 @@ function KnowledgeBody({ model }: { model: IndexModel }) {
   // restarts, unlike URL params which a Link navigation drops) AND shared
   // with the theme detail pages: the time direction lives in `pref.timeDir`,
   // so a "sort by date, newest first" choice here carries to every theme
-  // page. An explicit URL sort (shared link) still wins per-visit.
+  // page. URL params are consumed ON ARRIVAL: a shared link (or a back
+  // navigation carrying an old `?sort=&dir=`) lands into the prefs and is
+  // stripped from the URL, so the persisted choice — not a stale history
+  // entry — drives every subsequent visit. Day-to-day clicks never write
+  // sort params; they update localStorage instead.
   const [pref, setPref] = useState<KnowledgeSortPref>(() =>
     readKnowledgeSortPref(window.localStorage),
   );
@@ -174,16 +178,33 @@ function KnowledgeBody({ model }: { model: IndexModel }) {
       return next;
     });
   };
-  const { key: sortKey, dir: sortDir } = resolveKnowledgeWallSort(params, pref);
-  const setSort = (key: ThemeSortKey, dir: ThemeSortDir) => {
+  // Merge explicit URL params into prefs (arrival-only) and clear them —
+  // ONCE per landing. Clearing makes back navigation behave: a stale
+  // `?sort=&dir=` from before the last click stops overriding the newer
+  // localStorage preference. The ref guard keeps the replace() from
+  // re-entering the effect on the same params.
+  const { key: sortKey, dir: sortDir, clear } = resolveKnowledgeWallSort(params, pref);
+  const consumedRef = useRef<string>('');
+  useEffect(() => {
+    if (clear.length === 0) return;
+    const signature = clear.join(',');
+    if (consumedRef.current === signature) return;
+    consumedRef.current = signature;
+    applyPref(
+      isTimeSortKey(sortKey)
+        ? { wallKey: sortKey, timeDir: sortDir }
+        : { wallKey: sortKey, wallDir: sortDir },
+    );
     setParams(
       (p) => {
-        p.set('sort', key);
-        p.set('dir', dir);
+        for (const k of clear) p.delete(k);
         return p;
       },
       { replace: true },
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clear.join(','), sortKey, sortDir]);
+  const setSort = (key: ThemeSortKey, dir: ThemeSortDir) => {
     // Time keys rotate the SHARED time direction; count/name keep their own.
     applyPref(
       isTimeSortKey(key)

--- a/console-ui/src/pages/ThemeDetailPage.tsx
+++ b/console-ui/src/pages/ThemeDetailPage.tsx
@@ -327,8 +327,11 @@ function ThemeBody({
   // Claim filter/sort — the SAME persisted pref family as the knowledge
   // wall. The Day sort's direction is the shared time direction, so a date
   // sort picked here agrees with the wall automatically (and vice versa);
-  // filter/sort choices also persist across visits. Explicit URL params
-  // (shared links) still win per-visit. Chat dock shares searchParams.
+  // filter/sort choices also persist across visits. URL params are consumed
+  // ON ARRIVAL (shared links land into prefs and are stripped; back
+  // navigation carrying old params can't override the current preference).
+  // Day-to-day clicks never write claim-view params — only localStorage.
+  // Chat dock shares searchParams (which may carry ?chat=).
   const [pref, setPref] = useState<KnowledgeSortPref>(() =>
     readKnowledgeSortPref(window.localStorage),
   );
@@ -339,37 +342,48 @@ function ThemeBody({
       return next;
     });
   };
-  const { filter: claimFilter, sort: claimSort, dir: claimDir } =
+  const { filter: claimFilter, sort: claimSort, dir: claimDir, clear } =
     resolveThemeClaimsSort(searchParams, pref);
+  // Consumed ONCE per landing (see the wall): merge explicit URL params into
+  // prefs and strip them, so back navigation can't override the current
+  // preference. The ref guard keeps the replace() from re-entering.
+  const consumedParamsRef = useRef<string>('');
+  useEffect(() => {
+    if (clear.length === 0) return;
+    const signature = clear.join(',');
+    if (consumedParamsRef.current === signature) return;
+    consumedParamsRef.current = signature;
+    const prefPatch: Partial<KnowledgeSortPref> = {};
+    if (clear.includes('filter')) prefPatch.detailFilter = claimFilter;
+    // Only a URL sort=day is an explicit claim-list choice; default is not
+    // stored (see resolveThemeClaimsSort).
+    if (clear.includes('sort') && claimSort === 'day') prefPatch.detailSort = 'day';
+    if (clear.includes('dir')) prefPatch.timeDir = claimDir;
+    applyPref(prefPatch);
+    setSearchParams(
+      (prev) => {
+        const p = new URLSearchParams(prev);
+        for (const k of clear) p.delete(k);
+        return p;
+      },
+      { replace: true },
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clear.join(','), claimFilter, claimSort, claimDir]);
   const setClaimView = (patch: {
     filter?: ClaimStatusFilter;
     sort?: ThemeClaimSortKey;
     dir?: ThemeSortDir;
   }) => {
-    setSearchParams(
-      (prev) => {
-        const p = new URLSearchParams(prev);
-        if (patch.filter !== undefined) {
-          if (patch.filter === 'all') p.delete('filter');
-          else p.set('filter', patch.filter);
-        }
-        if (patch.sort !== undefined) {
-          if (patch.sort === 'default') p.delete('sort');
-          else p.set('sort', patch.sort);
-        }
-        if (patch.dir !== undefined) {
-          if (patch.dir === 'desc') p.delete('dir');
-          else p.set('dir', patch.dir);
-        }
-        return p;
-      },
-      { replace: true },
-    );
     // Filter/sort choices are the page's prefs; the direction button spins
-    // the SHARED time direction (meaningful when sorting by day).
+    // the SHARED time direction (meaningful when sorting by day). 'default'
+    // is NOT stored — it means "follow the wall" — so it clears detailSort
+    // instead of freezing it (see resolveThemeClaimsSort).
     const prefPatch: Partial<KnowledgeSortPref> = {};
     if (patch.filter !== undefined) prefPatch.detailFilter = patch.filter;
-    if (patch.sort !== undefined) prefPatch.detailSort = patch.sort;
+    if (patch.sort !== undefined) {
+      prefPatch.detailSort = patch.sort === 'default' ? null : patch.sort;
+    }
     if (patch.dir !== undefined) prefPatch.timeDir = patch.dir;
     applyPref(prefPatch);
   };


### PR DESCRIPTION
## Background

PR #456 merged as `e988d12c` but that commit did NOT include the full worktree state. The deployed portal (port 61465) runs the COMPLETE fix; repository main is missing the core behavior this PR restores:

- URL sort/filter params are consumed ON ARRIVAL (merged into prefs and stripped from the URL) so browser BACK navigation can't override the persisted preference with a stale ?sort=&dir= — the "sorting is not remembered" bug
- Clicking the theme page's **Default** button no longer freezes the list out of the shared time axis (detailSort 'default' is not stored; only 'day' is an explicit choice) — the "sort is lost" bug
- localStorage key constant renamed (KNOWLEDGE_SORT_PREF_STORAGE, same value ovp.knowledgeSortPref.v1)
- Shared timeDir carried from wall Updated/Created to the theme page's Day sort, and vice versa

All verified + deployed already (216/216 tests, Playwright end-to-end on :61465, no JS errors). This PR lands the exact code already running in production.

## Files (206 insertions / 71 deletions vs the merged commit)

- console-ui/src/lib/derive.ts
- console-ui/src/lib/derive.knowledgeSortPref.test.ts
- console-ui/src/pages/KnowledgePage.tsx
- console-ui/src/pages/ThemeDetailPage.tsx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Sort and filter preferences now persist between visits.
  * URL-based sort and filter settings are applied once when opening a page, then removed while preserving unrelated parameters.
  * Default claim sorting now follows the selected wall sort.
  * Invalid URL parameters remain available instead of being discarded.
  * Improved handling of browser Back navigation and time-based sorting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->