### PR TITLE
feat(crystal): recheck durable claims against today's evidence

### DIFF
--- a/crates/ovp-cli/src/commands/crystal_recheck.rs
+++ b/crates/ovp-cli/src/commands/crystal_recheck.rs
@@ -16,7 +16,9 @@
 use std::path::PathBuf;
 
 use ovp_domain::crystal::recheck::{RecheckReport, recheck};
-use ovp_domain::crystal::{Citation, CrystalCandidate, CrystalClaim};
+use ovp_domain::crystal::{
+    Citation, CrystalCandidate, CrystalClaim, CrystalStatus, FinalClass, StoreEvent, fold_ledger,
+};
 
 use crate::CliError;
 use crate::commands::crystal_write::build_grounding_index;
@@ -33,90 +35,55 @@ pub struct CrystalRecheckArgs {
     pub limit: usize,
 }
 
-/// Rebuild a lintable candidate from the durable ledger.
+/// Rebuild a lintable candidate from what the vault CURRENTLY asserts.
 ///
-/// Only `op: write` records with `final_class: durable` are in scope — the
-/// point is to recheck what the vault currently asserts, not the history of
-/// how it got there. A later record for the same `claim_key` supersedes an
-/// earlier one.
+/// Goes through the domain's typed `StoreEvent` + [`fold_ledger`] rather than
+/// reading `op` strings here. The ledger has three ops, not one: `Supersede`
+/// also flips its predecessor to `Superseded`, and `Retract` marks a record
+/// retracted. Re-implementing "latest write wins" in the CLI reproduces none
+/// of that, so it would recheck retracted claims as if they were live and miss
+/// the replacements — and today's vault happens to contain only `write`
+/// records, so the mistake would have looked correct until the first
+/// supersede landed.
+///
+/// Typed deserialization is also the point for citations: a hand-rolled
+/// `filter_map` drops a malformed citation silently, and a claim that loses
+/// all of them then reports as intact — staleness is measured from citation
+/// defects, and a claim with no citations has none.
 fn durable_from_ledger(path: &PathBuf) -> Result<CrystalCandidate, CliError> {
     let text = std::fs::read_to_string(path)
         .map_err(|e| CliError::Io(format!("reading {}: {e}", path.display())))?;
-    // BTreeMap: last write per claim_key wins, deterministic order out.
-    let mut by_key: std::collections::BTreeMap<String, CrystalClaim> =
-        std::collections::BTreeMap::new();
-    let mut skipped = 0usize;
+    let mut events: Vec<StoreEvent> = Vec::new();
     for (i, line) in text.lines().enumerate() {
         let line = line.trim();
         if line.is_empty() {
             continue;
         }
-        let v: serde_json::Value = serde_json::from_str(line)
+        let ev: StoreEvent = serde_json::from_str(line)
             .map_err(|e| CliError::Io(format!("{}:{}: {e}", path.display(), i + 1)))?;
-        if v.get("op").and_then(|o| o.as_str()) != Some("write") {
-            continue;
-        }
-        let Some(rec) = v.get("record") else {
-            skipped += 1;
-            continue;
-        };
-        if rec.get("final_class").and_then(|c| c.as_str()) != Some("durable") {
-            continue;
-        }
-        let key = rec
-            .get("claim_key")
-            .or_else(|| rec.get("claim_id"))
-            .and_then(|k| k.as_str())
-            .unwrap_or_default()
-            .to_string();
-        if key.is_empty() {
-            skipped += 1;
-            continue;
-        }
-        let citations: Vec<Citation> = rec
-            .get("citations")
-            .and_then(|c| c.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|c| {
-                        Some(Citation {
-                            case_id: c.get("case_id")?.as_str()?.to_string(),
-                            unit_id: c.get("unit_id")?.as_str()?.to_string(),
-                            quote: c.get("quote")?.as_str()?.to_string(),
-                            claimed_line: None,
-                        })
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-        by_key.insert(
-            key.clone(),
-            CrystalClaim {
-                id: key,
-                claim: rec
-                    .get("claim")
-                    .and_then(|c| c.as_str())
-                    .unwrap_or_default()
-                    .to_string(),
-                theme: rec
-                    .get("theme")
-                    .and_then(|c| c.as_str())
-                    .unwrap_or_default()
-                    .to_string(),
-                citations,
-                caveat: None,
-            },
-        );
+        events.push(ev);
     }
-    if skipped > 0 {
-        // Loud, not silent: a record we could not key is a durable claim that
-        // this recheck did NOT cover, and a report that hides its own gaps is
-        // worse than no report.
-        eprintln!("crystal-recheck: {skipped} durable record(s) had no usable claim key — NOT rechecked");
-    }
-    Ok(CrystalCandidate {
-        items: by_key.into_values().collect(),
-    })
+    let items = fold_ledger(&events)
+        .into_iter()
+        .filter(|r| r.status == CrystalStatus::Active && r.final_class == FinalClass::Durable)
+        .map(|r| CrystalClaim {
+            id: r.claim_key,
+            claim: r.claim,
+            theme: r.theme,
+            citations: r
+                .citations
+                .into_iter()
+                .map(|c| Citation {
+                    case_id: c.case_id,
+                    unit_id: c.unit_id,
+                    quote: c.quote,
+                    claimed_line: None,
+                })
+                .collect(),
+            caveat: None,
+        })
+        .collect();
+    Ok(CrystalCandidate { items })
 }
 
 fn print_summary(report: &RecheckReport, limit: usize) {
@@ -233,41 +200,84 @@ mod tests {
         d
     }
 
+    /// A full durable record — the typed `StoreEvent` shape the ledger really
+    /// carries, not the trimmed JSON a hand-rolled parser would have accepted.
+    fn rec(key: &str, claim: &str, class: &str, unit: &str) -> String {
+        format!(
+            r#"{{"claim_key":"{key}","claim_id":"{key}","claim":"{claim}","theme":"t",
+                 "source_cases":["2026-01-01_X-a"],
+                 "citations":[{{"case_id":"2026-01-01_X-a","unit_id":"{unit}","quote":"q","resolved_line":1}}],
+                 "provenance_score":1.0,"provenance_class":"durable","strength":"supported",
+                 "strength_rationale":"r","final_class":"{class}","run_id":"r1","status":"active"}}"#
+        )
+        .replace('\n', "")
+    }
+
     #[test]
-    fn only_durable_write_records_are_rechecked() {
+    fn only_active_durable_records_are_rechecked() {
         let d = tmp("scope");
         let p = write_ledger(
             &d,
             &[
-                r#"{"op":"write","record":{"claim_key":"ck-1","final_class":"durable","claim":"a","citations":[{"case_id":"2026-01-01_X-a","unit_id":"u-1","quote":"q"}]}}"#,
-                r#"{"op":"write","record":{"claim_key":"ck-2","final_class":"caveated","claim":"b","citations":[]}}"#,
-                r#"{"op":"revoke","record":{"claim_key":"ck-3","final_class":"durable","claim":"c","citations":[]}}"#,
+                &format!(r#"{{"op":"write","record":{}}}"#, rec("ck-1", "a", "durable", "u-1")),
+                &format!(r#"{{"op":"write","record":{}}}"#, rec("ck-2", "b", "caveated", "u-2")),
                 "",
             ],
         );
         let c = durable_from_ledger(&p).unwrap();
         let ids: Vec<&str> = c.items.iter().map(|i| i.id.as_str()).collect();
-        assert_eq!(ids, vec!["ck-1"], "caveated and non-write ops stay out");
+        assert_eq!(ids, vec!["ck-1"], "caveated stays out");
         std::fs::remove_dir_all(&d).ok();
     }
 
     #[test]
-    fn a_later_write_supersedes_an_earlier_one_for_the_same_key() {
-        // The ledger is append-only, so the same claim_key appears more than
-        // once. Rechecking the stale historical copy would report defects that
-        // the current vault does not actually assert.
+    fn a_retracted_claim_is_not_rechecked() {
+        // Retract is a real ledger op. Rechecking a retracted claim reports
+        // defects the vault does not assert — and "latest write wins" cannot
+        // see it, which is why this goes through the domain's fold.
+        let d = tmp("retract");
+        let p = write_ledger(
+            &d,
+            &[
+                &format!(r#"{{"op":"write","record":{}}}"#, rec("ck-1", "a", "durable", "u-1")),
+                &format!(r#"{{"op":"retract","record":{}}}"#, rec("ck-1", "a", "durable", "u-1")),
+            ],
+        );
+        let c = durable_from_ledger(&p).unwrap();
+        assert!(c.items.is_empty(), "retracted claims are not live assertions");
+        std::fs::remove_dir_all(&d).ok();
+    }
+
+    #[test]
+    fn a_supersede_swaps_in_the_replacement_and_drops_the_predecessor() {
         let d = tmp("supersede");
         let p = write_ledger(
             &d,
             &[
-                r#"{"op":"write","record":{"claim_key":"ck-1","final_class":"durable","claim":"old","citations":[{"case_id":"2026-01-01_X-a","unit_id":"u-old","quote":"q"}]}}"#,
-                r#"{"op":"write","record":{"claim_key":"ck-1","final_class":"durable","claim":"new","citations":[{"case_id":"2026-01-01_X-a","unit_id":"u-new","quote":"q"}]}}"#,
+                &format!(r#"{{"op":"write","record":{}}}"#, rec("ck-old", "old", "durable", "u-old")),
+                &format!(
+                    r#"{{"op":"supersede","record":{},"supersedes":"ck-old"}}"#,
+                    rec("ck-new", "new", "durable", "u-new")
+                ),
             ],
         );
         let c = durable_from_ledger(&p).unwrap();
-        assert_eq!(c.items.len(), 1);
-        assert_eq!(c.items[0].claim, "new");
+        let ids: Vec<&str> = c.items.iter().map(|i| i.id.as_str()).collect();
+        assert_eq!(ids, vec!["ck-new"], "the superseded predecessor drops out");
         assert_eq!(c.items[0].citations[0].unit_id, "u-new");
+        std::fs::remove_dir_all(&d).ok();
+    }
+
+    #[test]
+    fn a_malformed_citation_fails_loudly_instead_of_vanishing() {
+        // Dropping it would leave a claim with zero citations, and staleness is
+        // measured from citation DEFECTS — a claim with none reports intact.
+        let d = tmp("badcit");
+        let p = write_ledger(
+            &d,
+            &[r#"{"op":"write","record":{"claim_key":"ck-1","claim_id":"ck-1","claim":"a","theme":"t","source_cases":[],"citations":[{"case_id":"c","unit_id":123,"quote":"q"}],"provenance_score":1.0,"provenance_class":"durable","strength":"supported","strength_rationale":"r","final_class":"durable","run_id":"r1","status":"active"}}"#],
+        );
+        assert!(durable_from_ledger(&p).is_err());
         std::fs::remove_dir_all(&d).ok();
     }
 

--- a/crates/ovp-cli/src/commands/crystal_recheck.rs
+++ b/crates/ovp-cli/src/commands/crystal_recheck.rs
@@ -1,0 +1,283 @@
+//! `crystal-recheck` — staleness recheck over the durable ledger.
+//!
+//! The pre-write gate proves a claim's citations ground the day it is written.
+//! Nothing re-asks afterwards, so a durable claim whose supporting unit later
+//! moved keeps asserting itself with a citation that no longer resolves — and
+//! it does so silently, because the ledger is append-only and the linter never
+//! runs again.
+//!
+//! This reconstructs a candidate from the durable ledger, re-lints it against
+//! the CURRENT reader packs, and reports. Read-only by design: it never edits
+//! the ledger, never rewrites a claim, never marks anything. A stale claim is
+//! not a wrong claim — it is one whose evidence can no longer be assumed
+//! without looking, and resolving that is a consolidation write that belongs
+//! behind the same gate and the same human as any other durable write.
+
+use std::path::PathBuf;
+
+use ovp_domain::crystal::recheck::{RecheckReport, recheck};
+use ovp_domain::crystal::{Citation, CrystalCandidate, CrystalClaim};
+
+use crate::CliError;
+use crate::commands::crystal_write::build_grounding_index;
+
+pub struct CrystalRecheckArgs {
+    pub vault_root: PathBuf,
+    /// Reader packs to re-lint against. Defaults to `<vault>/40-Resources/Reader`.
+    pub packs_dir: Option<PathBuf>,
+    /// Durable ledger. Defaults to `<vault>/.ovp/crystal/ledger.jsonl`.
+    pub ledger: Option<PathBuf>,
+    /// Write the JSON report here (stdout summary always prints).
+    pub out: Option<PathBuf>,
+    /// Cap the per-claim listing in the printed summary.
+    pub limit: usize,
+}
+
+/// Rebuild a lintable candidate from the durable ledger.
+///
+/// Only `op: write` records with `final_class: durable` are in scope — the
+/// point is to recheck what the vault currently asserts, not the history of
+/// how it got there. A later record for the same `claim_key` supersedes an
+/// earlier one.
+fn durable_from_ledger(path: &PathBuf) -> Result<CrystalCandidate, CliError> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| CliError::Io(format!("reading {}: {e}", path.display())))?;
+    // BTreeMap: last write per claim_key wins, deterministic order out.
+    let mut by_key: std::collections::BTreeMap<String, CrystalClaim> =
+        std::collections::BTreeMap::new();
+    let mut skipped = 0usize;
+    for (i, line) in text.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let v: serde_json::Value = serde_json::from_str(line)
+            .map_err(|e| CliError::Io(format!("{}:{}: {e}", path.display(), i + 1)))?;
+        if v.get("op").and_then(|o| o.as_str()) != Some("write") {
+            continue;
+        }
+        let Some(rec) = v.get("record") else {
+            skipped += 1;
+            continue;
+        };
+        if rec.get("final_class").and_then(|c| c.as_str()) != Some("durable") {
+            continue;
+        }
+        let key = rec
+            .get("claim_key")
+            .or_else(|| rec.get("claim_id"))
+            .and_then(|k| k.as_str())
+            .unwrap_or_default()
+            .to_string();
+        if key.is_empty() {
+            skipped += 1;
+            continue;
+        }
+        let citations: Vec<Citation> = rec
+            .get("citations")
+            .and_then(|c| c.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|c| {
+                        Some(Citation {
+                            case_id: c.get("case_id")?.as_str()?.to_string(),
+                            unit_id: c.get("unit_id")?.as_str()?.to_string(),
+                            quote: c.get("quote")?.as_str()?.to_string(),
+                            claimed_line: None,
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        by_key.insert(
+            key.clone(),
+            CrystalClaim {
+                id: key,
+                claim: rec
+                    .get("claim")
+                    .and_then(|c| c.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                theme: rec
+                    .get("theme")
+                    .and_then(|c| c.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                citations,
+                caveat: None,
+            },
+        );
+    }
+    if skipped > 0 {
+        // Loud, not silent: a record we could not key is a durable claim that
+        // this recheck did NOT cover, and a report that hides its own gaps is
+        // worse than no report.
+        eprintln!("crystal-recheck: {skipped} durable record(s) had no usable claim key — NOT rechecked");
+    }
+    Ok(CrystalCandidate {
+        items: by_key.into_values().collect(),
+    })
+}
+
+fn print_summary(report: &RecheckReport, limit: usize) {
+    println!(
+        "crystal-recheck: {} durable claims — {} intact, {} stale",
+        report.n_claims, report.n_intact, report.n_stale
+    );
+    if !report.by_defect.is_empty() {
+        let parts: Vec<String> = report
+            .by_defect
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect();
+        println!("  defects (claims, not citations): {}", parts.join(" "));
+    }
+    // Iterate the declared bucket order, not the map's: sorted by key,
+    // "181-365d" prints before "91-180d" and the histogram reads backwards.
+    let ages: Vec<String> = ovp_domain::crystal::recheck::AGE_BUCKET_NAMES
+        .iter()
+        .map(|k| format!("{k}={}", report.age_buckets.get(*k).copied().unwrap_or(0)))
+        .collect();
+    println!("  evidence age (oldest citation per claim): {}", ages.join(" "));
+    if report.n_undated > 0 {
+        println!("  undated evidence: {} claim(s)", report.n_undated);
+    }
+    for row in report.stale.iter().take(limit) {
+        println!(
+            "  STALE {} — {}/{} citations ground",
+            row.claim_id, row.n_grounded, row.n_citations
+        );
+        for c in &row.stale_citations {
+            println!("      {:?}  {} / {}", c.defect, c.case_id, c.unit_id);
+        }
+    }
+    if report.stale.len() > limit {
+        println!("  … {} more (see the JSON report)", report.stale.len() - limit);
+    }
+    // Staleness is a prompt to look, not a verdict that anything is wrong, so
+    // this never fails the command. Gating on it would make a routine pack
+    // rebuild look like corruption.
+    println!("  read-only: nothing was rewritten. Stale claims stay stale until re-verified.");
+}
+
+/// Recheck a vault's durable claims. Shared with `doctor` so the health check
+/// and the command can never drift into disagreeing about what is stale.
+pub fn recheck_vault(
+    vault_root: &std::path::Path,
+    packs_dir: Option<PathBuf>,
+    ledger: Option<PathBuf>,
+) -> Result<RecheckReport, CliError> {
+    let packs_dir = packs_dir.unwrap_or_else(|| vault_root.join("40-Resources/Reader"));
+    let ledger = ledger.unwrap_or_else(|| vault_root.join(".ovp/crystal/ledger.jsonl"));
+    let durable = durable_from_ledger(&ledger)?;
+    let index = build_grounding_index(&packs_dir)?;
+    Ok(recheck(&durable, &index, today_civil()))
+}
+
+pub fn run(args: CrystalRecheckArgs) -> Result<(), CliError> {
+    let packs_dir = args
+        .packs_dir
+        .clone()
+        .unwrap_or_else(|| args.vault_root.join("40-Resources/Reader"));
+    let ledger = args
+        .ledger
+        .clone()
+        .unwrap_or_else(|| args.vault_root.join(".ovp/crystal/ledger.jsonl"));
+
+    let today = today_civil();
+    let report = recheck_vault(&args.vault_root, args.packs_dir, args.ledger)?;
+
+    print_summary(&report, args.limit);
+
+    if let Some(out) = &args.out {
+        if let Some(parent) = out.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        let body = serde_json::json!({
+            "schema": "ovp.crystal.recheck/v1",
+            "as_of": format!("{:04}-{:02}-{:02}", today.0, today.1, today.2),
+            "packs_dir": packs_dir.display().to_string(),
+            "ledger": ledger.display().to_string(),
+            "report": report,
+        });
+        let s = serde_json::to_string_pretty(&body).map_err(|e| CliError::Io(e.to_string()))?;
+        std::fs::write(out, format!("{s}\n"))
+            .map_err(|e| CliError::Io(format!("writing {}: {e}", out.display())))?;
+        println!("  report: {}", out.display());
+    }
+    Ok(())
+}
+
+/// Today as a civil date in LOCAL time — the same wall clock the scheduler and
+/// the `case_id` date prefixes use, so an age never comes out off-by-one
+/// against the dates a human reads in the vault.
+fn today_civil() -> (i32, u32, u32) {
+    let now = chrono::Local::now().date_naive();
+    use chrono::Datelike;
+    (now.year(), now.month(), now.day())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_ledger(dir: &std::path::Path, lines: &[&str]) -> PathBuf {
+        let p = dir.join("ledger.jsonl");
+        std::fs::write(&p, lines.join("\n")).unwrap();
+        p
+    }
+
+    fn tmp(name: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("ovp2-recheck-{name}-{}", std::process::id()));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn only_durable_write_records_are_rechecked() {
+        let d = tmp("scope");
+        let p = write_ledger(
+            &d,
+            &[
+                r#"{"op":"write","record":{"claim_key":"ck-1","final_class":"durable","claim":"a","citations":[{"case_id":"2026-01-01_X-a","unit_id":"u-1","quote":"q"}]}}"#,
+                r#"{"op":"write","record":{"claim_key":"ck-2","final_class":"caveated","claim":"b","citations":[]}}"#,
+                r#"{"op":"revoke","record":{"claim_key":"ck-3","final_class":"durable","claim":"c","citations":[]}}"#,
+                "",
+            ],
+        );
+        let c = durable_from_ledger(&p).unwrap();
+        let ids: Vec<&str> = c.items.iter().map(|i| i.id.as_str()).collect();
+        assert_eq!(ids, vec!["ck-1"], "caveated and non-write ops stay out");
+        std::fs::remove_dir_all(&d).ok();
+    }
+
+    #[test]
+    fn a_later_write_supersedes_an_earlier_one_for_the_same_key() {
+        // The ledger is append-only, so the same claim_key appears more than
+        // once. Rechecking the stale historical copy would report defects that
+        // the current vault does not actually assert.
+        let d = tmp("supersede");
+        let p = write_ledger(
+            &d,
+            &[
+                r#"{"op":"write","record":{"claim_key":"ck-1","final_class":"durable","claim":"old","citations":[{"case_id":"2026-01-01_X-a","unit_id":"u-old","quote":"q"}]}}"#,
+                r#"{"op":"write","record":{"claim_key":"ck-1","final_class":"durable","claim":"new","citations":[{"case_id":"2026-01-01_X-a","unit_id":"u-new","quote":"q"}]}}"#,
+            ],
+        );
+        let c = durable_from_ledger(&p).unwrap();
+        assert_eq!(c.items.len(), 1);
+        assert_eq!(c.items[0].claim, "new");
+        assert_eq!(c.items[0].citations[0].unit_id, "u-new");
+        std::fs::remove_dir_all(&d).ok();
+    }
+
+    #[test]
+    fn a_corrupt_ledger_line_fails_loudly() {
+        // Skipping unparseable lines would let the report under-count silently
+        // and still print a confident "all intact".
+        let d = tmp("corrupt");
+        let p = write_ledger(&d, &["not json at all"]);
+        assert!(durable_from_ledger(&p).is_err());
+        std::fs::remove_dir_all(&d).ok();
+    }
+}

--- a/crates/ovp-cli/src/commands/doctor.rs
+++ b/crates/ovp-cli/src/commands/doctor.rs
@@ -321,14 +321,21 @@ fn check_stale_index(vault_root: &Path, findings: &mut Vec<Finding>, fix: bool) 
 fn check_crystal_staleness(vault_root: &Path, findings: &mut Vec<Finding>) {
     use crate::commands::crystal_recheck::recheck_vault;
 
+    // A vault with no crystal store yet is the normal fresh state and must not
+    // nag. Anything else — unreadable packs, a malformed ledger — means the
+    // check did not run, and reporting THAT as Info would quietly retire the
+    // very signal this exists to provide.
+    let store_absent = !vault_root.join(".ovp/crystal/ledger.jsonl").exists();
     let report = match recheck_vault(vault_root, None, None) {
         Ok(r) => r,
         Err(e) => {
             findings.push(Finding {
                 check: "crystal-staleness".into(),
-                // Info, not Warn: no crystal store yet is the normal state of
-                // a fresh vault, and this check must not nag it.
-                severity: Severity::Info,
+                severity: if store_absent {
+                    Severity::Info
+                } else {
+                    Severity::Warn
+                },
                 message: format!("could not recheck durable claims: {e}"),
                 fixed: false,
             });

--- a/crates/ovp-cli/src/commands/doctor.rs
+++ b/crates/ovp-cli/src/commands/doctor.rs
@@ -65,6 +65,7 @@ pub fn run(args: DoctorArgs) -> Result<(), CliError> {
     check_orphan_packs(&args.vault_root, &layout, &mut findings);
     check_stale_index(&args.vault_root, &mut findings, args.fix);
     check_crystal_integrity(&args.vault_root, &mut findings);
+    check_crystal_staleness(&args.vault_root, &mut findings);
     let threshold_hours = args.since_hours.unwrap_or(DEFAULT_RECENCY_HOURS);
     check_run_recency(&args.vault_root, &layout, now_unix_secs(), threshold_hours, &mut findings);
     check_disk_usage(&args.vault_root, &layout, &mut findings);
@@ -305,6 +306,84 @@ fn check_stale_index(vault_root: &Path, findings: &mut Vec<Finding>, fix: bool) 
             });
         }
     }
+}
+
+/// Do the durable claims still ground against TODAY's reader packs?
+///
+/// `crystal-integrity` only proves the ledger parses. A claim can parse
+/// perfectly while the unit it cites has moved, and because the ledger is
+/// append-only and the pre-write linter never runs again, nothing would ever
+/// say so. Routine visibility is the whole point — a staleness signal you have
+/// to remember to ask for is one you find out about from a wrong answer.
+///
+/// WARN, never FAIL: a stale claim is not a wrong claim, and a routine pack
+/// rebuild would otherwise read as corruption and start failing CI.
+fn check_crystal_staleness(vault_root: &Path, findings: &mut Vec<Finding>) {
+    use crate::commands::crystal_recheck::recheck_vault;
+
+    let report = match recheck_vault(vault_root, None, None) {
+        Ok(r) => r,
+        Err(e) => {
+            findings.push(Finding {
+                check: "crystal-staleness".into(),
+                // Info, not Warn: no crystal store yet is the normal state of
+                // a fresh vault, and this check must not nag it.
+                severity: Severity::Info,
+                message: format!("could not recheck durable claims: {e}"),
+                fixed: false,
+            });
+            return;
+        }
+    };
+    if report.n_claims == 0 {
+        findings.push(Finding {
+            check: "crystal-staleness".into(),
+            severity: Severity::Pass,
+            message: "no durable claims to recheck".into(),
+            fixed: false,
+        });
+        return;
+    }
+    let aged = report
+        .age_buckets
+        .get("181-365d")
+        .copied()
+        .unwrap_or(0)
+        + report.age_buckets.get("365d+").copied().unwrap_or(0);
+    let age_note = format!(
+        "{}/{} lean on evidence older than 180d",
+        aged, report.n_claims
+    );
+    if report.n_stale == 0 {
+        findings.push(Finding {
+            check: "crystal-staleness".into(),
+            severity: Severity::Pass,
+            message: format!(
+                "all {} durable claims still ground ({age_note})",
+                report.n_claims
+            ),
+            fixed: false,
+        });
+        return;
+    }
+    let defects: Vec<String> = report
+        .by_defect
+        .iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect();
+    findings.push(Finding {
+        check: "crystal-staleness".into(),
+        severity: Severity::Warn,
+        message: format!(
+            "{} of {} durable claims no longer ground ({}) — {age_note}. \
+             Run `ovp2 crystal-recheck --vault-root <vault> --out <report>`; \
+             re-verification is a gated write, never automatic",
+            report.n_stale,
+            report.n_claims,
+            defects.join(" ")
+        ),
+        fixed: false,
+    });
 }
 
 fn check_crystal_integrity(vault_root: &Path, findings: &mut Vec<Finding>) {

--- a/crates/ovp-cli/src/commands/mod.rs
+++ b/crates/ovp-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod client;
 pub mod compare_run;
 pub mod copy_probe;
 pub mod crystal_lint;
+pub mod crystal_recheck;
 pub mod crystal_review;
 pub mod crystal_review_session;
 pub mod crystal_synth;

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -558,6 +558,27 @@ enum Cmd {
         #[command(subcommand)]
         action: ScheduleAction,
     },
+    /// PRODUCT — staleness recheck over ALREADY-durable claims: re-run the
+    /// citation linter against the CURRENT reader packs and report which
+    /// durable claims no longer ground, plus how old their evidence is.
+    /// READ-ONLY — never rewrites a claim. A stale claim is not a wrong claim;
+    /// it is one whose evidence can no longer be assumed without looking.
+    CrystalRecheck {
+        #[arg(long)]
+        vault_root: PathBuf,
+        /// Reader packs to re-lint against. Default: `<vault>/40-Resources/Reader`.
+        #[arg(long)]
+        packs_dir: Option<PathBuf>,
+        /// Durable ledger. Default: `<vault>/.ovp/crystal/ledger.jsonl`.
+        #[arg(long)]
+        ledger: Option<PathBuf>,
+        /// Write the JSON report here (the summary always prints).
+        #[arg(long)]
+        out: Option<PathBuf>,
+        /// Cap the per-claim listing in the printed summary.
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+    },
     /// PRODUCT — reader/crystal trunk (the blessed path).
     /// M22 Crystal pre-write gate: lint a structured-citation synthesis candidate
     /// against the grounded units and score provenance. Mechanical, fail-loud, no
@@ -1999,6 +2020,22 @@ fn main() -> ExitCode {
                 commands::scheduler::run_set_enabled(&vault_root, &id, false)
             }
         },
+        Cmd::CrystalRecheck {
+            vault_root,
+            packs_dir,
+            ledger,
+            out,
+            limit,
+        } => {
+            use commands::crystal_recheck::CrystalRecheckArgs;
+            commands::crystal_recheck::run(CrystalRecheckArgs {
+                vault_root,
+                packs_dir,
+                ledger,
+                out,
+                limit,
+            })
+        }
         Cmd::CrystalLint {
             candidate,
             packs_dir,

--- a/crates/ovp-domain/src/crystal.rs
+++ b/crates/ovp-domain/src/crystal.rs
@@ -49,6 +49,11 @@ pub mod themes;
 /// over active durable claims. Append-only; never rewrites evidence.
 pub mod lineage;
 
+/// Staleness recheck over already-durable claims: re-run the citation linter
+/// against the CURRENT grounding index, plus evidence age. Read-only, never a
+/// repair — a stale claim is not a wrong claim.
+pub mod recheck;
+
 use crate::units::validator::deterministic_contains;
 use crate::units::{Unit, UnitStatus};
 

--- a/crates/ovp-domain/src/crystal/recheck.rs
+++ b/crates/ovp-domain/src/crystal/recheck.rs
@@ -1,0 +1,439 @@
+//! Staleness recheck over ALREADY-DURABLE claims.
+//!
+//! The pre-write gate ([`super::lint_candidate`]) proves a claim's citations
+//! ground at the moment it is written. Nothing re-asks the question afterwards,
+//! so a durable claim whose supporting unit later moved — a reader pack
+//! regenerated, a prompt version bumped, a source re-processed — keeps
+//! asserting itself with a citation that no longer resolves. Nothing errors;
+//! the claim simply stops being backed by what it says backs it.
+//!
+//! This module re-runs the SAME linter against the CURRENT grounding index and
+//! reports. It is deliberately read-only and deliberately not a repair: a
+//! stale claim is not a wrong claim, it is one whose evidence can no longer be
+//! assumed without looking. Rewriting it is a consolidation write and belongs
+//! behind the same gate and the same human as any other durable write.
+//!
+//! Second axis, free from the data we already have: how OLD the evidence is.
+//! A citation can still ground verbatim while the world it describes has moved
+//! on, and `case_id` already carries the capture date, so age needs no refetch
+//! and no new field.
+
+use std::collections::BTreeMap;
+
+use super::{CitationDefect, CrystalCandidate, GroundingIndex, lint_candidate};
+
+/// Age buckets, in days. Boundaries are reporting conveniences, not thresholds
+/// anything branches on — nothing here decides a claim is wrong because it is
+/// old.
+const AGE_BUCKETS: [(&str, i64); 4] = [
+    ("0-90d", 90),
+    ("91-180d", 180),
+    ("181-365d", 365),
+    ("365d+", i64::MAX),
+];
+
+/// Bucket names in AGE ORDER. `age_buckets` is a map keyed by these names, and
+/// sorting them as strings puts "181-365d" before "91-180d" — a histogram that
+/// reads backwards. Render through this.
+pub const AGE_BUCKET_NAMES: [&str; 4] = ["0-90d", "91-180d", "181-365d", "365d+"];
+
+/// Why one claim came back stale. Mirrors [`CitationDefect`] but counts at the
+/// claim level, since one broken citation is enough to stop trusting the claim.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct StaleCitation {
+    pub case_id: String,
+    pub unit_id: String,
+    pub defect: CitationDefect,
+}
+
+/// One durable claim's recheck verdict.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ClaimRecheck {
+    pub claim_id: String,
+    pub n_citations: usize,
+    pub n_grounded: usize,
+    /// Empty when every citation still grounds.
+    pub stale_citations: Vec<StaleCitation>,
+    /// Days since the OLDEST cited capture; `None` when no `case_id` carried a
+    /// parseable date prefix.
+    pub oldest_evidence_days: Option<i64>,
+    pub newest_evidence_days: Option<i64>,
+}
+
+impl ClaimRecheck {
+    pub fn is_stale(&self) -> bool {
+        !self.stale_citations.is_empty()
+    }
+}
+
+/// The whole recheck.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct RecheckReport {
+    pub n_claims: usize,
+    pub n_intact: usize,
+    pub n_stale: usize,
+    /// Claim-level counts per defect kind, so "the packs were rebuilt" (mass
+    /// `UnitNotFound`) reads differently from "a quote was edited"
+    /// (`QuoteNotInUnit`).
+    pub by_defect: BTreeMap<String, usize>,
+    /// Only the stale ones — the intact majority is a count, not a list.
+    pub stale: Vec<ClaimRecheck>,
+    /// Distribution of each claim's OLDEST evidence. Reported, never gated.
+    pub age_buckets: BTreeMap<String, usize>,
+    /// Claims whose citations carried no parseable date at all.
+    pub n_undated: usize,
+}
+
+/// Days between the capture date embedded in `case_id` and `today`.
+///
+/// `case_id` is a reader-pack directory name and the live vault has TWO
+/// layouts — `<date>_<title>-<hash8>` and `<hash8>-<date>_<title>…`. Anchoring
+/// on position 0 reads the second form as undated, which on the real ledger
+/// meant 72% of claims silently lost their age. So scan for the first
+/// well-formed `YYYY-MM-DD` anywhere in the id; both layouts put the capture
+/// date ahead of the title.
+///
+/// Returns `None` when no plausible date is present — a malformed id must not
+/// count as "captured today", which would report the oldest evidence in the
+/// vault as the newest.
+pub fn evidence_age_days(case_id: &str, today: (i32, u32, u32)) -> Option<i64> {
+    let b = case_id.as_bytes();
+    for start in 0..b.len().saturating_sub(9) {
+        // A date must not be glued to a longer digit run (a 12-digit id would
+        // otherwise yield a nonsense year from its first four digits).
+        if start > 0 && b[start - 1].is_ascii_digit() {
+            continue;
+        }
+        let Some(head) = case_id.get(start..start + 10) else {
+            continue;
+        };
+        if let Some(age) = parse_civil(head).map(|(y, m, d)| {
+            days_from_civil(today.0, today.1, today.2) - days_from_civil(y, m, d)
+        }) {
+            return Some(age);
+        }
+    }
+    None
+}
+
+/// `YYYY-MM-DD` with real bounds. Deliberately strict: this is the only thing
+/// standing between a typo'd id and a fabricated age.
+fn parse_civil(s: &str) -> Option<(i32, u32, u32)> {
+    let bytes = s.as_bytes();
+    if bytes.len() != 10 || bytes[4] != b'-' || bytes[7] != b'-' {
+        return None;
+    }
+    let y: i32 = s.get(0..4)?.parse().ok()?;
+    let m: u32 = s.get(5..7)?.parse().ok()?;
+    let d: u32 = s.get(8..10)?.parse().ok()?;
+    if !(1970..=9999).contains(&y) || !(1..=12).contains(&m) || !(1..=31).contains(&d) {
+        return None;
+    }
+    Some((y, m, d))
+}
+
+/// Howard Hinnant's `days_from_civil`. Chrono is not a dependency of this
+/// crate's pure layer and the caller already knows today's date.
+fn days_from_civil(y: i32, m: u32, d: u32) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = (y - era * 400) as i64;
+    let mp = ((m + 9) % 12) as i64;
+    let doy = (153 * mp + 2) / 5 + d as i64 - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era as i64 * 146_097 + doe - 719_468
+}
+
+fn bucket_for(days: i64) -> &'static str {
+    for (name, hi) in AGE_BUCKETS {
+        if days <= hi {
+            return name;
+        }
+    }
+    AGE_BUCKETS[AGE_BUCKETS.len() - 1].0
+}
+
+fn defect_name(d: &CitationDefect) -> &'static str {
+    match d {
+        CitationDefect::CaseNotFound => "case_not_found",
+        CitationDefect::UnitNotFound => "unit_not_found",
+        CitationDefect::UnitNotAccepted => "unit_not_accepted",
+        CitationDefect::QuoteNotInUnit => "quote_not_in_unit",
+    }
+}
+
+/// Re-lint `durable` against the CURRENT index and fold in evidence age.
+///
+/// `today` is passed in rather than read from the clock so the whole thing
+/// stays pure and the report is reproducible from the same inputs.
+pub fn recheck(
+    durable: &CrystalCandidate,
+    index: &GroundingIndex,
+    today: (i32, u32, u32),
+) -> RecheckReport {
+    let lint = lint_candidate(durable, index);
+    let mut by_defect: BTreeMap<String, usize> = BTreeMap::new();
+    let mut age_buckets: BTreeMap<String, usize> = BTreeMap::new();
+    for (name, _) in AGE_BUCKETS {
+        age_buckets.insert(name.to_string(), 0);
+    }
+    let mut stale = Vec::new();
+    let mut n_undated = 0usize;
+
+    for (claim, lint_row) in durable.items.iter().zip(lint.claims.iter()) {
+        let mut ages: Vec<i64> = Vec::new();
+        for c in &claim.citations {
+            if let Some(days) = evidence_age_days(&c.case_id, today) {
+                ages.push(days);
+            }
+        }
+        let oldest = ages.iter().copied().max();
+        let newest = ages.iter().copied().min();
+        match oldest {
+            Some(d) => *age_buckets.entry(bucket_for(d).to_string()).or_insert(0) += 1,
+            None => n_undated += 1,
+        }
+
+        let stale_citations: Vec<StaleCitation> = lint_row
+            .citations
+            .iter()
+            .filter_map(|v| {
+                v.defect.clone().map(|defect| StaleCitation {
+                    case_id: v.case_id.clone(),
+                    unit_id: v.unit_id.clone(),
+                    defect,
+                })
+            })
+            .collect();
+
+        // Count each defect kind ONCE per claim: a pack rebuild breaks every
+        // citation in a claim at once, and a citation-level tally would report
+        // that as many separate problems instead of one.
+        let mut kinds: Vec<&str> = stale_citations.iter().map(|s| defect_name(&s.defect)).collect();
+        kinds.sort_unstable();
+        kinds.dedup();
+        for k in kinds {
+            *by_defect.entry(k.to_string()).or_insert(0) += 1;
+        }
+
+        if !stale_citations.is_empty() {
+            stale.push(ClaimRecheck {
+                claim_id: claim.id.clone(),
+                n_citations: lint_row.n_citations,
+                n_grounded: lint_row.n_grounded,
+                stale_citations,
+                oldest_evidence_days: oldest,
+                newest_evidence_days: newest,
+            });
+        }
+    }
+
+    let n_claims = durable.items.len();
+    let n_stale = stale.len();
+    RecheckReport {
+        n_claims,
+        n_intact: n_claims - n_stale,
+        n_stale,
+        by_defect,
+        stale,
+        age_buckets,
+        n_undated,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crystal::{Citation, CrystalClaim};
+    use crate::units::{Unit, UnitEvidence, UnitStatus};
+
+    const TODAY: (i32, u32, u32) = (2026, 8, 25);
+
+    fn unit(id: &str, quote: &str) -> Unit {
+        Unit {
+            id: id.into(),
+            kind: crate::units::UnitKind::Assertion,
+            subtype: None,
+            text: quote.into(),
+            evidence: UnitEvidence {
+                ref_id: "p001".into(),
+                quote: quote.into(),
+                location: None,
+            },
+            attribution: crate::units::Attribution::Author,
+            modality: crate::units::Modality::Asserted,
+            arguments: Vec::new(),
+            status: UnitStatus::Accepted,
+            issues: Vec::new(),
+        }
+    }
+
+    fn claim(id: &str, case: &str, unit_id: &str, quote: &str) -> CrystalClaim {
+        CrystalClaim {
+            id: id.into(),
+            claim: format!("claim {id}"),
+            theme: String::new(),
+            citations: vec![Citation {
+                case_id: case.into(),
+                unit_id: unit_id.into(),
+                quote: quote.into(),
+                claimed_line: None,
+            }],
+            caveat: None,
+        }
+    }
+
+    #[test]
+    fn age_parses_the_case_id_date_prefix() {
+        assert_eq!(evidence_age_days("2026-08-25_Title-abc123", TODAY), Some(0));
+        assert_eq!(evidence_age_days("2026-08-15_Title-abc123", TODAY), Some(10));
+        assert_eq!(evidence_age_days("2025-08-25_Title-abc123", TODAY), Some(365));
+    }
+
+    #[test]
+    fn age_also_parses_the_hash_prefixed_layout() {
+        // Verbatim from the live ledger. This layout is the MAJORITY there
+        // (4185 of 5182 citations); anchoring on position 0 reported all of
+        // them as undated while the summary still looked healthy.
+        assert_eq!(
+            evidence_age_days("1b16bbab-2026-06-11_Building_a_Good_Vertical_Agent-1b16bbab_", TODAY),
+            Some(75)
+        );
+        assert_eq!(
+            evidence_age_days("1bd54847-2026-04-25_What_is_an_Agent_Harness_", TODAY),
+            Some(122)
+        );
+    }
+
+    #[test]
+    fn a_malformed_case_id_is_undated_not_fresh() {
+        // Silently treating these as day 0 would report the oldest evidence in
+        // the vault as the newest.
+        for id in [
+            "no-date-here",
+            "2026-13-01_Bad",
+            "2026-08-99_Bad",
+            "",
+            "20260825_x",
+            "1969-12-31_TooOld",
+        ] {
+            assert_eq!(evidence_age_days(id, TODAY), None, "{id}");
+        }
+    }
+
+    #[test]
+    fn a_long_digit_run_does_not_masquerade_as_a_date() {
+        // `2026-08-25` embedded in a longer number is not a capture date.
+        assert_eq!(evidence_age_days("12026-08-250_x", TODAY), None);
+    }
+
+    #[test]
+    fn an_intact_claim_is_not_reported_stale() {
+        let mut index = GroundingIndex::new();
+        index.insert("2026-08-01_Case-aaa".into(), vec![unit("u-1", "the quote")]);
+        let cand = CrystalCandidate {
+            items: vec![claim("c1", "2026-08-01_Case-aaa", "u-1", "the quote")],
+        };
+        let r = recheck(&cand, &index, TODAY);
+        assert_eq!((r.n_claims, r.n_stale, r.n_intact), (1, 0, 1));
+        assert!(r.stale.is_empty());
+        assert_eq!(r.age_buckets["0-90d"], 1);
+    }
+
+    #[test]
+    fn a_moved_unit_makes_the_claim_stale_with_its_defect() {
+        // The pack was regenerated and unit ids were renumbered — the classic
+        // way a durable claim quietly stops being backed by its citation.
+        let mut index = GroundingIndex::new();
+        index.insert("2026-08-01_Case-aaa".into(), vec![unit("u-9", "the quote")]);
+        let cand = CrystalCandidate {
+            items: vec![claim("c1", "2026-08-01_Case-aaa", "u-1", "the quote")],
+        };
+        let r = recheck(&cand, &index, TODAY);
+        assert_eq!(r.n_stale, 1);
+        assert_eq!(r.by_defect["unit_not_found"], 1);
+        assert_eq!(r.stale[0].stale_citations[0].defect, CitationDefect::UnitNotFound);
+    }
+
+    #[test]
+    fn an_edited_quote_reads_as_quote_drift_not_a_missing_unit() {
+        let mut index = GroundingIndex::new();
+        index.insert("2026-08-01_Case-aaa".into(), vec![unit("u-1", "a different quote")]);
+        let cand = CrystalCandidate {
+            items: vec![claim("c1", "2026-08-01_Case-aaa", "u-1", "the quote")],
+        };
+        let r = recheck(&cand, &index, TODAY);
+        assert_eq!(r.by_defect["quote_not_in_unit"], 1);
+    }
+
+    #[test]
+    fn one_broken_pack_counts_once_per_claim_not_once_per_citation() {
+        // A rebuilt pack breaks every citation in a claim at once. Tallying per
+        // citation would report one event as many problems and make the defect
+        // histogram useless for telling "packs rebuilt" from "quotes edited".
+        let index = GroundingIndex::new(); // whole case gone
+        let cand = CrystalCandidate {
+            items: vec![CrystalClaim {
+                id: "c1".into(),
+                claim: "c".into(),
+                theme: String::new(),
+                citations: vec![
+                    Citation {
+                        case_id: "2026-08-01_Case-aaa".into(),
+                        unit_id: "u-1".into(),
+                        quote: "q".into(),
+                        claimed_line: None,
+                    },
+                    Citation {
+                        case_id: "2026-08-01_Case-aaa".into(),
+                        unit_id: "u-2".into(),
+                        quote: "q".into(),
+                        claimed_line: None,
+                    },
+                ],
+                caveat: None,
+            }],
+        };
+        let r = recheck(&cand, &index, TODAY);
+        assert_eq!(r.n_stale, 1);
+        assert_eq!(r.by_defect["case_not_found"], 1, "one claim, not two citations");
+        assert_eq!(r.stale[0].stale_citations.len(), 2, "both are still listed");
+    }
+
+    #[test]
+    fn age_uses_the_oldest_citation_and_undated_claims_are_counted_separately() {
+        let mut index = GroundingIndex::new();
+        index.insert("2026-08-01_New-aaa".into(), vec![unit("u-1", "q")]);
+        index.insert("2024-01-01_Old-bbb".into(), vec![unit("u-1", "q")]);
+        index.insert("nodate_Case-ccc".into(), vec![unit("u-1", "q")]);
+        let two_sources = CrystalClaim {
+            id: "c1".into(),
+            claim: "c".into(),
+            theme: String::new(),
+            citations: vec![
+                Citation {
+                    case_id: "2026-08-01_New-aaa".into(),
+                    unit_id: "u-1".into(),
+                    quote: "q".into(),
+                    claimed_line: None,
+                },
+                Citation {
+                    case_id: "2024-01-01_Old-bbb".into(),
+                    unit_id: "u-1".into(),
+                    quote: "q".into(),
+                    claimed_line: None,
+                },
+            ],
+            caveat: None,
+        };
+        let cand = CrystalCandidate {
+            items: vec![two_sources, claim("c2", "nodate_Case-ccc", "u-1", "q")],
+        };
+        let r = recheck(&cand, &index, TODAY);
+        assert_eq!(r.n_stale, 0, "both still ground");
+        // The claim leans on 2024 evidence; reporting it as fresh because one
+        // citation is recent would hide exactly what this axis exists to show.
+        assert_eq!(r.age_buckets["365d+"], 1);
+        assert_eq!(r.n_undated, 1);
+    }
+}

--- a/crates/ovp-domain/src/crystal/recheck.rs
+++ b/crates/ovp-domain/src/crystal/recheck.rs
@@ -116,8 +116,10 @@ pub fn evidence_age_days(case_id: &str, today: (i32, u32, u32)) -> Option<i64> {
     None
 }
 
-/// `YYYY-MM-DD` with real bounds. Deliberately strict: this is the only thing
-/// standing between a typo'd id and a fabricated age.
+/// `YYYY-MM-DD` with real calendar bounds. Deliberately strict: this is the
+/// only thing standing between a typo'd id and a fabricated age, and
+/// `days_from_civil` will happily convert `2026-02-31` into a real number that
+/// nothing downstream can tell apart from a true date.
 fn parse_civil(s: &str) -> Option<(i32, u32, u32)> {
     let bytes = s.as_bytes();
     if bytes.len() != 10 || bytes[4] != b'-' || bytes[7] != b'-' {
@@ -126,10 +128,20 @@ fn parse_civil(s: &str) -> Option<(i32, u32, u32)> {
     let y: i32 = s.get(0..4)?.parse().ok()?;
     let m: u32 = s.get(5..7)?.parse().ok()?;
     let d: u32 = s.get(8..10)?.parse().ok()?;
-    if !(1970..=9999).contains(&y) || !(1..=12).contains(&m) || !(1..=31).contains(&d) {
+    if !(1970..=9999).contains(&y) || !(1..=12).contains(&m) || d < 1 || d > days_in_month(y, m) {
         return None;
     }
     Some((y, m, d))
+}
+
+fn days_in_month(y: i32, m: u32) -> u32 {
+    match m {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if (y % 4 == 0 && y % 100 != 0) || y % 400 == 0 => 29,
+        2 => 28,
+        _ => 0,
+    }
 }
 
 /// Howard Hinnant's `days_from_civil`. Chrono is not a dependency of this
@@ -325,6 +337,23 @@ mod tests {
     fn a_long_digit_run_does_not_masquerade_as_a_date() {
         // `2026-08-25` embedded in a longer number is not a capture date.
         assert_eq!(evidence_age_days("12026-08-250_x", TODAY), None);
+    }
+
+    #[test]
+    fn an_impossible_calendar_date_is_undated() {
+        // `days_from_civil` converts these into perfectly real-looking numbers,
+        // so a day-range check alone would fabricate an age nothing downstream
+        // could tell apart from a true one.
+        for id in [
+            "2026-02-31_Bad",
+            "2025-02-29_NotALeapYear",
+            "2026-04-31_Bad",
+            "2026-06-31_Bad",
+        ] {
+            assert_eq!(evidence_age_days(id, TODAY), None, "{id}");
+        }
+        // Real leap day still parses.
+        assert!(evidence_age_days("2024-02-29_Good", TODAY).is_some());
     }
 
     #[test]


### PR DESCRIPTION
## The gap

The pre-write gate proves a claim's citations ground **the day it is written**, and then nothing ever asks again. The ledger is append-only and `lint_candidate` only runs on candidates, so a durable claim whose supporting unit later moved — pack regenerated, prompt version bumped, source re-processed — keeps asserting itself with a citation that no longer resolves. Nothing errors. The claim just quietly stops being backed by what it says backs it.

`doctor`'s existing `crystal-integrity` check only proves the ledger *parses*.

## What this adds

`ovp2 crystal-recheck` rebuilds what the vault currently asserts from the durable ledger and re-runs the **same** `lint_candidate` against the **current** reader packs. The four existing `CitationDefect` codes already describe every way a citation can come loose, so this adds no new vocabulary — only the missing habit of asking again.

**Read-only, deliberately.** A stale claim is not a wrong claim; it is one whose evidence can no longer be assumed without looking. Rewriting it is a consolidation write and belongs behind the same gate and the same human as any other durable write.

**Second axis: evidence age**, free from data already on disk. A citation can still ground verbatim while the world it describes has moved on, and `case_id` already carries the capture date — no refetch, no new field.

Plus a `crystal-staleness` check in `doctor`, sharing one `recheck_vault` so the check and the command cannot drift into disagreeing. WARN, never FAIL: gating on it would make a routine pack rebuild read as corruption.

## On the live vault

```
1229 durable claims — 1229 intact, 0 stale
evidence age (oldest citation per claim): 0-90d=190 91-180d=982 181-365d=45 365d+=0
undated evidence: 12 claim(s)
```

Both halves are the signal. Zero stale says the append-only + gate design held. **982 of 1229 leaning on 3-6 month old evidence** is the thing we could not see before.

## Two bugs the live data caught that tests would not have

- **First cut anchored the date at position 0 → 891 of 1229 reported undated.** The vault has two pack-name layouts (`<date>_<title>` and `<hash8>-<date>_<title>`) and the second is the majority. Scanning for the first well-formed date anywhere takes it to 12 — those are genuinely dateless (`<hash8>-<title>`) and are counted as undated rather than given a fabricated age.
- **0 stale means the detection path never executed on real data.** Fault-injected end to end with half the packs hidden: 1004 stale, all `case_not_found`, partial per-claim grounding reported honestly ("1/4 citations ground"). An empty packs dir fails loudly at the index builder rather than declaring the whole ledger stale.

## Codex gate: FAIL then fixed

- **[P1] Hand-rolled ledger parsing.** I read raw `op` strings and kept the latest `write` per key. The ledger has three ops — `Supersede` also flips its predecessor, `Retract` marks a record retracted — and `fold_ledger` in ovp-domain already implements all of it. The recheck would have rechecked retracted claims as live and missed their replacements. Today's vault holds only `write` records so both versions agree on it; that is luck, not correctness, and it is exactly the bug shape that survives review.
- **[P2] `filter_map` silently dropped malformed citations** — and since staleness is measured from citation *defects*, a claim that lost every citation reported as **intact**. Typed deserialization refuses the record instead. Fixed by the same change.
- **[P2] `2026-02-31` and non-leap `2025-02-29` were accepted**, and `days_from_civil` turns those into real-looking numbers. Month lengths and leap years now checked.
- **[P2] `doctor` reported every recheck failure as INFO**, retiring the signal on a vault with unreadable packs. Only an absent store is INFO now.

Defects are counted once per claim, not once per citation: a rebuilt pack breaks every citation in a claim at once, and a citation-level tally would report one event as many problems and make the histogram useless for telling "packs rebuilt" from "quotes edited".

## Scope

Report only. No portal surface yet, no repair path, no refetch. Whether to act on the age distribution is a separate decision.
