### PR TITLE
feat(eval): move the retrieval qrels into the committed contract

### DIFF
--- a/crates/ovp-cli/src/commands/retrieval_eval.rs
+++ b/crates/ovp-cli/src/commands/retrieval_eval.rs
@@ -710,6 +710,97 @@ fn assemble_report(
 mod tests {
     use super::*;
 
+    /// `fixtures/retrieval-qrels/<set>` — the committed ground truth.
+    fn qrels_dir(set: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../fixtures/retrieval-qrels")
+            .join(set)
+    }
+
+    /// The committed qrels must survive schema drift: this loads them through
+    /// the SAME `load_qrels` the command uses, so a field change that would
+    /// break a real run breaks here first.
+    #[test]
+    fn committed_qrels_load_and_are_well_formed() {
+        const CLASSES: [&str; 8] = [
+            "exact",
+            "paraphrase",
+            "claim_evidence",
+            "compare",
+            "recent",
+            "source_scoped",
+            "meta",
+            "negative",
+        ];
+        const SURFACES: [&str; 5] = ["source", "claim", "card", "unit", "chunk"];
+
+        for (set, expected) in [("gold", 34usize), ("holdout", 10usize)] {
+            let qrels = load_qrels(&qrels_dir(set)).expect(set);
+            // An exact count, not `> 0`: a prefix whitelist once silently
+            // dropped the `s-*` half of this set and the run still reported
+            // itself complete, so "some files loaded" is not evidence.
+            assert_eq!(qrels.len(), expected, "{set} question count");
+            for q in &qrels {
+                assert_eq!(
+                    q.confidence.as_deref(),
+                    Some("gold"),
+                    "{}: only adjudicated records belong here",
+                    q.id
+                );
+                let class = q.class.as_deref().unwrap_or_default();
+                assert!(CLASSES.contains(&class), "{}: unknown class {class}", q.id);
+                assert_eq!(
+                    q.relevant.is_empty(),
+                    q.no_answer,
+                    "{}: a negative has no relevant set, and vice versa",
+                    q.id
+                );
+                for r in &q.relevant {
+                    assert!(
+                        SURFACES.contains(&r.surface.as_str()),
+                        "{}: unknown surface {}",
+                        q.id,
+                        r.surface
+                    );
+                    assert!(
+                        matches!(r.grade, Some(1..=3)),
+                        "{}: grade must be 1..=3, got {:?}",
+                        q.id,
+                        r.grade
+                    );
+                }
+            }
+        }
+    }
+
+    /// The holdout is only worth anything while it stays unseen. Leaking one
+    /// question into the optimization set turns it into a second training set
+    /// that reports flattering numbers, and nothing else would catch it — the
+    /// rule is otherwise just a sentence in a README.
+    #[test]
+    fn qrels_gold_and_holdout_stay_disjoint() {
+        let gold = load_qrels(&qrels_dir("gold")).expect("gold");
+        let holdout = load_qrels(&qrels_dir("holdout")).expect("holdout");
+
+        let gold_ids: std::collections::BTreeSet<&str> =
+            gold.iter().map(|q| q.id.as_str()).collect();
+        for q in &holdout {
+            assert!(!gold_ids.contains(q.id.as_str()), "id {} in both sets", q.id);
+        }
+        // Also compare the questions themselves: renumbering a duplicate would
+        // sail past an id check while leaking the same judgement.
+        let norm = |s: &str| s.split_whitespace().collect::<Vec<_>>().join(" ");
+        let gold_qs: std::collections::BTreeSet<String> =
+            gold.iter().map(|q| norm(&q.question)).collect();
+        for q in &holdout {
+            assert!(
+                !gold_qs.contains(&norm(&q.question)),
+                "{}: question also appears in gold",
+                q.id
+            );
+        }
+    }
+
     fn source_row(sha: &str, title: &str) -> ovp_index::SourceRow {
         ovp_index::SourceRow {
             sha256: sha.into(),

--- a/fixtures/retrieval-qrels/README.md
+++ b/fixtures/retrieval-qrels/README.md
@@ -1,0 +1,54 @@
+# Retrieval qrels — frozen ground truth
+
+44 hand-adjudicated relevance judgements for `ovp2 retrieval-eval`. Same role as
+the rest of `fixtures/`: the thing the system is measured against, not a sample
+of its output. Schema and bucket semantics live in `docs/design/retrieval-eval.md`.
+
+```
+gold/      34 questions — the optimization set. Tune against these.
+holdout/   10 questions — frozen 2026-08-14, BEFORE any tuning.
+```
+
+## Why these are in the repo
+
+They were produced on 2026-08-13/14 by a deterministic digest of real
+`ask-sessions` transcripts → cheap-model draft → operator adjudication, and they
+lived only in gitignored `.run/retrieval-eval/`. That is hours of human judgement
+sitting on one untracked disk. Every retrieval number this project reports is
+measured against them, so losing them means losing the ability to compare against
+any past result — the numbers become unfalsifiable.
+
+## The holdout rule
+
+**Never** use `holdout/` to choose fusion weights, thresholds, stop-words, query
+modes, or any other knob. It is scored once, at the acceptance of a candidate,
+and the result goes in the evolution ledger. Selection was deterministic
+(sha256 of the id), stratified across classes, and excluded every question that
+had already been analysed individually.
+
+A holdout you consult while tuning is not a holdout — it is a second training
+set that reports flattering numbers. `qrels_gold_and_holdout_stay_disjoint` in
+`crates/ovp-cli/src/commands/retrieval_eval.rs` enforces the split mechanically
+so the rule survives a copy-paste; it cannot enforce the discipline of not
+looking, which stays on the operator.
+
+## Bucket sizes are small on purpose
+
+`docs/design/retrieval-eval.md` §2: 50–80 questions, not 300 — a single-operator
+dogfood product cannot sustain weeks of annotation, and an abandoned 300-question
+set is worth less than a finished 44. Several buckets hold fewer than 5
+questions (`meta`, `source_scoped`, `negative`, `recent`). Per §4 those buckets
+are **reported, not adjudicated**: read them as a smoke signal, never as a
+verdict on a change.
+
+## Running
+
+```bash
+ovp2 retrieval-eval --vault-root <vault> --qrels fixtures/retrieval-qrels/gold --gold-only
+```
+
+Both directories mix `q-*.json` (from directly adjudicated sessions) and
+`s-*.json` (silver drafts promoted to gold confidence). They are one population;
+the prefix is provenance, not a tier. Do not filter on it — a prefix whitelist
+once silently dropped the `s-*` half and a 44-question run reported itself
+complete at 14.

--- a/fixtures/retrieval-qrels/gold/q-001-agent-memory-durable.json
+++ b/fixtures/retrieval-qrels/gold/q-001-agent-memory-durable.json
@@ -1,0 +1,87 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "q-001",
+ "question": "我的 vault 里关于 agent memory 的 durable 结论有哪些?给出引用。",
+ "source_session": "a3b-smoke-1",
+ "language": "mixed",
+ "class": "claim_evidence",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "01b4867abcf3b294369fd429d278fdace5d79b829cb0b5488e4b49b4b74f3cfe",
+   "grade": 3,
+   "why": "标题 We broke the frontier in agent memory，正面承载 memory 系统结论，是引用源之一。"
+  },
+  {
+   "surface": "source",
+   "id": "2c7baaa763519920162d55af20afebd4c62b85b1dd65c780458d513acb631289",
+   "grade": 3,
+   "why": "Karpathy Second Brain 在 agent 规模下失效，正面承载 memory 局限结论。"
+  },
+  {
+   "surface": "source",
+   "id": "342165ed1b51d3a471a2633d197539242d351da21770517f60e66698ec0377f3",
+   "grade": 3,
+   "why": "同一 Karpathy Second Brain 文章的另一发布面（不同 author），同结论的双源引用。"
+  },
+  {
+   "surface": "source",
+   "id": "43154e2f57beb2e9aa8f2431bb612298c0c9f3ba767893f25465808d5621835a",
+   "grade": 2,
+   "why": "Emotion Is the Missing Memory Layer，正面讨论 memory 层，承载部分 memory 结论。"
+  },
+  {
+   "surface": "source",
+   "id": "53a20bf3436bec2f99891632a898e5738c20d8e85b3db115f1aa9235f33512fd",
+   "grade": 2,
+   "why": "Honcho + Hermes-LCM 改进 Hermes Agent 记忆，正面承载 memory 系统实践。"
+  },
+  {
+   "surface": "claim",
+   "id": "ck-9841d0974d8ef1c9",
+   "grade": 3,
+   "why": "claim 原文直接给出 machine-facing agent memory 与 human-facing note-taking 的根本差异，是 agent memory 的核心结论。"
+  },
+  {
+   "surface": "claim",
+   "id": "ck-c50fb1b08438f85c",
+   "grade": 3,
+   "why": "claim 原文直接说明 memory/context 管理依赖 vector stores、knowledge bases、skills 等多种机制，是 memory 系统的核心结论。"
+  },
+  {
+   "surface": "claim",
+   "id": "ck-22676f418a7cf239",
+   "grade": 3,
+   "why": "claim 原文直接给出 agent memory 多时间尺度（working + external）与当前系统缺乏选择性遗忘的判断，是 memory 本体结论。"
+  },
+  {
+   "surface": "claim",
+   "id": "ck-b5ef1405ace93349",
+   "grade": 3,
+   "why": "claim 原文直接定义 agent memory 架构与 human note-taking 系统的本质差异，正面回答 memory 设计。"
+  },
+  {
+   "surface": "claim",
+   "id": "ck-ac5a863e10faada2",
+   "grade": 3,
+   "why": "claim 原文直接列出 memory failure 的三种表现（amnesia、personalization loss、hallucination）。"
+  },
+  {
+   "surface": "claim",
+   "id": "ck-4b73e227d6cbd6f9",
+   "grade": 3,
+   "why": "claim 原文直接断言 memory systems 是 agent 持续改进的基础设施。"
+  },
+  {
+   "surface": "claim",
+   "id": "ck-20c363815ecfba31",
+   "grade": 3,
+   "why": "claim 原文直接给出 agent memory 按 declarative/procedural/episodic 分层的实践。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "第二轮重标（digest 修复后）：补入 digest 中出现的 claim_key 与 search_claims 结果来源；final_answer 没有实际列出结论或引用，因此 claims/source 均按证据可见性标注，未提升 confidence。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "vault 里有充足 agent memory durable claims；按 ground-truth 实际标题修剪 15 个 source，仅保留真 memory 主题；删 3 个 context/skills claim。"
+}

--- a/fixtures/retrieval-qrels/gold/q-005-context-engineering-systematic.json
+++ b/fixtures/retrieval-qrels/gold/q-005-context-engineering-systematic.json
@@ -1,0 +1,57 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "q-005",
+ "question": "找一下讲 context engineering 的文章,哪篇讲得最系统?",
+ "source_session": "a3d-eval-agent-q3-find-source",
+ "language": "mixed",
+ "class": "compare",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "01461090526e4112accab4ba83e827c4ab302ee614188dc39dd90b33d56884e8",
+   "grade": 3,
+   "why": "Anthropic Effective context engineering，是 CE 主题最权威的一手论述，最系统候选。"
+  },
+  {
+   "surface": "source",
+   "id": "f1ae727f8b08e34af4441733da8ba468fe51559bb515937cd82d76e007e55a6e",
+   "grade": 3,
+   "why": "Aman primer 上下文工程综述，篇幅长且系统，正面承载 CE 系统化论述。"
+  },
+  {
+   "surface": "source",
+   "id": "3db88bc656b322f6ea505b77bfd59e95f63f931f436197a2728c8c44697bc29f",
+   "grade": 3,
+   "why": "Advanced Context Engineering for Coding Agents，coding agent 维度的 CE 深度论述。"
+  },
+  {
+   "surface": "source",
+   "id": "afafd391882bd5299788ee81c3124282bef9d1b5ab96720645400e5e8bf33e19",
+   "grade": 2,
+   "why": "Nyk 短文 Context Engineering Is The Only Engineering，单点主张较系统论述短。"
+  },
+  {
+   "surface": "source",
+   "id": "2978e8abceba8e266b1a6c79397ad5c6e16061e04fa666a8b96412bcca121054",
+   "grade": 2,
+   "why": "Neil Rahilly Context engineering: the key to great agents，CE 主张型短文。"
+  },
+  {
+   "surface": "source",
+   "id": "67ff28702a18a0de5687dba15c22dab600259a15b3d7573273eebccb3b2346f2",
+   "grade": 1,
+   "why": "supplemental adjudication 2026-08-14 (label completeness): 标题谈的是「虚拟公司」式多 Agent 架构的工程批评，属 AI agent 工程邻接主题；不承载 context engineering 的方法/理念论述（matched 'engineering'"
+  },
+  {
+   "surface": "source",
+   "id": "837e49a102adee0bf40415af3f9f30c92c7b035ef786261e6820cdd660bc414d",
+   "grade": 2,
+   "why": "supplemental adjudication 2026-08-14 (label completeness): 标题直接给出上下文定位的核心比喻——「不是仓库，是工作台」，属 context engineering 的本体/方法论主张，是 CE 系统论述的候选材料。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "工具轨迹显示做了多来源比较，但 seen_source_ids 的标题为空且 final_answer 尚未给出选择或引用；只能保留低等级候选。 | supplemental labels added 2026-08-14 (droid, v8 forensics)",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "5 个 source 全是 context engineering 主题，按 ground-truth 实际标题全部 promote；该问哪个最系统是 compare 题，5 个都是候选。"
+}

--- a/fixtures/retrieval-qrels/gold/q-008-rag-long-context.json
+++ b/fixtures/retrieval-qrels/gold/q-008-rag-long-context.json
@@ -1,0 +1,39 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "q-008",
+ "question": "关于 RAG 和 long context 的取舍,vault 里有什么证据?",
+ "source_session": "a3d-eval-agent-q6-grounded-qa",
+ "language": "mixed",
+ "class": "compare",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "8ae56ab1ef50ec5188b3c67375752e860b2d4a21d1313480ba56f85771eb179b",
+   "grade": 3,
+   "why": "1M Context ≠ Lossless Long Memory，正面论述 long context 与 long memory 的工程取舍。"
+  },
+  {
+   "surface": "source",
+   "id": "eda8b14272d8ccc982ff087a94f3b8e514cbb213c96537f1c8aede09a9e73590",
+   "grade": 3,
+   "why": "Why long-term memory for LLMs remains unsolved，直接讨论 LLM 长期记忆的局限。"
+  },
+  {
+   "surface": "source",
+   "id": "105068eabae55d2dc2a60f8a5265f4ab613b8618e9f6508982b9964d7d1595aa",
+   "grade": 3,
+   "why": "Coding Agents are Effective Long-Context Processors，正面支撑 long context 处理证据。"
+  },
+  {
+   "surface": "source",
+   "id": "01b4867abcf3b294369fd429d278fdace5d79b829cb0b5488e4b49b4b74f3cfe",
+   "grade": 1,
+   "why": "agent memory SOTA 系统，作为 RAG/LC 对照的弱相关候选保留。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "digest 有多篇带标题的候选并做了 source_chunks 检索，但最终答案未完成且没有引用；候选相关性未经答案验证。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "compare 题：3 个 source 标题直接谈 long context / long memory 取舍；删 Building a Good Vertical Agent（弱相关），memory 那条降 grade 1。"
+}

--- a/fixtures/retrieval-qrels/gold/q-010-llm-evals-practice.json
+++ b/fixtures/retrieval-qrels/gold/q-010-llm-evals-practice.json
@@ -1,0 +1,33 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "q-010",
+ "question": "关于 LLM 评测(evals)的最佳实践,把不同来源的观点综合一下,带引用。",
+ "source_session": "a3d-eval-agent-q8-cross-source",
+ "language": "mixed",
+ "class": "compare",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "1d7cd07f9f255a3d61c6c937c660fda032d1cdea006ea96a75f5797f49393ea1",
+   "grade": 3,
+   "why": "benchflow-ai/awesome-evals，evals 资源策展，正面承载评测资源综述。"
+  },
+  {
+   "surface": "source",
+   "id": "65b9f77e3d6c1fd723abd16fee7eaf29f0e3d57c617517f8f6850ebb81e87c11",
+   "grade": 2,
+   "why": "Perplexity Qwen3.5 factuality 后训练评测，evals 具体案例证据。"
+  },
+  {
+   "surface": "source",
+   "id": "0adfa4027791014d5f067356de4087d07f8c9960661ccfb99fe2d2a7931bc57d",
+   "grade": 2,
+   "why": "evo autoresearch loop 自动发现指标并跑 benchmark，evals/best practice 候选。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "digest 有多来源标题和深入读取轨迹，但最终答案在扩展检索阶段结束，没有任何最终引用；候选均为 grade 1。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "compare 题：3 个 source 直接谈 evals；Perplexity/evo-hq 为具体 eval 案例 grade 2；删 multi-agent research（不在 evals 主题上）。(1 个编造 id 已剔除)"
+}

--- a/fixtures/retrieval-qrels/gold/q-017-transformer-job-story.json
+++ b/fixtures/retrieval-qrels/gold/q-017-transformer-job-story.json
@@ -1,0 +1,14 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "q-017",
+ "question": "你看看能不能帮我找到一篇我之前的文章，或者是一条 Twitter，讲的是一个女生毕业的时候投了几十份简历，最后被 OpenAI 或者anthropic类似的公司录取了。她还分享了一个诀窍，就是要能够手写 Transformer，而且写得很细致，还分享了她的笔记。",
+ "source_session": "agent-1784902644119-63232-0",
+ "language": "mixed",
+ "class": "negative",
+ "relevant": [],
+ "no_answer": true,
+ "confidence": "gold",
+ "annotator_notes": "final_answer 明确说 vault 中都没有命中；seen_source_ids 虽有若干 ID，但标题为空，无法依据 digest 判断任何一个是主题相关候选。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "transformer-job-story variant B 负例：digest 明确 final_answer 说 vault 无命中；no_answer=true。保留作为不可解负例测试。"
+}

--- a/fixtures/retrieval-qrels/gold/q-020-context-engineering-core.json
+++ b/fixtures/retrieval-qrels/gold/q-020-context-engineering-core.json
@@ -1,0 +1,153 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "q-020",
+ "question": "context engineering 一句话核心结论?",
+ "source_session": "final-sanity-mcp2",
+ "language": "mixed",
+ "class": "claim_evidence",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "01461090526e4112accab4ba83e827c4ab302ee614188dc39dd90b33d56884e8",
+   "grade": 3,
+   "why": "Anthropic Effective context engineering，CE 权威一手论述。"
+  },
+  {
+   "surface": "source",
+   "id": "2978e8abceba8e266b1a6c79397ad5c6e16061e04fa666a8b96412bcca121054",
+   "grade": 3,
+   "why": "Context engineering: the key to great agents，CE 主张核心来源。"
+  },
+  {
+   "surface": "source",
+   "id": "800bd16e703926ccf6913397c0bcddab7b9d66be650f143d158129bbcbd72abf",
+   "grade": 3,
+   "why": "LangChain Context engineering in Deep Agents，CE 工程化文档。"
+  },
+  {
+   "surface": "source",
+   "id": "65f5c5e24f91d9508ca77f8fb28b8f589d2731be6d38243e448f378a5b4c8d16",
+   "grade": 3,
+   "why": "Martin Fowler 站 Context Engineering for Coding Agents，CE 深度综述。"
+  },
+  {
+   "surface": "source",
+   "id": "024fa72c02389abf120f7feef6ce86f0c2769c7af2f3fc4e7bcfc1fe23b9524a",
+   "grade": 2,
+   "why": "Tw93 你不知道的 Agent 包含 agent 架构与上下文处理实践。"
+  },
+  {
+   "surface": "source",
+   "id": "103fd8059638b8807b49a039e1af27e8b4537b6f0fb6c6f55156ebe6913a9721",
+   "grade": 2,
+   "why": "Skill Issue: Harness Engineering，harness 管理直接等于上下文工程。"
+  },
+  {
+   "surface": "source",
+   "id": "2421eb2c19992efb15637edc8a69283748dfbbafd6805a706d3118e2481faae0",
+   "grade": 2,
+   "why": "Best Practices For CLAUDE.md/AGENTS.md，CLAUDE.md 是 CE 落地实践。"
+  },
+  {
+   "surface": "source",
+   "id": "77a22cddd1aca710a36cd4ba0803da4ba3580dbb796a87b5222f30b8eea757ae",
+   "grade": 2,
+   "why": "The Anatomy of an AI Agent Harness，harness 结构即上下文管理结构。"
+  },
+  {
+   "surface": "source",
+   "id": "7fec4927eb4de7a7c264067924d63fe16abbd7e3b67847b60b452164b4ba9023",
+   "grade": 2,
+   "why": "Build Agents that never forget，memory 即上下文工程组成。"
+  },
+  {
+   "surface": "source",
+   "id": "5208365372c07aa5388d68d20aafc5452b3ec108b664b186b9e419e3efa1064e",
+   "grade": 2,
+   "why": "mksglu/context-mode 直接做 context window 优化，CE 一手工具。"
+  },
+  {
+   "surface": "source",
+   "id": "da9a91fe4fd1e0bb1a21704872c123dda002be06e97730c83dedcb3aef5bd4cc",
+   "grade": 2,
+   "why": "Anthropic Code execution with MCP，code execution 减少 context 传递。"
+  },
+  {
+   "surface": "source",
+   "id": "1d171ea92a54164b896dcbb092361bd6dc24fbb844804c9997da4667aee2c2c2",
+   "grade": 2,
+   "why": "MCP vs CLI was the wrong debate，懒加载是 CE 的核心模式之一。"
+  },
+  {
+   "surface": "claim",
+   "id": "ck-2c51d4069315ce9f",
+   "grade": 3,
+   "why": "claim 原文把 CE 定义为应对 context rot/dumb zone 的 discipline，是 CE 核心结论。"
+  },
+  {
+   "surface": "claim",
+   "id": "ck-1873cef951b6410e",
+   "grade": 3,
+   "why": "claim 原文直接给出 context 增长→LLM 性能退化、token efficiency 是核心约束的判断。"
+  },
+  {
+   "surface": "claim",
+   "id": "ck-2c29534256276bdc",
+   "grade": 3,
+   "why": "claim 原文直接断言 context 是有限共享预算，过载损害 agent。"
+  },
+  {
+   "surface": "claim",
+   "id": "ck-f58488e4c093d437",
+   "grade": 3,
+   "why": "claim 原文把 CE 归纳为「curating what an LLM sees」，是 CE 一句话核心。"
+  },
+  {
+   "surface": "claim",
+   "id": "ck-1dc5a1d4fa22290d",
+   "grade": 3,
+   "why": "claim 原文给出 tool output 占满 40% context 的定量结论。"
+  },
+  {
+   "surface": "claim",
+   "id": "ck-61568a8a92511420",
+   "grade": 3,
+   "why": "claim 原文给出 code execution/context-mode 98.7%、94-99% token 节省的硬数据。"
+  },
+  {
+   "surface": "claim",
+   "id": "ck-a257b43724a09948",
+   "grade": 3,
+   "why": "claim 原文把 MCP/CLI 之争归因于工具描述全量塞 context，是 CE 关键模式判断。"
+  },
+  {
+   "surface": "claim",
+   "id": "ck-1722c52f3d0ee13d",
+   "grade": 3,
+   "why": "claim 原文说明 code execution 把中间结果留在执行环境，是 CE 减少 context 传递的实践总结。"
+  },
+  {
+   "surface": "source",
+   "id": "837e49a102adee0bf40415af3f9f30c92c7b035ef786261e6820cdd660bc414d",
+   "grade": 2,
+   "why": "supplemental adjudication 2026-08-14 (label completeness): 标题本身就是一句可摘录的 CE 核心结论：「上下文不是仓库，是工作台」，直接回答「一句话核心结论」类问题。"
+  },
+  {
+   "surface": "source",
+   "id": "67ff28702a18a0de5687dba15c22dab600259a15b3d7573273eebccb3b2346f2",
+   "grade": 1,
+   "why": "supplemental adjudication 2026-08-14 (label completeness): 标题主题是多 Agent 架构的工程批评（matched「engineering」来自「工程」子串），不承载 CE 一句话结论；邻接主题保留作候选。"
+  },
+  {
+   "surface": "source",
+   "id": "e6d6a20710528ae5e99461185755e321ddd1f7375454e8c376872305f446d4e4",
+   "grade": 1,
+   "why": "supplemental adjudication 2026-08-14 (label completeness): 标题是李宏毅讲 AI Agent 运作原理的科普讲座（OpenClaw 解剖），范围广于 CE；可能顺带提上下文但不是 CE 一句话结论承载，邻接主题保留作候选。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "第二轮重标（digest 修复后）：补入 digest 中出现的 claim_key 与 search_claims 结果来源；final_answer 为空且没有引用，claims/source 仅依据 digest 可见证据标注，confidence 保持 needs_review。 | supplemental labels added 2026-08-14 (droid, v8 forensics)",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "context engineering 一句话核心结论：草稿塞 15 source + 9 claim，按 ground-truth 删 IDA Pro MCP（无关 CE）和 input-normalization claim，剩 12 source + 8 claim 全部 promote。"
+}

--- a/fixtures/retrieval-qrels/gold/q-022-financial-product.json
+++ b/fixtures/retrieval-qrels/gold/q-022-financial-product.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "q-022",
+ "question": "详细讲讲这个金融产品，金融现象的本质",
+ "source_session": "src-ms8oe2fl-wvaspa",
+ "language": "zh",
+ "class": "source_scoped",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "816380d615c63038a3aae393ecaa8a2c624045a5a03200111d46e0f860183519",
+   "grade": 3,
+   "why": "事关7709 文章本身详尽讨论 7709.HK 单股杠杆 ETF 反身性与 KOSPI 7·13 风暴，是问题的承载对象。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "这是 source-grounded chat，焦点 source 在 digest 的上下文中完整给出；但 cited_sources/cited_claims 为空，无法判断回答实际引用了哪些段落。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "source_scoped 题：focus context 唯一给出，事关7709 文章本身是答案；promote 到 grade 3。"
+}

--- a/fixtures/retrieval-qrels/gold/q-023-memory-best-practices.json
+++ b/fixtures/retrieval-qrels/gold/q-023-memory-best-practices.json
@@ -1,0 +1,45 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "q-023",
+ "question": "像我们obsidian vault pipeline这种项目，怎么做meomory效果最好，有没有最佳实践，或者最适合的memory产品",
+ "source_session": "thm-msiqhp82-ke4pbi",
+ "language": "mixed",
+ "class": "compare",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "01b4867abcf3b294369fd429d278fdace5d79b829cb0b5488e4b49b4b74f3cfe",
+   "grade": 3,
+   "why": "We broke the frontier in agent memory（supermemory 博客），SOTA memory 系统实现，正面承载 memory 产品/最佳实践。"
+  },
+  {
+   "surface": "source",
+   "id": "9a1a6d8cd7e66e7a461e7582db61fa486adb2f4b0b8a42ef949dae8ad011f23a",
+   "grade": 3,
+   "why": "Dhravya Shah 同一内容的 X/Twitter 版本，承载 memory SOTA 主张。"
+  },
+  {
+   "surface": "source",
+   "id": "6e2160664be15c24db3c39daf51b7ec3f65a9324d4a20a589006f1aa5c6a2ee2",
+   "grade": 3,
+   "why": "98.2% on LongMemEval，可长期记忆 agent 评测与实现，正面承载 memory 最佳实践。"
+  },
+  {
+   "surface": "source",
+   "id": "98043fd561a59f3620d512a98d1c81beccd4047fcebacdd52d87b4cd20298789",
+   "grade": 3,
+   "why": "Agent Memory Is Blind to Time，mem0 temporal reasoning 层，承载 memory 时间维度实践。"
+  },
+  {
+   "surface": "source",
+   "id": "63ee63befc1394f8aec0cd9102d80ee750ceeb18b1900fea9bef64e0acf9675d",
+   "grade": 2,
+   "why": "How Memory Works in HyperAgents?，mem0 双层记忆架构，承载 memory 架构候选。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "theme-grounded 上下文提供了 active claims 和 56 个 cited sources，候选可据此标注；但最终 cited_sources/cited_claims 为空，因此全部保留 grade 1。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "compare 题：5 个 source 全是 agent memory 系统实践（包括 LongMemEval、SOTA、temporal memory、HyperAgents），全部 promote。"
+}

--- a/fixtures/retrieval-qrels/gold/q-024-context-engineering-durable.json
+++ b/fixtures/retrieval-qrels/gold/q-024-context-engineering-durable.json
@@ -1,0 +1,33 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "q-024",
+ "question": "vault 里关于 context engineering 的来源和 durable 结论有哪些?",
+ "source_session": "web-a3c-smoke1",
+ "language": "mixed",
+ "class": "claim_evidence",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "01461090526e4112accab4ba83e827c4ab302ee614188dc39dd90b33d56884e8",
+   "grade": 3,
+   "why": "Anthropic Effective context engineering，CE 一手权威综述。"
+  },
+  {
+   "surface": "source",
+   "id": "3db88bc656b322f6ea505b77bfd59e95f63f931f436197a2728c8c44697bc29f",
+   "grade": 3,
+   "why": "Advanced Context Engineering for Coding Agents，CE 深度综述。"
+  },
+  {
+   "surface": "source",
+   "id": "f1ae727f8b08e34af4441733da8ba468fe51559bb515937cd82d76e007e55a6e",
+   "grade": 3,
+   "why": "Aman AI Journal • Context Engineering primer，CE 系统化 primer。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "会话以 model_error 结束；工具确实返回候选，但标题不完整且最终答案没有引用，故只保留 grade 1。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "claim_evidence 题：3 个 source 全是 CE 系统综述，按 ground-truth 标题全部 promote grade 3；草稿未给 claim，只能列 source。"
+}

--- a/fixtures/retrieval-qrels/gold/q-031-cerebras-llm-article.json
+++ b/fixtures/retrieval-qrels/gold/q-031-cerebras-llm-article.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "q-031",
+ "question": "有一篇 Cerebus 的，好像是关于 LLM 的文章，帮我找一下。",
+ "source_session": "web-msfnaa35-6okobq",
+ "language": "mixed",
+ "class": "exact",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "8e2da9a4e95e0452d01d88fb6fd434ad8de3c3f400d6469abe539172424ce69f",
+   "grade": 2,
+   "why": "Cerebras How we built our knowledge base，Cerebus 拼写应为 Cerebras，是最贴合 Cerebras/LLM 主题的官方候选。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "Cerebus 拼写未直接命中，final_answer 推断用户可能指 Cerebras 并找到官方知识库候选；仍未完成正本确认。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "exact 题：Cerebus 应是 Cerebras 拼写变体，Cerebras 官方知识库文章是匹配候选；promote 到 grade 2（拼写不一致但实质答案）。"
+}

--- a/fixtures/retrieval-qrels/gold/q-040-transformer-job-story.json
+++ b/fixtures/retrieval-qrels/gold/q-040-transformer-job-story.json
@@ -1,0 +1,27 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "q-040",
+ "question": "你看看能不能帮我找到一篇我之前的文章，或者是一条 Twitter，讲的是一个女生毕业的时候投了几十份简历，最后被 OpenAI 或者anthropic类似的公司录取了。她还分享了一个诀窍，就是要能够手写 Transformer，而且写得很细致，还分享了她的笔记。",
+ "source_session": "web-v2i6-regression",
+ "language": "mixed",
+ "class": "paraphrase",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "51c47a5b14cbada25319c3f4813d2371a5c52383514046cfd49befb986f74c5c",
+   "grade": 3,
+   "why": "alisawuffles Notes on the Industry Job Search，dozens of interviews + transformer muscle memory + 公开笔记全部命中，是目标故事。"
+  },
+  {
+   "surface": "source",
+   "id": "95f4610732e6e6555151bae7d1d7ea0b7fee2c829637a3e9b251254d53870591",
+   "grade": 2,
+   "why": "silviasapora ML Job Interviews: The Ultimate Guide，Transformer from scratch 笔记候选，主题相邻但不是目标故事。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "final_answer 已找到与多个线索吻合的行业求职笔记，但仍需确认作者、Twitter/文章形态及手写笔记细节；无最终引用。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "transformer-job-story variant B 正例：alisawuffles Notes on the Industry Job Search 的几十次面试/Transformer 练习/笔记线索全部命中；promote 到 grade 3。ML Job Interviews 仍 grade 2。"
+}

--- a/fixtures/retrieval-qrels/gold/s-001-cua.json
+++ b/fixtures/retrieval-qrels/gold/s-001-cua.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-001",
+ "question": "我之前看过一篇标题里直接写 CUA 的 agent 基础设施文章，能帮我找出来吗？",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "exact",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "3d693fb99a6752e4d99d18fb5a4d590d2482f4d851ecda4fe37521d43bc7fadb",
+   "grade": 3,
+   "why": "标题《CUA - Computer-Use Agent Infrastructure》本身是问题的承载对象，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=3d693fb99a6752e4d99d18fb5a4d590d2482f4d851ecda4fe37521d43bc7fadb（标题《CUA - Computer-Use Agent Infrastructure》）做 exact 项目名提问。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "exact 题：'标题里直接写 CUA 的 agent 基础设施' 直指唯一标题《CUA - Computer-Use Agent Infrastructure》，自然中文提问，可判别；没有复用标题其他词组但作为 exact 桶正是预期行为。"
+}

--- a/fixtures/retrieval-qrels/gold/s-002-langfuse.json
+++ b/fixtures/retrieval-qrels/gold/s-002-langfuse.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-002",
+ "question": "Can you find the vault note whose title is just “Langfuse”?",
+ "source_session": "silver-generated",
+ "language": "en",
+ "class": "exact",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "17c1b85cd7268ec1859a1d6bf8d6cf6a1ddae7ee7c7837fdca6864dad1b09925",
+   "grade": 3,
+   "why": "唯一标题《Langfuse》本身就是答案，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=17c1b85cd7268ec1859a1d6bf8d6cf6a1ddae7ee7c7837fdca6864dad1b09925（标题《Langfuse》）做 exact 标题提问。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "exact 题：'vault note whose title is just Langfuse' 措辞轻微书面但属 exact 桶的源标题直接引用，在英文用户用 prompt 定位唯一标题时很常见；可判别、不泄漏。"
+}

--- a/fixtures/retrieval-qrels/gold/s-003-coral.json
+++ b/fixtures/retrieval-qrels/gold/s-003-coral.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-003",
+ "question": "哪篇文章标题里有 CORAL，讲的是多智能体自我进化基础设施？",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "exact",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "fb4f0932187ec09096113c5b536588450af92b9d0d6c1de51958a8fac3ff9cf3",
+   "grade": 3,
+   "why": "唯一带 CORAL 与 Multi-Agent Self-Evolution 的标题文章，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=fb4f0932187ec09096113c5b536588450af92b9d0d6c1de51958a8fac3ff9cf3（标题《CORAL - Multi-Agent Self-Evolution Infrastructure》）做 exact 项目名提问。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "exact 题：'标题里有 CORAL，讲的是多智能体自我进化基础设施' 把独特项目名 CORAL 与主题并置，自然中文、可判别、exact 桶预期。"
+}

--- a/fixtures/retrieval-qrels/gold/s-005-memmy-agent.json
+++ b/fixtures/retrieval-qrels/gold/s-005-memmy-agent.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-005",
+ "question": "找一下标题里有 memmy-agent 的那条，应该是给多个 AI 共用本地记忆的项目。",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "exact",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "97b645a800ea95505bfd100a05e0d390d2896c8a173a79846f06dcf3b709b0f7",
+   "grade": 3,
+   "why": "标题以《MemTensor/memmy-agent》开头，副标题明确讨论共享/本地记忆，是问题唯一目标，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=97b645a800ea95505bfd100a05e0d390d2896c8a173a79846f06dcf3b709b0f7（标题以《MemTensor/memmy-agent》开头）做 exact 项目名提问。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "exact 题：'标题里有 memmy-agent 的那条，给多个 AI 共用本地记忆的项目' 项目名 + 主题双轴，自然、可判别。"
+}

--- a/fixtures/retrieval-qrels/gold/s-006-log-is-agent.json
+++ b/fixtures/retrieval-qrels/gold/s-006-log-is-agent.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-006",
+ "question": "找一下标题里写着 “The Log is the Agent” 的那篇 paper。",
+ "source_session": "silver-generated",
+ "language": "mixed",
+ "class": "exact",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "72f86b3edee1946ff42b48a115a9fec6f912e58bf5b381d1af481df6db0930e4",
+   "grade": 3,
+   "why": "唯一带《The Log is the Agent》字样的 vault 文章，是 paper 本身，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=72f86b3edee1946ff42b48a115a9fec6f912e58bf5b381d1af481df6db0930e4（标题含《The Log is the Agent》）做 exact 标题短语提问。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "exact 题：'标题里写着 The Log is the Agent 的那篇 paper' 中英混排引标题短语作为定位线索，自然、可判别、exact 桶预期。"
+}

--- a/fixtures/retrieval-qrels/gold/s-009-llm-wiki-replacement.json
+++ b/fixtures/retrieval-qrels/gold/s-009-llm-wiki-replacement.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-009",
+ "question": "有没有文章讲把原来那套大模型知识库换掉，做成真正能用的版本？",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "paraphrase",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "f919df1d2831f5e2cdc52f80df8d802ccc9ccba8b2e62e14fd30b25fde3edbbb",
+   "grade": 3,
+   "why": "标题《I Replaced Karpathy's LLM Wiki with Something That Actually Works》唯一对应 '把 LLM wiki 换掉换成真可用版本'，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=f919df1d2831f5e2cdc52f80df8d802ccc9ccba8b2e62e14fd30b25fde3edbbb（标题《I Replaced Karpathy's LLM Wiki with Something That Actually Works》）做 paraphrase。 | label review 2026-08-14 (droid): label_correct_hard_question - 三方 miss 为真实能力缺口非标注错误",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "paraphrase 题：'把原来那套大模型知识库换掉，做成真正能用的版本' 把 'I Replaced Karpathy's LLM Wiki with Something That Actually Works' 改写为中文自然提问，未复用 Karpathy/replaced/wiki 等原词；可判别。"
+}

--- a/fixtures/retrieval-qrels/gold/s-010-self-healing-harness.json
+++ b/fixtures/retrieval-qrels/gold/s-010-self-healing-harness.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-010",
+ "question": "我记得有篇文章说光有记忆和外围框架还不够，还得让这套东西能自己发现问题并修好，帮我找下？",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "paraphrase",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "c12b52bfc7abfa61c839c168e62fef4c4bc7c4cb3a6217fa5dcaff10e60b6aa6",
+   "grade": 3,
+   "why": "标题《Open Memory and Open Harness Is Not Enough: You Need Self-Optimizing (Self-Healing) Harness》是唯一把 memory + harness 列为不够并主张 self-healing 的文章，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=c12b52bfc7abfa61c839c168e62fef4c4bc7c4cb3a6217fa5dcaff10e60b6aa6（标题《Open Memory and Open Harness Is Not Enough: ...》）做 paraphrase。 | label review 2026-08-14 (droid): label_correct_hard_question - 三方 miss 为真实能力缺口非标注错误",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "paraphrase 题：'光有记忆和外围框架还不够，得能自己发现问题并修好' 用 '记忆' 译 Memory、'外围框架' 译 Harness、'自己发现问题并修好' 译 Self-Healing，未复述 Self-Healing Harness 原词；与 vault 中其他 harness 文章（Anatomy of an Agent Harness / Harness Is the Backend）不相交，可判别。"
+}

--- a/fixtures/retrieval-qrels/gold/s-011-effective-agents.json
+++ b/fixtures/retrieval-qrels/gold/s-011-effective-agents.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-011",
+ "question": "I'm looking for the practical guide to turning a language model into a useful autonomous worker.",
+ "source_session": "silver-generated",
+ "language": "en",
+ "class": "paraphrase",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "67000a6afabe9cbcc3494513111832b3c48e9bbd9602782d2f929bc7f757d336",
+   "grade": 3,
+   "why": "标题《Building Effective AI Agents》是实践型 '把模型变成有用 autonomous worker' 的主要指南，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=67000a6afabe9cbcc3494513111832b3c48e9bbd9602782d2f929bc7f757d336（标题《Building Effective AI Agents》）做 paraphrase。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "paraphrase 题：'practical guide to turning a language model into a useful autonomous worker' 是 Building Effective AI Agents 的口语化换词（没用 Building / Effective / Agents 中任何一个原词），可判别。"
+}

--- a/fixtures/retrieval-qrels/gold/s-012-daily-note-dashboard.json
+++ b/fixtures/retrieval-qrels/gold/s-012-daily-note-dashboard.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-012",
+ "question": "有没有一篇教我做笔记首页的文章，能把今天真正重要的东西集中显示出来？",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "paraphrase",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "f48476156888967b2ff380a27d6c7b745995394ff73708c3849bb3180459e7d1",
+   "grade": 3,
+   "why": "标题《How to Build an Obsidian Dashboard That Shows You Everything That Matters Today》是 Obsidian 主题唯一文章，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=f48476156888967b2ff380a27d6c7b745995394ff73708c3849bb3180459e7d1（标题《How to Build an Obsidian Dashboard That Shows You Everything That Matters Today》）做 paraphrase。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "paraphrase 题：'教我做笔记首页的文章，把今天真正重要的东西集中显示出来' 用 '笔记首页' 译 Obsidian Dashboard、'今天真正重要的东西集中显示' 译 Today/Everything That Matters Today 的语义但用不同中文表达；可判别，Obsidian dashboard 在 vault 内只有这一篇。"
+}

--- a/fixtures/retrieval-qrels/gold/s-013-active-memory-retrieval.json
+++ b/fixtures/retrieval-qrels/gold/s-013-active-memory-retrieval.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-013",
+ "question": "agent 的 memory 如果只是把东西堆起来，为什么会失效？要怎样才能真正好用？",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "claim_evidence",
+ "relevant": [
+  {
+   "surface": "claim",
+   "id": "ck-4153cf5ac8c54758",
+   "grade": 3,
+   "why": "claim 原文正是关于把 memory 当被动存储为什么失效、主动检索+打分+新鲜度门控怎么解决的结论，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 claim_key=ck-4153cf5ac8c54758（主题 LLM agent memory & retrieval）把结论反向改写成问题。该 claim 的 source_ids 未在 silver-input.sources 中提供可对应的 sha256，故按允许 ID 约束不另引。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "claim_evidence 题：'memory 只是把东西堆起来为什么会失效？要怎样才能真正好用' 把 'Treating memory as a passive store breaks at agent scale; effective agent memory requires active retrieval, scoring, and freshness gating' 反向改写成反问；自然、可判别、不复用 'passive store/active retrieval/scoring/freshness gating' 等原词。"
+}

--- a/fixtures/retrieval-qrels/gold/s-014-holdout-evals.json
+++ b/fixtures/retrieval-qrels/gold/s-014-holdout-evals.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-014",
+ "question": "为什么 eval 要分优化集和 holdout 集，专门防止 agent 钻评测空子？",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "claim_evidence",
+ "relevant": [
+  {
+   "surface": "claim",
+   "id": "ck-c968145c1fc49510",
+   "grade": 3,
+   "why": "claim 原文直接给出 holdout set 拆分为优化/holdout 来防御 reward hacking 与过拟合，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 claim_key=ck-c968145c1fc49510（主题 Agent Harness Engineering）把结论反向改写成问题。该 claim 的 source_ids 未在 silver-input.sources 中提供可对应的 sha256，故按允许 ID 约束不另引。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "claim_evidence 题：'eval 为什么要分优化集和 holdout 集，专门防止 agent 钻评测空子' 把 holdout pattern claim 反向改写；'holdout' 是该 claim 的核心术语，用作问题关键词符合 claim_evidence 桶预期，可判别。"
+}

--- a/fixtures/retrieval-qrels/gold/s-015-loop-engineering.json
+++ b/fixtures/retrieval-qrels/gold/s-015-loop-engineering.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-015",
+ "question": "What exactly does “loop engineering” mean—how does the loop take over the human prompter?",
+ "source_session": "silver-generated",
+ "language": "mixed",
+ "class": "claim_evidence",
+ "relevant": [
+  {
+   "surface": "claim",
+   "id": "ck-e5a3183b0890cc4e",
+   "grade": 3,
+   "why": "claim 原文直接定义 loop engineering 为替代 human prompter 的迭代驱动循环，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 claim_key=ck-e5a3183b0890cc4e（主题 Loop Engineering）把结论反向改写成英文问题。该 claim 的 source_ids 未在 silver-input.sources 中提供可对应的 sha256，故按允许 ID 约束不另引。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "claim_evidence 题：'What exactly does loop engineering mean—how does the loop take over the human prompter' 反向询问 'loop engineering 替代 human prompter' claim；用术语是 claim_evidence 桶预期行为，可判别。"
+}

--- a/fixtures/retrieval-qrels/gold/s-016-external-execution-state.json
+++ b/fixtures/retrieval-qrels/gold/s-016-external-execution-state.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-016",
+ "question": "想让 agent 长时间工作、能暂停后继续，还能交接给别人，执行状态应该怎么保存？",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "claim_evidence",
+ "relevant": [
+  {
+   "surface": "claim",
+   "id": "ck-0e2ae8a9fdd6c5a8",
+   "grade": 3,
+   "why": "claim 原文给出 execution state 应外置到 progress files/scratchpads/JSONL logs/session memory，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 claim_key=ck-0e2ae8a9fdd6c5a8（主题 Managed AI agent runtime & execution）把结论反向改写成问题。该 claim 的 source_ids 未在 silver-input.sources 中提供可对应的 sha256，故按允许 ID 约束不另引。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "claim_evidence 题：'agent 长时间工作、能暂停后继续、还能交接给别人，执行状态应该怎么保存' 把 external execution state claim 反向改写为工程问题；自然、可判别。"
+}

--- a/fixtures/retrieval-qrels/gold/s-019-robert-meta.json
+++ b/fixtures/retrieval-qrels/gold/s-019-robert-meta.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-019",
+ "question": "Robert 在 May 2026 写的、讲 agent 运行记录压缩的那篇是什么？",
+ "source_session": "silver-generated",
+ "language": "mixed",
+ "class": "meta",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "da31750624b47bb64547f4e91636fdea73dcf23a764ec8e8964bb87edc147ffe",
+   "grade": 3,
+   "why": "source 元数据 author=Robert、date=2026-05-20、标题为 Laminar trace 压缩文章，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=da31750624b47bb64547f4e91636fdea73dcf23a764ec8e8964bb87edc147ffe 的 author/date/title 元数据生成 meta 问题。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "meta 题：'Robert 在 May 2026 写的讲 agent 运行记录压缩的那篇' 用 author + month + 主题定位，自然、可判别。"
+}

--- a/fixtures/retrieval-qrels/gold/s-020-scnace-meta.json
+++ b/fixtures/retrieval-qrels/gold/s-020-scnace-meta.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-020",
+ "question": "5 月 scnace 写的那篇讲智能体任务编排的文章是哪条？",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "meta",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "a5bb08edab1e5306285e535ac73b35e7ea0308979a1dbb4d186f62a11946e796",
+   "grade": 3,
+   "why": "source 元数据 author=scnace、date=2026-05-20、标题《tape x bee : 我对智能体任务的编排方式》全部命中，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=a5bb08edab1e5306285e535ac73b35e7ea0308979a1dbb4d186f62a11946e796 的 author/date/title 元数据生成 meta 问题。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "meta 题：'5 月 scnace 写的那篇讲智能体任务编排的文章是哪条' 用 author + month + 主题定位，自然、可判别。"
+}

--- a/fixtures/retrieval-qrels/gold/s-021-ashwin-meta.json
+++ b/fixtures/retrieval-qrels/gold/s-021-ashwin-meta.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-021",
+ "question": "Ashwin Gopinath 在 6 月写的、把“记忆”和“目的”放在一起讲的文章是哪篇？",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "meta",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "8f26fc0a15409ea3c9cb377664431899bda0c7efa76dd6f3b71141a717e5fc45",
+   "grade": 3,
+   "why": "source 元数据 author=Ashwin Gopinath、date=2026-06-03、标题《Memory Is Purpose》全部命中，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=8f26fc0a15409ea3c9cb377664431899bda0c7efa76dd6f3b71141a717e5fc45 的 author/date/title 元数据生成 meta 问题。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "meta 题：'Ashwin Gopinath 在 6 月写的、把记忆和目的放在一起讲的文章' 用 author + month + 标题同义（中文化 Memory/Purpose）定位，自然、可判别。"
+}

--- a/fixtures/retrieval-qrels/gold/s-022-recent-shared-memory.json
+++ b/fixtures/retrieval-qrels/gold/s-022-recent-shared-memory.json
@@ -1,0 +1,25 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-022",
+ "question": "最近（8 月初）看过的、让不同 AI 共用一套记忆的文章是哪篇？",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "recent",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "97b645a800ea95505bfd100a05e0d390d2896c8a173a79846f06dcf3b709b0f7",
+   "grade": 3,
+   "why": "source date=2026-08-04，副标题明确讨论让 Claude Code / Codex / OpenClaw / Hermes Agent 共用一套记忆，是 8 月初唯一匹配候选，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=97b645a800ea95505bfd100a05e0d390d2896c8a173a79846f06dcf3b709b0f7 的 date=2026-08-04 与标题主题生成 recent 问题。 | date window 2026-08-01..2026-08-10 adjudicated blind from wording (\"8 月初\") 2026-08-14",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "recent 题：'最近（8 月初）看过的、让不同 AI 共用一套记忆的文章' 用时间窗 + 主题定位，silver-input 中 8 月初日期的 source 仅这一篇共享记忆主题，无混淆候选。",
+ "filters": {
+  "date_from": "2026-08-01",
+  "date_to": "2026-08-10"
+ }
+}

--- a/fixtures/retrieval-qrels/gold/s-023-recent-agent-team.json
+++ b/fixtures/retrieval-qrels/gold/s-023-recent-agent-team.json
@@ -1,0 +1,25 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-023",
+ "question": "最近读的关于 Multi-Agent 团队协作最佳实践是哪篇？",
+ "source_session": "silver-generated",
+ "language": "mixed",
+ "class": "recent",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "f51d6296d879060d0356aa81e768a38edb0304dd5e9f53c4ddb16ce544ba8c01",
+   "grade": 3,
+   "why": "source date=2026-08-08，标题《最佳实践：从Multi-Agent到Agent Team》唯一匹配 Multi-Agent 团队协作最佳实践最近阅读意图，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=f51d6296d879060d0356aa81e768a38edb0304dd5e9f53c4ddb16ce544ba8c01 的 date=2026-08-08 与标题主题生成 recent 问题。 | date window 2026-07-15..2026-08-14 adjudicated blind from wording (\"最近\"无锚,30 天惯例窗口) 2026-08-14",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "recent 题：'最近读的关于 Multi-Agent 团队协作最佳实践是哪篇' 时间近 + 主题，单一候选。",
+ "filters": {
+  "date_from": "2026-07-15",
+  "date_to": "2026-08-14"
+ }
+}

--- a/fixtures/retrieval-qrels/gold/s-024-recent-control-agents.json
+++ b/fixtures/retrieval-qrels/gold/s-024-recent-control-agents.json
@@ -1,0 +1,25 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-024",
+ "question": "7 月底最近看的、讲让多个智能体同时做事但人还能掌控的文章是哪篇？",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "recent",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "edccb9e67b2ac0d4fcd7110d97d439501f864cd1e533906d199fc7871e0843be",
+   "grade": 3,
+   "why": "source date=2026-07-28，标题《Air: Multitask with agents, stay in control》直接匹配 multitask + stay-in-control 主题，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=edccb9e67b2ac0d4fcd7110d97d439501f864cd1e533906d199fc7871e0843be 的 date=2026-07-28 与标题主题生成 recent 问题。 | date window 2026-07-20..2026-07-31 adjudicated blind from wording (\"7 月底\") 2026-08-14",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "recent 题：'7 月底最近看的、讲让多个智能体同时做事但人还能掌控的文章' 时间窗 + multitask + human-in-control 主题，silver-input 中 7 月底日期相符唯一。",
+ "filters": {
+  "date_from": "2026-07-20",
+  "date_to": "2026-07-31"
+ }
+}

--- a/fixtures/retrieval-qrels/gold/s-025-building-effective-scoped.json
+++ b/fixtures/retrieval-qrels/gold/s-025-building-effective-scoped.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-025",
+ "question": "《Building Effective AI Agents》那篇里，关于怎样把智能体做得真正可用，主要讲了什么？",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "source_scoped",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "67000a6afabe9cbcc3494513111832b3c48e9bbd9602782d2f929bc7f757d336",
+   "grade": 3,
+   "why": "问题用标题《Building Effective AI Agents》直接定位源，文章本身承载答案，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=67000a6afabe9cbcc3494513111832b3c48e9bbd9602782d2f929bc7f757d336（标题《Building Effective AI Agents》）生成 source_scoped 问题。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "source_scoped 题：用完整标题《Building Effective AI Agents》指明唯一 source，询问内容，可判别、不泄漏（title 是定位手段）。"
+}

--- a/fixtures/retrieval-qrels/gold/s-027-memmy-scoped.json
+++ b/fixtures/retrieval-qrels/gold/s-027-memmy-scoped.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-027",
+ "question": "《MemTensor/memmy-agent: 🍙 A personal AI agent & local memory hub for all AI agents like Claude Code, Codex, OpenClaw and Hermes Agent. Gives every AI one shared, fully controlled memory and persistent context — all AI remember the same you.》那篇里，shared memory 具体想解决什么问题？",
+ "source_session": "silver-generated",
+ "language": "mixed",
+ "class": "source_scoped",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "97b645a800ea95505bfd100a05e0d390d2896c8a173a79846f06dcf3b709b0f7",
+   "grade": 3,
+   "why": "问题用完整标题定位唯一 source，副标题说明该项目正是多个 AI 共享一套记忆的设计，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=97b645a800ea95505bfd100a05e0d390d2896c8a173a79846f06dcf3b709b0f7（完整标题见问题）生成 source_scoped 问题。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "source_scoped 题：标题全文较长且含 emoji，引用稍显笨重，但 source_scoped 桶本就用标题作唯一标识，问题随后问的是文章内 'shared memory' 设计意图，可判别；不视作翻译腔（无中翻英/英翻中的不对接）。vault 中仅此一篇 memmy-agent，无混淆候选。"
+}

--- a/fixtures/retrieval-qrels/gold/s-028-cuda-negative.json
+++ b/fixtures/retrieval-qrels/gold/s-028-cuda-negative.json
@@ -1,0 +1,14 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-028",
+ "question": "vault 里有没有关于 NVIDIA CUDA kernel 调优和显存占用对比的实测？",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "negative",
+ "relevant": [],
+ "no_answer": true,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据输入中的 AI agent/LLM 邻近主题构造负例；silver-input 未出现 CUDA kernel、显存实测或对应 claim/source，故 relevant 为空。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "negative 题：'vault 里有没有 NVIDIA CUDA kernel 调优和显存占用对比的实测' 对照 silver-input 全部 claims/sources 无任何 CUDA / kernel / 显存 / GPU 性能主题内容，确认 no_answer=true。问题自然、范围足够窄以判断无答案。"
+}

--- a/fixtures/retrieval-qrels/gold/s-029-api-pricing-negative.json
+++ b/fixtures/retrieval-qrels/gold/s-029-api-pricing-negative.json
@@ -1,0 +1,14 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-029",
+ "question": "有没有一篇专门比较 OpenAI、Anthropic 和 Google API 价格，并给出最新套餐表？",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "negative",
+ "relevant": [],
+ "no_answer": true,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据输入中的 provider/API key 与 AI agent 邻近主题构造负例；silver-input 未出现三家 API 价格、套餐表或对应 claim/source，故 relevant 为空。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "negative 题：'OpenAI、Anthropic、Google API 价格 + 最新套餐表' 对照 silver-input 无任一三家 API 价格比较或套餐表内容（vault 仅在 claim 中涉及 provider API keys pluggable，并未做价格比较），确认 no_answer=true。问题自然、范围明确。"
+}

--- a/fixtures/retrieval-qrels/holdout/q-007-recent-topics.json
+++ b/fixtures/retrieval-qrels/holdout/q-007-recent-topics.json
@@ -1,0 +1,43 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "q-007",
+ "question": "我最近读了哪些主题的东西?挑三篇值得重读的。",
+ "source_session": "a3d-eval-agent-q5-explore-recent",
+ "language": "mixed",
+ "class": "recent",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "96901268f6e8fed73b8edc9c05bbf115db856c94f4477eb14a830e802de55a49",
+   "grade": 1,
+   "why": "Anthropic 大规模 Claude Code 迁移，list_recent_sources 候选。"
+  },
+  {
+   "surface": "source",
+   "id": "747237d54ac314200edd0320489d799f663a217b837ebb5d9b82b9632b480567",
+   "grade": 1,
+   "why": "CMGS 1M concurrent sandboxes，list_recent_sources 候选。"
+  },
+  {
+   "surface": "source",
+   "id": "873b49a7b5c6024697cea56cb9f8e759db8458a2103d2aca60269910242a1be1",
+   "grade": 1,
+   "why": "中美 AI 模型前沿比较，list_recent_sources 候选。"
+  },
+  {
+   "surface": "source",
+   "id": "8e2da9a4e95e0452d01d88fb6fd434ad8de3c3f400d6469abe539172424ce69f",
+   "grade": 1,
+   "why": "Cerebras 知识库实践，list_recent_sources 候选。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "list_recent_sources 返回了候选，但 final_answer 在完成三篇推荐前结束，且没有最终引用；候选均为 grade 1。 | date window 2026-07-15..2026-08-14 adjudicated blind from wording (\"最近\"无锚,30 天惯例窗口) 2026-08-14",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "recent 题：list_recent_sources 返回 4 个候选都是 vault 近期源，全部 keep 作 grade 1（候选集合）。",
+ "filters": {
+  "date_from": "2026-07-15",
+  "date_to": "2026-08-14"
+ }
+}

--- a/fixtures/retrieval-qrels/holdout/q-009-cs336-mentions.json
+++ b/fixtures/retrieval-qrels/holdout/q-009-cs336-mentions.json
@@ -1,0 +1,27 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "q-009",
+ "question": "Stanford CS336 是什么?我的哪些文章提到了它?",
+ "source_session": "a3d-eval-agent-q7-entity",
+ "language": "mixed",
+ "class": "exact",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "f503789f77b73c2215ab8b1a76cd6ca43cb97b3af814fc297634bd83a5c64191",
+   "grade": 3,
+   "why": "Stanford CS336 | Language Modeling from Scratch，是 CS336 课程主页本身，直接回答第一问。"
+  },
+  {
+   "surface": "source",
+   "id": "51c47a5b14cbada25319c3f4813d2371a5c52383514046cfd49befb986f74c5c",
+   "grade": 1,
+   "why": "alisawuffles 求职笔记可能提到 CS336，但 final_answer 没确认该具体来源，仅作候选保留。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "CS336 的直接来源可确认，但 final_answer 只说找到三篇、没有列出引用，其他提及它的来源无法从 digest 明确映射。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "exact 题：CS336 主页本身 grade 3；alisawuffles 是否提及 CS336 不确定但问题第二部分问提到它的文章，保留 grade 1。"
+}

--- a/fixtures/retrieval-qrels/holdout/q-030-digital-human-video.json
+++ b/fixtures/retrieval-qrels/holdout/q-030-digital-human-video.json
@@ -1,0 +1,39 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "q-030",
+ "question": "在知识库里找一下，就是跟这个数字人做视频生成相关的内容，串一串，就有什么比较好的实践吗？就是做数字人、数字分身，或者是做视频编辑。",
+ "source_session": "web-ms5oakt4-vvpf41",
+ "language": "mixed",
+ "class": "compare",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "6dc988d1d27614055ed13de8010eddbd44f107635061e25c7a6a5647f887a0a3",
+   "grade": 3,
+   "why": "Codex+Hyperframes+HeyGen+声音克隆自媒体变现，正面承载数字人/视频编辑组合实践。"
+  },
+  {
+   "surface": "source",
+   "id": "979d7ea1381359b259a4d78a0b13a032f24272c77980b9539c3ec5d2cce4f9c1",
+   "grade": 3,
+   "why": "rachel-digital-human-production，数字人制作实践项目本身。"
+  },
+  {
+   "surface": "source",
+   "id": "3e3d2ca0bf8696a4fce3c1173f90123393bdc95ec553755dd316a3c8a25cf3f3",
+   "grade": 3,
+   "why": "Kmeng AI Animata 本地化 AI 视频创作工具，正面承载视频创作工具实践。"
+  },
+  {
+   "surface": "source",
+   "id": "e806e9e5f4721f65509ef33f045c36e61ed15cab8293572048191352262ecdbe",
+   "grade": 2,
+   "why": "Seedance2-Storyboard-Generator，视频分镜生成工具，承载视频编辑相邻实践。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "工具结果和标题覆盖数字人、数字分身、视频生成与编辑多个方向，但 final_answer 在补充确认前结束且没有引用。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "compare 题：4 个 source 全是数字人/视频生成主题，按 ground-truth 全部 promote；Seedance2 与其他三个相比偏工具化故 grade 2。"
+}

--- a/fixtures/retrieval-qrels/holdout/s-004-remotion-skills.json
+++ b/fixtures/retrieval-qrels/holdout/s-004-remotion-skills.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-004",
+ "question": "我想找那篇标题含 Remotion Skills、还提到视频制作提示词的文章。",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "exact",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "d7a6d329efc1ce798803124f5160c34ae083abb70f0f482a74edf66aa2437be4",
+   "grade": 3,
+   "why": "标题《Remotion Skills 制作视频完整过程和提示词》是唯一同时含 Remotion Skills 与提示词的 vault 文章，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=d7a6d329efc1ce798803124f5160c34ae083abb70f0f482a74edf66aa2437be4（标题《Remotion Skills 制作视频完整过程和提示词》）做 exact 项目名提问。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "exact 题：'标题含 Remotion Skills、还提到视频制作提示词' 用独特项目名 + 主题双轴定位，自然、可判别。"
+}

--- a/fixtures/retrieval-qrels/holdout/s-007-self-building-ai.json
+++ b/fixtures/retrieval-qrels/holdout/s-007-self-building-ai.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-007",
+ "question": "我想找一篇讲某个智能程序能不断改造自己、越跑越会搭建自身的文章。",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "paraphrase",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "055d42f737cc5038f073b92780de1634ab2d87436250e9b4f904cb9a0a080b23",
+   "grade": 3,
+   "why": "标题《The self-improving AI system that keeps building itself》正是 'single program keeps self-modifying' 主题的承载对象，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=055d42f737cc5038f073b92780de1634ab2d87436250e9b4f904cb9a0a080b23（标题《The self-improving AI system that keeps building itself》）做 paraphrase。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "paraphrase 题：'智能程序能不断改造自己、越跑越会搭建自身' 复述 self-improving-keeps-building-itself 主题，没有复用 'self-improving' 或 'building itself' 原词；问题用单数 '智能程序' 与多智能体自我进化（CORAL）作了区分，可判别。"
+}

--- a/fixtures/retrieval-qrels/holdout/s-008-laminar-traces.json
+++ b/fixtures/retrieval-qrels/holdout/s-008-laminar-traces.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-008",
+ "question": "有没有一篇讲把 agent 跑过的记录压到原来二十分之一左右的？",
+ "source_session": "silver-generated",
+ "language": "mixed",
+ "class": "paraphrase",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "da31750624b47bb64547f4e91636fdea73dcf23a764ec8e8964bb87edc147ffe",
+   "grade": 3,
+   "why": "标题《How Laminar compresses agent traces by 20x》是该主题唯一文章，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=da31750624b47bb64547f4e91636fdea73dcf23a764ec8e8964bb87edc147ffe（标题《How Laminar compresses agent traces by 20x》）做 paraphrase。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "paraphrase 题：'把 agent 跑过的记录压到原来二十分之一左右' 把 20x 改写成 '1/20 of original' 倒述、用 '跑过的记录' 替代 'agent traces'，自然换词、未复用原标题；可判别。"
+}

--- a/fixtures/retrieval-qrels/holdout/s-017-fail-closed-governance.json
+++ b/fixtures/retrieval-qrels/holdout/s-017-fail-closed-governance.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-017",
+ "question": "agent 权限治理为什么要默认拒绝？策略门、能力沙箱和继承规则该怎么设计？",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "claim_evidence",
+ "relevant": [
+  {
+   "surface": "claim",
+   "id": "ck-8a33edb839c8442f",
+   "grade": 3,
+   "why": "claim 原文给出 fail-closed policy gates + 能力沙箱 + kill switch + 继承只收紧不放松，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 claim_key=ck-8a33edb839c8442f（主题 Managed AI agent runtime & execution）把结论反向改写成问题。该 claim 的 source_ids 未在 silver-input.sources 中提供可对应的 sha256，故按允许 ID 约束不另引。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "claim_evidence 题：'agent 权限治理为什么要默认拒绝？策略门、能力沙箱和继承规则该怎么设计' 把 fail-closed governance claim 反向改写；问题只点了三个具体设计要素（policy gates / capability sandboxes / 继承），与 claim 三段结构对齐，可判别。"
+}

--- a/fixtures/retrieval-qrels/holdout/s-018-jason-liu-meta.json
+++ b/fixtures/retrieval-qrels/holdout/s-018-jason-liu-meta.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-018",
+ "question": "Jason Liu 在 5 月写的那篇 Codex-maxxing，能帮我翻出来吗？",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "meta",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "63ed0f127d5f1f1e2007e8881b24b08d7818184f327322f1b4720e7e52d541e9",
+   "grade": 3,
+   "why": "source 元数据 author=Jason Liu、date=2026-05-25、标题《Codex-maxxing - Jason Liu》全部命中，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=63ed0f127d5f1f1e2007e8881b24b08d7818184f327322f1b4720e7e52d541e9 的 author/date/title 元数据生成 meta 问题。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "meta 题：'Jason Liu 在 5 月写的那篇 Codex-maxxing' 用 author + month + 标题定位，自然、可判别。"
+}

--- a/fixtures/retrieval-qrels/holdout/s-026-laminar-scoped.json
+++ b/fixtures/retrieval-qrels/holdout/s-026-laminar-scoped.json
@@ -1,0 +1,21 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-026",
+ "question": "《How Laminar compresses agent traces by 20x》那篇里面，具体是怎么处理运行轨迹的？",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "source_scoped",
+ "relevant": [
+  {
+   "surface": "source",
+   "id": "da31750624b47bb64547f4e91636fdea73dcf23a764ec8e8964bb87edc147ffe",
+   "grade": 3,
+   "why": "问题用标题直接定位源，文章本身承载答案，grade 3。"
+  }
+ ],
+ "no_answer": false,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据 source sha256=da31750624b47bb64547f4e91636fdea73dcf23a764ec8e8964bb87edc147ffe（标题《How Laminar compresses agent traces by 20x》）生成 source_scoped 问题。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "source_scoped 题：用完整标题《How Laminar compresses agent traces by 20x》指明唯一 source，询问内容，可判别。"
+}

--- a/fixtures/retrieval-qrels/holdout/s-030-agent-business-metrics-negative.json
+++ b/fixtures/retrieval-qrels/holdout/s-030-agent-business-metrics-negative.json
@@ -1,0 +1,14 @@
+{
+ "schema": "ovp.retrieval_eval.qrel/v1",
+ "id": "s-030",
+ "question": "我想找 agent 产品在生产环境的留存率、付费转化率和月度收入数据，vault 里有吗？",
+ "source_session": "silver-generated",
+ "language": "zh",
+ "class": "negative",
+ "relevant": [],
+ "no_answer": true,
+ "confidence": "gold",
+ "annotator_notes": "生成方式：据输入中的 agent 产品与 readiness 邻近主题构造负例；silver-input 未出现留存率、付费转化率、月度收入等实测经营数据或对应 claim/source，故 relevant 为空。",
+ "adjudicated_by": "droid",
+ "adjudication_reason": "negative 题：'agent 产品在生产环境的留存率、付费转化率和月度收入数据' 对照 silver-input 无 agent 产品经营指标 / MRR / 付费转化数据（vault 只谈 agent 技术与产品理念），确认 no_answer=true。问题自然、范围明确。"
+}


### PR DESCRIPTION
## What

Moves the 44 hand-adjudicated retrieval qrels from gitignored `.run/retrieval-eval/` into `fixtures/retrieval-qrels/{gold,holdout}`, and adds two tests that enforce the invariants the eval depends on.

## Why now

Every retrieval number this project reports is measured against these judgements. They were produced on 2026-08-13/14 (deterministic digest of real ask-sessions → cheap-model draft → operator adjudication) and existed on exactly one untracked disk. `rm -rf .run` would not just delete files — it would make every past retrieval result **unfalsifiable**, because there would be nothing left to re-measure against.

`fixtures/` is already described as "the frozen behavioral contract — the thing the system is measured against". This is that. The design doc's other candidate, `docs/eval/`, is gitignored (`.gitignore:29`), which is the problem rather than a fix for it.

## Tests

Both were verified to fail on the condition they exist to catch, then pass again after restore:

- **`committed_qrels_load_and_are_well_formed`** — loads through the *same* `load_qrels` the command uses, so schema drift breaks here before it breaks a run. Checks confidence, class vocabulary, surface vocabulary, grade range, and that `no_answer` and an empty relevant set agree.

  It asserts an **exact** count, not "non-empty". While writing this I copied with a `q-*.json` glob and silently dropped all 23 `s-*` records — the identical mistake `load_qrels`' own comment records (a 44-question run once reported itself complete at 14). Only the expected-count check caught it.

- **`qrels_gold_and_holdout_stay_disjoint`** — compares ids **and** normalized question text. Renumbering a duplicate sails past an id check while still leaking the judgement; that is the case that actually fired in the fault-injection run.

## What this does and does not buy

It makes the split mechanical. It cannot make the discipline mechanical: nothing can stop someone reading `holdout/` while tuning, and a holdout you consult is a second training set that reports flattering numbers. The README states the rule; the test only guarantees the two sets stay different questions.

## Not a finding, for the record

Several buckets hold fewer than 5 questions (`meta`, `source_scoped`, `negative`, `recent`). That is the design doc's §2 decision — 50–80 questions rather than 300, because a single-operator dogfood product cannot sustain weeks of annotation and an abandoned 300-question set is worth less than a finished 44. Per §4 those buckets are reported, not adjudicated.

No content changes to the judgements. Scanned for competitor names and credentials before committing; only hit was "token" in the LLM sense.
