### PR TITLE
fix(desktop): sticky portal port so the webview keeps its localStorage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3079,6 +3079,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tempfile",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -35,3 +35,8 @@ serde_json = { workspace = true }
 # (.ovp/providers.toml), without set_var on the multi-threaded Tauri host.
 ovp-server = { path = "../../../crates/ovp-server", features = ["anthropic"] }
 ovp-domain = { path = "../../../crates/ovp-domain" }
+
+[dev-dependencies]
+# Tests write real files; tempfile cleans up on PANIC too, which a manual
+# temp_dir() + remove_dir_all() at the end of the test does not.
+tempfile = { workspace = true }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@
 //!   sidecar's `schedule tick` — REPLACING launchd/systemd entirely;
 //! - persists the chosen vault, with a first-run folder picker.
 
+use std::collections::BTreeMap;
 use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -32,6 +33,12 @@ struct AppConfig {
     /// also the head of this list after a successful open.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     known_vaults: Vec<String>,
+    /// Canonical portal port per vault path — the vault's stable webview
+    /// origin. App-scoped rather than per-vault because the property being
+    /// protected is CROSS-vault: only a registry that sees every claim can
+    /// keep two vaults off the same port. BTreeMap for deterministic output.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    ports: BTreeMap<String, u16>,
 }
 
 /// Recent-list cap — enough for real multi-vault use, small enough for a menu.
@@ -86,7 +93,13 @@ fn read_config_file(app: &AppHandle) -> AppConfig {
     let Some(path) = config_file(app) else {
         return AppConfig::default();
     };
-    std::fs::read_to_string(&path)
+    read_config_at(&path)
+}
+
+/// Path-addressed read — a corrupt or missing file is an empty config, never
+/// a hard failure (the app must still boot into onboarding).
+fn read_config_at(path: &Path) -> AppConfig {
+    std::fs::read_to_string(path)
         .ok()
         .and_then(|t| serde_json::from_str(&t).ok())
         .unwrap_or_default()
@@ -94,11 +107,27 @@ fn read_config_file(app: &AppHandle) -> AppConfig {
 
 fn save_config(app: &AppHandle, cfg: &AppConfig) -> Result<(), String> {
     let path = config_file(app).ok_or("cannot resolve the app config dir")?;
+    write_config_at(&path, cfg)
+}
+
+/// Path-addressed write, sibling-temp + rename so it is atomic. A crash or a
+/// full disk mid-write must not leave truncated JSON: this file now carries
+/// the per-vault port map, and a corrupt read means every vault silently
+/// changes origin (and loses its portal settings) on the next launch.
+fn write_config_at(path: &Path, cfg: &AppConfig) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
     }
     let body = serde_json::to_string_pretty(cfg).map_err(|e| e.to_string())?;
-    std::fs::write(&path, body).map_err(|e| format!("write {}: {e}", path.display()))
+    // Per-process temp name: two instances sharing one `config.json.tmp` would
+    // overwrite each other's half-written content and rename the wrong bytes
+    // into place. Rename itself is atomic, so the loser just loses its update.
+    let tmp = path.with_extension(format!("json.tmp.{}", std::process::id()));
+    std::fs::write(&tmp, body).map_err(|e| format!("write {}: {e}", tmp.display()))?;
+    std::fs::rename(&tmp, path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp);
+        format!("rename into {}: {e}", path.display())
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -130,6 +159,93 @@ fn free_port() -> Result<u16, String> {
     let l = TcpListener::bind("127.0.0.1:0").map_err(|e| format!("bind loopback: {e}"))?;
     let port = l.local_addr().map_err(|e| e.to_string())?.port();
     Ok(port)
+}
+
+// ---------------------------------------------------------------------------
+// Sticky portal port.
+//
+// The webview's origin is `http://127.0.0.1:<port>`, and Chromium/WKWebView
+// partition localStorage + IndexedDB BY ORIGIN. A fresh `free_port()` per
+// launch therefore hands the portal a brand-new, empty storage bucket every
+// time the app restarts — silently wiping theme, language, panel width and
+// the persisted knowledge sort prefs. Nothing errors; the settings are just
+// gone. So the port has to be stable across launches, per vault.
+//
+// Per vault, not per app: each vault is served on its own origin, so switching
+// vaults must not let vault A's portal state leak into vault B's.
+// ---------------------------------------------------------------------------
+
+/// Low end of the candidate window, and its width.
+///
+/// Deliberately below every common ephemeral range, because a remembered port
+/// drawn from one is the port most likely to be gone by the next launch: macOS
+/// `bind :0` draws from 49152..65535, and Linux's default
+/// `net.ipv4.ip_local_port_range` is 32768..60999 — so the window has to stop
+/// at 32768, not 40000, to clear both.
+const PORT_WINDOW_LO: u16 = 20000;
+const PORT_WINDOW_LEN: u16 = 12768; // 20000..32768
+
+/// Deterministic candidate derived from the vault path (FNV-1a, so it is
+/// stable across Rust versions and reinstalls — unlike `DefaultHasher`).
+///
+/// This is a STARTING POINT, not an identity: 12768 slots cannot give distinct
+/// vaults distinct ports, and a collision would put two vaults on one origin
+/// and hand vault B vault A's portal settings. `allocate_port` probes away from
+/// a collision; the config's port map is what actually enforces uniqueness.
+fn stable_port_candidate(vault: &str) -> u16 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in vault.as_bytes() {
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    PORT_WINDOW_LO + u16::try_from(hash % u64::from(PORT_WINDOW_LEN)).unwrap_or(0)
+}
+
+/// True iff we can bind `port` on loopback right now. Same TOCTOU caveat as
+/// `free_port`; a lost race just falls through to the caller's retry.
+fn port_is_free(port: u16) -> bool {
+    TcpListener::bind(("127.0.0.1", port)).is_ok()
+}
+
+/// The port `vault` should serve on, and whether it is that vault's canonical
+/// origin (`true`) or a transient stand-in because the canonical one was busy
+/// (`false`). Only a canonical result may be written back to the config —
+/// overwriting the canonical port with a stand-in would strand the settings
+/// stored under the original origin even after the conflict clears.
+///
+/// Allocation walks forward from the hashed candidate, skipping ports another
+/// vault has already claimed and ports that will not bind, so two vaults whose
+/// hashes collide still land on different origins.
+fn allocate_port(ports: &BTreeMap<String, u16>, vault: &str) -> (u16, bool) {
+    let claimed = ports.get(vault).copied().filter(|p| *p >= 1024);
+    if let Some(port) = claimed.filter(|p| port_is_free(*p)) {
+        return (port, true);
+    }
+    // Either no claim yet, or the canonical port is busy right now. Probe the
+    // window either way — a stand-in MUST come from the same vault-owned
+    // space, never `free_port()`. An ephemeral stand-in is a port the OS will
+    // later hand to some other vault's launch, which is the cross-vault
+    // localStorage bleed this whole registry exists to prevent.
+    let others: std::collections::BTreeSet<u16> = ports
+        .iter()
+        .filter(|(k, _)| k.as_str() != vault)
+        .map(|(_, v)| *v)
+        .collect();
+    let start = claimed.unwrap_or_else(|| stable_port_candidate(vault));
+    let start = start.clamp(PORT_WINDOW_LO, PORT_WINDOW_LO + PORT_WINDOW_LEN - 1);
+    for step in 0..PORT_WINDOW_LEN {
+        let offset = (start - PORT_WINDOW_LO + step) % PORT_WINDOW_LEN;
+        let port = PORT_WINDOW_LO + offset;
+        if !others.contains(&port) && port_is_free(port) {
+            // Only the vault's FIRST allocation is canonical. When a claim
+            // already exists, anything other than that exact port is a
+            // stand-in and must not overwrite it.
+            return (port, claimed.is_none_or(|c| c == port));
+        }
+    }
+    // Whole window unavailable — serve rather than refuse to launch, but never
+    // record it.
+    (free_port().unwrap_or(0), false)
 }
 
 fn wait_until_up(port: u16) -> Result<(), String> {
@@ -207,7 +323,11 @@ fn resolve_viz_dir(app: &AppHandle) -> PathBuf {
 /// calls `set_var` — safe under Tauri's multi-threaded runtime. Scheduler
 /// children still exec the bundled `ovp2` sidecar, which loads providers.toml
 /// into their own env at process start.
-fn start_server(vault: PathBuf, viz_dir: PathBuf) -> Result<String, String> {
+fn start_server(
+    vault: PathBuf,
+    viz_dir: PathBuf,
+    cfg_path: Option<PathBuf>,
+) -> Result<String, String> {
     // Retry a few times: free_port has a tiny TOCTOU window (another process
     // could grab the port between the probe and run_server binding it), so a
     // lost race just picks a new port rather than failing the launch.
@@ -237,16 +357,26 @@ fn start_server(vault: PathBuf, viz_dir: PathBuf) -> Result<String, String> {
         vault.display(),
         viz_dir.display()
     ));
+    let vault_key = vault.display().to_string();
     for attempt in 0..3 {
-        let port = match free_port() {
-            Ok(p) => p,
-            Err(e) => {
-                last_err = e;
-                diag(&format!("free_port failed: {last_err}"));
-                continue;
+        // First attempt takes this vault's canonical port so the webview
+        // origin — and therefore the portal's localStorage — survives a
+        // restart. Later attempts mean that port lost a race; take any free
+        // one rather than failing the launch over a settings nicety.
+        let (port, canonical) = if attempt == 0 {
+            match cfg_path.as_deref() {
+                Some(p) => allocate_port(&read_config_at(p).ports, &vault_key),
+                None => (free_port().unwrap_or(0), false),
             }
+        } else {
+            (free_port().unwrap_or(0), false)
         };
-        diag(&format!("attempt {attempt} port {port}"));
+        if port == 0 {
+            last_err = "could not obtain a loopback port".to_string();
+            diag(&format!("port allocation failed: {last_err}"));
+            continue;
+        }
+        diag(&format!("attempt {attempt} port {port} canonical={canonical}"));
         let ask_client = ovp_server::providers_ask_client_factory(vault.clone());
         let config = ovp_server::ServeConfig {
             vault_root: vault.clone(),
@@ -264,14 +394,55 @@ fn start_server(vault: PathBuf, viz_dir: PathBuf) -> Result<String, String> {
             // the agent path serves Ask unless OVP_ASK_AGENT=0.
             ask_agent: std::env::var("OVP_ASK_AGENT").map(|v| v != "0").unwrap_or(true),
         };
+        // `wait_until_http` only proves SOMEBODY answers 200 on that port. If a
+        // second instance won the bind race, the loser would read the winner's
+        // response as its own success and then record a claim for a port it
+        // never owned. Have the server report its own bind failure instead.
+        let (tx, rx) = std::sync::mpsc::channel::<String>();
         std::thread::spawn(move || {
             if let Err(e) = ovp_server::run_server(config) {
-                eprintln!("ovp2-desktop: portal server exited: {e}");
+                let _ = tx.send(e.to_string());
             }
         });
+        // A lost bind fails immediately; a healthy server never sends.
+        if let Ok(e) = rx.recv_timeout(Duration::from_millis(300)) {
+            last_err = format!("portal server could not bind {port}: {e}");
+            diag(&last_err);
+            continue;
+        }
         match wait_until_http(port) {
             Ok(()) => {
+                if let Ok(e) = rx.try_recv() {
+                    last_err = format!("portal server exited on {port}: {e}");
+                    diag(&last_err);
+                    continue;
+                }
                 let url = format!("http://127.0.0.1:{port}/");
+                // Claim only a canonical port that actually served. A stand-in
+                // must never overwrite the claim: the settings live under the
+                // canonical origin, and once a transient conflict clears we
+                // want to go back to it, not strand them.
+                let claim = if canonical { cfg_path.as_deref() } else { None };
+                if let Some(p) = claim {
+                    let mut cfg = read_config_at(p);
+                    // Re-read and re-check: another vault may have claimed this
+                    // port since allocation. Losing the claim costs stickiness
+                    // once; taking it would alias two vaults onto one origin.
+                    let stolen = cfg
+                        .ports
+                        .iter()
+                        .any(|(k, v)| k != &vault_key && *v == port);
+                    if stolen {
+                        diag(&format!("port {port} claimed by another vault; not recording"));
+                    } else if cfg.ports.get(&vault_key) != Some(&port) {
+                        cfg.ports.insert(vault_key.clone(), port);
+                        // Surfacing this matters: an unrecorded canonical port
+                        // is one another vault may later be handed.
+                        if let Err(e) = write_config_at(p, &cfg) {
+                            diag(&format!("could not record port {port}: {e}"));
+                        }
+                    }
+                }
                 diag(&format!("portal up at {url}"));
                 return Ok(url);
             }
@@ -294,7 +465,7 @@ fn ensure_server(app: &AppHandle, state: &AppState, vault: &Path) -> Result<Stri
             return Ok(url.clone());
         }
     }
-    let url = start_server(vault.to_path_buf(), resolve_viz_dir(app))?;
+    let url = start_server(vault.to_path_buf(), resolve_viz_dir(app), config_file(app))?;
     let mut guard = state.server_url.lock().unwrap();
     if let Some(existing) = guard.as_ref() {
         return Ok(existing.clone());
@@ -445,6 +616,10 @@ async fn boot(app: AppHandle, state: State<'_, AppState>) -> Result<BootState, S
                     &AppConfig {
                         vault: cfg_file.vault.clone(),
                         known_vaults: remember_vault(&cfg_file.known_vaults, &vault),
+                        // `..cfg_file` rather than a fresh struct: rebuilding
+                        // field-by-field silently drops everything else in the
+                        // file — `ports` here, whatever comes next later.
+                        ..cfg_file
                     },
                 );
                 refresh_vault_menu(&app);
@@ -482,6 +657,7 @@ async fn set_vault_and_start(
         &AppConfig {
             vault: Some(vault.clone()),
             known_vaults: remember_vault(&prev.known_vaults, &vault),
+            ..prev
         },
     )?;
     refresh_vault_menu(&app);
@@ -603,6 +779,7 @@ fn switch_to_vault(app: &AppHandle, vault: &str) {
     let cfg = AppConfig {
         vault: Some(vault.to_string()),
         known_vaults: remember_vault(&prev.known_vaults, vault),
+        ..prev
     };
     if let Err(e) = save_config(app, &cfg) {
         eprintln!("ovp2-desktop: could not save vault config: {e}");
@@ -807,6 +984,7 @@ mod tests {
         let cfg = AppConfig {
             vault: Some("/Users/op/ovp-vault".into()),
             known_vaults: vec!["/Users/op/ovp-vault".into(), "/Users/op/other".into()],
+            ..AppConfig::default()
         };
         let s = serde_json::to_string(&cfg).unwrap();
         let back: AppConfig = serde_json::from_str(&s).unwrap();
@@ -851,5 +1029,140 @@ mod tests {
     fn free_port_is_bindable() {
         let p = free_port().unwrap();
         assert!(p > 0);
+    }
+
+    #[test]
+    fn stable_port_candidate_is_deterministic_and_below_every_ephemeral_range() {
+        let a = "/Users/op/Documents/ovp-vault";
+        assert_eq!(stable_port_candidate(a), stable_port_candidate(a));
+        // Must clear BOTH macOS (49152..) and Linux (32768..) ephemeral
+        // ranges: a candidate the OS also hands to other processes is the one
+        // least likely to still be free at the next launch.
+        for v in ["/a", "/b/c", a, ""] {
+            let p = stable_port_candidate(v);
+            assert!((PORT_WINDOW_LO..32768).contains(&p), "{v} -> {p}");
+        }
+    }
+
+    #[test]
+    fn hash_collisions_do_not_share_an_origin() {
+        // These two paths hash to the SAME candidate (12768 slots cannot be
+        // injective over arbitrary paths). Allocation must still give them
+        // different ports, or vault B reads vault A's portal localStorage.
+        let (a, b) = ("/Users/op/vault-69", "/Users/op/vault-450");
+        assert_eq!(
+            stable_port_candidate(a),
+            stable_port_candidate(b),
+            "fixture is only meaningful if these collide"
+        );
+        let mut ports = BTreeMap::new();
+        let (pa, ok_a) = allocate_port(&ports, a);
+        assert!(ok_a);
+        ports.insert(a.to_string(), pa);
+        let (pb, ok_b) = allocate_port(&ports, b);
+        assert!(ok_b);
+        assert_ne!(pa, pb, "collision must be probed away from");
+    }
+
+    #[test]
+    fn a_claimed_port_is_reused_and_is_stable_across_launches() {
+        let mut ports = BTreeMap::new();
+        let v = "/Users/op/vault-a";
+        let (first, ok) = allocate_port(&ports, v);
+        assert!(ok);
+        ports.insert(v.to_string(), first);
+        // Second launch: same vault, same origin. The whole point.
+        assert_eq!(allocate_port(&ports, v), (first, true));
+    }
+
+    #[test]
+    fn a_busy_canonical_port_yields_a_stand_in_that_must_not_be_claimed() {
+        let v = "/Users/op/vault-a";
+        let held = TcpListener::bind("127.0.0.1:0").unwrap();
+        let busy = held.local_addr().unwrap().port();
+        let mut ports = BTreeMap::new();
+        ports.insert(v.to_string(), busy);
+        let (port, canonical) = allocate_port(&ports, v);
+        assert_ne!(port, busy);
+        assert!(
+            !canonical,
+            "a stand-in must be flagged so the caller never overwrites the claim"
+        );
+        // Conflict clears -> back to the canonical origin, settings intact.
+        drop(held);
+        assert_eq!(allocate_port(&ports, v), (busy, true));
+    }
+
+    #[test]
+    fn a_stand_in_stays_inside_the_vault_owned_window() {
+        // The stand-in must NOT be an ephemeral port: the OS hands those to
+        // other vaults' launches later, which re-opens the cross-vault
+        // localStorage bleed on the fallback path.
+        let v = "/Users/op/vault-a";
+        let held = TcpListener::bind("127.0.0.1:0").unwrap();
+        let busy = held.local_addr().unwrap().port();
+        let mut ports = BTreeMap::new();
+        ports.insert(v.to_string(), busy);
+        let (port, canonical) = allocate_port(&ports, v);
+        assert!(!canonical);
+        assert!(
+            (PORT_WINDOW_LO..PORT_WINDOW_LO + PORT_WINDOW_LEN).contains(&port),
+            "stand-in {port} escaped the window"
+        );
+    }
+
+    #[test]
+    fn a_stand_in_avoids_ports_other_vaults_claimed() {
+        let (a, b) = ("/Users/op/vault-69", "/Users/op/vault-450");
+        let mut ports = BTreeMap::new();
+        // A's canonical is busy; B holds the very next port in the window.
+        let held = TcpListener::bind("127.0.0.1:0").unwrap();
+        ports.insert(a.to_string(), held.local_addr().unwrap().port());
+        let neighbour = stable_port_candidate(a);
+        ports.insert(b.to_string(), neighbour);
+        let (port, _) = allocate_port(&ports, a);
+        assert_ne!(port, neighbour, "must not stand in on B's claimed origin");
+    }
+
+    #[test]
+    fn a_privileged_claimed_port_is_repaired_not_reused() {
+        // 80 is not something this code could have written, so the entry is
+        // corrupt. Treat it as "no claim": allocate a real port and mark it
+        // canonical so the bad entry gets overwritten rather than retried
+        // forever.
+        let v = "/Users/op/vault-a";
+        let mut ports = BTreeMap::new();
+        ports.insert(v.to_string(), 80u16);
+        let (port, canonical) = allocate_port(&ports, v);
+        assert_ne!(port, 80);
+        assert!((PORT_WINDOW_LO..PORT_WINDOW_LO + PORT_WINDOW_LEN).contains(&port));
+        assert!(canonical, "a corrupt claim must be repaired");
+    }
+
+    #[test]
+    fn config_write_is_atomic_and_round_trips_the_port_map() {
+        let dir = std::env::temp_dir().join(format!("ovp2-cfg-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("config.json");
+        let mut cfg = AppConfig::default();
+        cfg.ports.insert("/Users/op/vault-a".into(), 20001);
+        write_config_at(&path, &cfg).unwrap();
+        assert_eq!(read_config_at(&path).ports.get("/Users/op/vault-a"), Some(&20001));
+        // No temp file left behind, and a corrupt file reads as empty rather
+        // than panicking the boot path.
+        assert!(!path
+            .with_extension(format!("json.tmp.{}", std::process::id()))
+            .exists());
+        std::fs::write(&path, "not json").unwrap();
+        assert!(read_config_at(&path).ports.is_empty());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn older_config_without_ports_still_loads() {
+        let cfg: AppConfig =
+            serde_json::from_str(r#"{"vault":"/v","known_vaults":["/v"]}"#).unwrap();
+        assert!(cfg.ports.is_empty());
+        assert_eq!(cfg.vault.as_deref(), Some("/v"));
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1153,8 +1153,12 @@ mod tests {
 
     #[test]
     fn config_write_is_atomic_and_round_trips_the_port_map() {
-        let dir = std::env::temp_dir().join(format!("ovp2-cfg-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
+        // tempfile, not `temp_dir()` + manual cleanup: the repo forbids run
+        // artifacts in /tmp, and a hand-rolled cleanup at the end of the test
+        // never runs when an assertion panics — leaving the directory behind
+        // exactly on the failures worth investigating.
+        let dir = tempfile::tempdir().unwrap();
+        let dir = dir.path();
         let path = dir.join("config.json");
         let mut cfg = AppConfig::default();
         cfg.ports.insert("/Users/op/vault-a".into(), 20001);
@@ -1167,7 +1171,6 @@ mod tests {
             .exists());
         std::fs::write(&path, "not json").unwrap();
         assert!(read_config_at(&path).ports.is_empty());
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -217,7 +217,13 @@ fn port_is_free(port: u16) -> bool {
 /// vault has already claimed and ports that will not bind, so two vaults whose
 /// hashes collide still land on different origins.
 fn allocate_port(ports: &BTreeMap<String, u16>, vault: &str) -> (u16, bool) {
-    let claimed = ports.get(vault).copied().filter(|p| *p >= 1024);
+    // A claim outside the window cannot have been written by this code, so it
+    // is corrupt (hand-edited config, or a port that predates the window).
+    // Treat it as no claim and repair, rather than honouring it or clamping
+    // the probe to the window edge — clamping silently moves the search away
+    // from the vault's own candidate.
+    let window = PORT_WINDOW_LO..(PORT_WINDOW_LO + PORT_WINDOW_LEN);
+    let claimed = ports.get(vault).copied().filter(|p| window.contains(p));
     if let Some(port) = claimed.filter(|p| port_is_free(*p)) {
         return (port, true);
     }
@@ -232,7 +238,6 @@ fn allocate_port(ports: &BTreeMap<String, u16>, vault: &str) -> (u16, bool) {
         .map(|(_, v)| *v)
         .collect();
     let start = claimed.unwrap_or_else(|| stable_port_candidate(vault));
-    let start = start.clamp(PORT_WINDOW_LO, PORT_WINDOW_LO + PORT_WINDOW_LEN - 1);
     for step in 0..PORT_WINDOW_LEN {
         let offset = (start - PORT_WINDOW_LO + step) % PORT_WINDOW_LEN;
         let port = PORT_WINDOW_LO + offset;
@@ -1076,52 +1081,59 @@ mod tests {
     }
 
     #[test]
-    fn a_busy_canonical_port_yields_a_stand_in_that_must_not_be_claimed() {
+    fn a_busy_canonical_port_yields_an_in_window_stand_in_and_recovers() {
         let v = "/Users/op/vault-a";
-        let held = TcpListener::bind("127.0.0.1:0").unwrap();
-        let busy = held.local_addr().unwrap().port();
         let mut ports = BTreeMap::new();
-        ports.insert(v.to_string(), busy);
-        let (port, canonical) = allocate_port(&ports, v);
-        assert_ne!(port, busy);
+        let (canonical_port, ok) = allocate_port(&ports, v);
+        assert!(ok);
+        ports.insert(v.to_string(), canonical_port);
+        // Occupy the vault's OWN canonical port — the claim has to be inside
+        // the window for this to model a real conflict rather than a corrupt
+        // entry (which takes the repair path instead).
+        let held = TcpListener::bind(("127.0.0.1", canonical_port)).expect("just probed free");
+
+        let (port, is_canonical) = allocate_port(&ports, v);
+        assert_ne!(port, canonical_port);
         assert!(
-            !canonical,
+            !is_canonical,
             "a stand-in must be flagged so the caller never overwrites the claim"
         );
-        // Conflict clears -> back to the canonical origin, settings intact.
-        drop(held);
-        assert_eq!(allocate_port(&ports, v), (busy, true));
-    }
-
-    #[test]
-    fn a_stand_in_stays_inside_the_vault_owned_window() {
-        // The stand-in must NOT be an ephemeral port: the OS hands those to
-        // other vaults' launches later, which re-opens the cross-vault
-        // localStorage bleed on the fallback path.
-        let v = "/Users/op/vault-a";
-        let held = TcpListener::bind("127.0.0.1:0").unwrap();
-        let busy = held.local_addr().unwrap().port();
-        let mut ports = BTreeMap::new();
-        ports.insert(v.to_string(), busy);
-        let (port, canonical) = allocate_port(&ports, v);
-        assert!(!canonical);
         assert!(
             (PORT_WINDOW_LO..PORT_WINDOW_LO + PORT_WINDOW_LEN).contains(&port),
-            "stand-in {port} escaped the window"
+            "stand-in {port} escaped the window; the OS would hand it to another vault"
         );
+
+        // Conflict clears -> back to the canonical origin, settings intact.
+        drop(held);
+        assert_eq!(allocate_port(&ports, v), (canonical_port, true));
     }
 
     #[test]
-    fn a_stand_in_avoids_ports_other_vaults_claimed() {
+    fn allocation_skips_a_port_another_vault_already_claimed() {
+        // `a` is unclaimed, so probing starts at ITS hashed candidate — which
+        // `b` already owns. That is the only setup that actually exercises the
+        // `others.contains` branch: give `a` an out-of-window claim instead and
+        // the probe starts somewhere else entirely and passes for free.
         let (a, b) = ("/Users/op/vault-69", "/Users/op/vault-450");
+        let contested = stable_port_candidate(a);
+        assert_eq!(contested, stable_port_candidate(b), "fixture must collide");
         let mut ports = BTreeMap::new();
-        // A's canonical is busy; B holds the very next port in the window.
-        let held = TcpListener::bind("127.0.0.1:0").unwrap();
-        ports.insert(a.to_string(), held.local_addr().unwrap().port());
-        let neighbour = stable_port_candidate(a);
-        ports.insert(b.to_string(), neighbour);
-        let (port, _) = allocate_port(&ports, a);
-        assert_ne!(port, neighbour, "must not stand in on B's claimed origin");
+        ports.insert(b.to_string(), contested);
+        let (port, canonical) = allocate_port(&ports, a);
+        assert_ne!(port, contested, "must not allocate B's origin to A");
+        assert!(canonical);
+    }
+
+    #[test]
+    fn an_out_of_window_claim_is_repaired() {
+        let v = "/Users/op/vault-a";
+        let mut ports = BTreeMap::new();
+        // Nothing this code writes lands here; honouring it would pin the
+        // vault to a port the OS reassigns freely.
+        ports.insert(v.to_string(), 51234u16);
+        let (port, canonical) = allocate_port(&ports, v);
+        assert_eq!(port, stable_port_candidate(v), "probe starts at the candidate");
+        assert!(canonical, "a corrupt claim must be repaired");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1072,7 +1072,10 @@ mod tests {
     #[test]
     fn a_claimed_port_is_reused_and_is_stable_across_launches() {
         let mut ports = BTreeMap::new();
-        let v = "/Users/op/vault-a";
+        // A DISTINCT path per test: these bind real ports, and a shared vault
+        // path means a shared candidate, which races under cargo's parallel
+        // test threads.
+        let v = "/Users/op/vault-reuse";
         let (first, ok) = allocate_port(&ports, v);
         assert!(ok);
         ports.insert(v.to_string(), first);
@@ -1082,7 +1085,7 @@ mod tests {
 
     #[test]
     fn a_busy_canonical_port_yields_an_in_window_stand_in_and_recovers() {
-        let v = "/Users/op/vault-a";
+        let v = "/Users/op/vault-standin";
         let mut ports = BTreeMap::new();
         let (canonical_port, ok) = allocate_port(&ports, v);
         assert!(ok);
@@ -1126,7 +1129,7 @@ mod tests {
 
     #[test]
     fn an_out_of_window_claim_is_repaired() {
-        let v = "/Users/op/vault-a";
+        let v = "/Users/op/vault-outofwindow";
         let mut ports = BTreeMap::new();
         // Nothing this code writes lands here; honouring it would pin the
         // vault to a port the OS reassigns freely.
@@ -1142,7 +1145,7 @@ mod tests {
         // corrupt. Treat it as "no claim": allocate a real port and mark it
         // canonical so the bad entry gets overwritten rather than retried
         // forever.
-        let v = "/Users/op/vault-a";
+        let v = "/Users/op/vault-privileged";
         let mut ports = BTreeMap::new();
         ports.insert(v.to_string(), 80u16);
         let (port, canonical) = allocate_port(&ports, v);


### PR DESCRIPTION
## The bug

`start_server` drew a fresh `free_port()` on every launch, so the webview origin was a different `http://127.0.0.1:<port>` each time. WKWebView and Chromium partition localStorage and IndexedDB **by origin**, so every restart handed the portal an empty storage bucket: theme, language, panel width — and the knowledge sort prefs shipped in #456/#457.

Nothing logged an error. The settings were simply gone, which is why this survived a release: tests pass, build is green, and the feature "just doesn't stick".

## The fix

Each vault gets a canonical port, recorded in the app config as a `vault path -> port` map.

- **App-scoped, not a file per vault.** The property being protected is cross-vault; only a registry that sees every claim can keep two vaults off one origin.
- **Allocation** hashes the vault path (FNV-1a — stable across Rust versions and reinstalls, unlike `DefaultHasher`) to a starting point, then probes forward past ports another vault claimed or that will not bind. 12768 slots cannot be injective over arbitrary paths; a collision would hand vault B vault A's portal settings.
- **Window is 20000..32768**, below both macOS `bind :0` (49152..) and Linux's default `ip_local_port_range` (32768..). Remembering a port the OS also hands out is self-defeating — it is the one least likely to still be free next launch. A stand-in comes from the same window for the same reason.
- **Stand-ins are flagged and never written back**, so a transient conflict cannot permanently strand settings under the canonical origin. Once it clears, the next launch returns there. A corrupt claim (< 1024) is treated as no claim and repaired.
- **Reservation is race-safe.** There is no single-instance plugin, so concurrent launches are possible. `wait_until_http` only proves *somebody* answers 200 on the port — the loser of a bind race would have read the winner's response as its own success and recorded a claim for a port it never owned. The server now reports its own bind failure over a channel; the claim is re-checked against a concurrent steal before writing; a failed write is logged rather than swallowed.
- Config writes use a per-process sibling temp + rename. A shared temp name let concurrent writers rename each other's half-written bytes into place.
- The three sites that rebuilt `AppConfig` field-by-field now use `..prev` — rebuilding by hand silently drops any field not restated, which would have wiped the port map on the next vault switch.

## Gate

`codex review`, two rounds, both FAIL-then-fixed:

**Round 1** — 1 × P1, 3 × P2 on this change. The P1 was real and I reproduced its collision example independently: hashing into a 20000-wide window does not *enforce* per-vault isolation, and my test asserting two specific paths differ proved nothing about the general property. Also correct: my comment claimed the window was outside the ephemeral range, which is false on Linux; and a transient conflict permanently overwrote the canonical port, defeating half the fix.

**Round 2** — 2 × P1 on the rework. Stand-ins were still coming from `free_port()`, so the fallback path re-opened the cross-vault bleed; and reservation was not transactional. Both fixed above. I verified the no-single-instance premise rather than assuming it.

Stopping the gate here: findings have converged on concurrency corners of a single-user desktop app.

## Tests

14 pass. New coverage: determinism and range bound, a real hash collision probed apart, reuse across launches, stand-in stays in-window and avoids other vaults' claims, recovery to canonical, corrupt-claim repair, atomic write plus corrupt-file tolerance, older configs predating the map.

## Not verified yet

**This needs the full desktop rebuild to accept.** Per CLAUDE.md this touches `apps/desktop/src-tauri/*`, so it is "rebuild the whole app + must quit and reopen" — not the sidecar row. Green tests are not the acceptance criterion here; surviving a real restart with settings intact is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added persistent portal-port allocation for each vault.
  - Automatically avoids port conflicts and reuses available canonical ports.
  - Supports temporary fallback ports when canonical ports are unavailable.
- **Bug Fixes**
  - Improved server startup handling for port-binding failures.
  - Preserved new configuration fields during vault updates.
  - Made configuration updates safer through atomic file replacement.
- **Tests**
  - Added coverage for port allocation, safe configuration writes, and backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->