### PR TITLE
feat(mcp): wire ovp-mcp into the repo so the vault agent is actually reachable

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,11 @@
   "mcpServers": {
     "ovp": {
       "command": "${OVP2_BIN:-/Applications/OVP2.app/Contents/MacOS/ovp2}",
-      "args": ["mcp", "--vault-root", "${OVP_VAULT_ROOT:-/Users/chris/Documents/ovp-vault}"],
+      "args": [
+        "mcp",
+        "--vault-root",
+        "${OVP_VAULT_ROOT}"
+      ],
       "env": {
         "OVP_LLM_NO_PROXY": "${OVP_LLM_NO_PROXY:-1}"
       }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "ovp": {
+      "command": "${OVP2_BIN:-/Applications/OVP2.app/Contents/MacOS/ovp2}",
+      "args": ["mcp", "--vault-root", "${OVP_VAULT_ROOT:-/Users/chris/Documents/ovp-vault}"],
+      "env": {
+        "OVP_LLM_NO_PROXY": "${OVP_LLM_NO_PROXY:-1}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

Registers `ovp-mcp` at project scope so the vault agent is reachable from the editor.

`ovp-mcp` has shipped `ask` (tool-loop vault agent with server-verified receipts), `claim` (full evidence closure for auditing a `[claim:…]` citation), `theme_page`, `find`, `search`, `doctor`, `status` for a while — but it was registered **nowhere**: no `.mcp.json` in the repo, nothing in the user or project scope of `~/.claude.json`. So answering "what does the vault have on X" meant hand-stringing `find` + grep + reading reader packs, while the product's own answer to that question sat unplugged.

## Deliberate choices

- **`command` defaults to the app bundle, not bare `ovp2` on PATH.** A PATH hit is more portable but can silently resolve to a stale cargo-dist build without `ask` or the live features — the trap CLAUDE.md documents, which surfaces as a build-time error in the GUI. A wrong absolute path fails loudly instead. Non-macOS users set `OVP2_BIN`.
- **`OVP_LLM_NO_PROXY` defaults to 1 but defers to the caller.** Unconditional `1` would break `ask` for anyone whose provider is only reachable through a proxy.

## Verification

Drove the server over stdio directly (`initialize` + `tools/list`): all 7 tools present including `ask`, `providers.toml` picked up (5 vars). `${VAR:-default}` expansion in `command`/`args`/`env` confirmed against the Claude Code MCP docs.

## Known / not fixed here

- `ovp2 mcp --help` still advertises the pre-`ask` tool set. Stale text, not a missing tool — separate PR.
- The `OVP_VAULT_ROOT` default is still operator-specific. Codex flagged this; keeping it preserves zero-config for the only current user, and the override is documented. Raise it if a second operator appears.

## Gate

`codex review` run on this diff. Round 1 raised 2 × P2 (machine-specific defaults; unconditional proxy override). The proxy one is fixed; the vault-path one is accepted with the rationale above. No P1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration for connecting to the OVP MCP server.
  * Supports customizable binary and vault-root paths with sensible defaults.
  * Added an environment setting to control proxy usage for LLM connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->