### PR TITLE
fix(scheduler): quarantine a broken job instead of stopping every job

### DIFF
--- a/console-ui/src/components/AutomationPanel.tsx
+++ b/console-ui/src/components/AutomationPanel.tsx
@@ -547,8 +547,10 @@ export default function AutomationPanel() {
             {t('auto.quarantined')}
           </p>
           <ul className="sm" style={{ margin: '0.4rem 0 0', paddingInlineStart: '1.1rem' }}>
-            {data.rejected!.map((r) => (
-              <li key={r.id}>
+            {/* id is NOT unique here: a registry with three jobs sharing an
+                id quarantines two of them, both reported under that same id. */}
+            {data.rejected!.map((r, i) => (
+              <li key={`${r.id}-${i}`}>
                 <code>{r.id}</code> — {r.reason}
               </li>
             ))}

--- a/console-ui/src/components/AutomationPanel.tsx
+++ b/console-ui/src/components/AutomationPanel.tsx
@@ -531,7 +531,30 @@ export default function AutomationPanel() {
       {data && data.present && data.jobs.length === 0 && (
         <div className="card">
           <p className="sm" style={{ margin: 0 }}>
-            {t('auto.empty')}
+            {/* An all-quarantined registry is NOT an empty one. Saying "no jobs
+                configured" there sends the operator looking for a config that
+                exists and is broken. */}
+            {(data.rejected?.length ?? 0) > 0
+              ? t('auto.allQuarantined')
+              : t('auto.empty')}
+          </p>
+        </div>
+      )}
+
+      {data && (data.rejected?.length ?? 0) > 0 && (
+        <div className="card">
+          <p className="sm warn" style={{ margin: 0, fontWeight: 600 }}>
+            {t('auto.quarantined')}
+          </p>
+          <ul className="sm" style={{ margin: '0.4rem 0 0', paddingInlineStart: '1.1rem' }}>
+            {data.rejected!.map((r) => (
+              <li key={r.id}>
+                <code>{r.id}</code> — {r.reason}
+              </li>
+            ))}
+          </ul>
+          <p className="sm muted" style={{ marginBottom: 0 }}>
+            {t('auto.quarantinedHelp', { path: data.registry_rel })}
           </p>
         </div>
       )}

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -655,6 +655,9 @@ export const en = {
   'auto.missing':
     'No schedule registry yet ({path}). Opening the desktop app seeds defaults (daily + weekly crystallize), or run `ovp2 schedule init`.',
   'auto.empty': 'Schedule registry is empty — no jobs configured.',
+  'auto.quarantined': 'Quarantined — will not run until fixed',
+  'auto.quarantinedHelp': 'These jobs are still in {path}. The scheduler skipped them and ran everything else.',
+  'auto.allQuarantined': 'Every configured job is quarantined — nothing is scheduled to run.',
   'auto.configHint': 'Source of truth: vault {path}. Historical volume:',
   'auto.flowLink': 'Pipeline flow →',
   'auto.cadence': 'When',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -621,6 +621,9 @@ export const zh: Record<keyof typeof en, string> = {
   'auto.missing':
     '还没有定时注册表（{path}）。打开桌面 App 会写入默认任务（每日 + 每周结晶），或运行 `ovp2 schedule init`。',
   'auto.empty': '定时注册表为空——没有配置任务。',
+  'auto.quarantined': '已隔离——修好前不会运行',
+  'auto.quarantinedHelp': '这些任务仍在 {path} 里。调度器跳过了它们,其余任务照常运行。',
+  'auto.allQuarantined': '所有已配置的任务都被隔离了——当前没有任何任务会运行。',
   'auto.configHint': '配置真相源：vault 的 {path}。历史流量：',
   'auto.flowLink': '管线 Flow →',
   'auto.cadence': '何时',

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -187,10 +187,18 @@ export interface ScheduleJob {
   due: boolean;
   features: ScheduleJobFeatures;
 }
+/** A job the scheduler refused to load, and why. Quarantined, not deleted:
+ *  it is still in `schedule.json` and will run again once the reason is fixed. */
+export interface RejectedScheduleJob {
+  id: string;
+  reason: string;
+}
 export interface SchedulePayload {
   present: boolean;
   registry_rel: string;
   jobs: ScheduleJob[];
+  /** Absent on servers older than the per-job quarantine change. */
+  rejected?: RejectedScheduleJob[];
 }
 export function fetchSchedule(): Promise<SchedulePayload> {
   return fetchJson<SchedulePayload>('/api/schedule');

--- a/crates/ovp-cli/src/commands/schedule.rs
+++ b/crates/ovp-cli/src/commands/schedule.rs
@@ -1506,18 +1506,24 @@ fn status_with(
     let reg_path = super::scheduler::registry_path(&meta.vault_root);
     println!("  registry:  {}", reg_path.display());
     match registry {
-        Ok(Some(reg)) => match super::scheduler::load_state(&meta.vault_root) {
-            Ok(state) => {
-                // status is the diagnostic command — a quarantined job going
-                // unmentioned HERE is exactly the silence this change exists
-                // to remove.
-                super::scheduler::report_rejected(&reg.rejected);
-                super::scheduler::print_jobs(&reg.registry, &state, super::scheduler::local_now(), "  ")
+        Ok(Some(reg)) => {
+            // BEFORE the state read, not inside its Ok arm: a malformed
+            // schedule-state.json takes the Err branch, and quarantined jobs
+            // would go unmentioned exactly when BOTH files need repair —
+            // which is when the operator most needs to see them.
+            super::scheduler::report_rejected(&reg.rejected);
+            match super::scheduler::load_state(&meta.vault_root) {
+                Ok(state) => super::scheduler::print_jobs(
+                    &reg.registry,
+                    &state,
+                    super::scheduler::local_now(),
+                    "  ",
+                ),
+                // A malformed state file blocks `tick`, so surface it rather
+                // than silently showing every job as never-run/due-now.
+                Err(e) => println!("             WARN: cannot read schedule state: {e}"),
             }
-            // A malformed state file blocks `tick`, so surface it rather than
-            // silently showing every job as never-run/due-now (codex P2).
-            Err(e) => println!("             WARN: cannot read schedule state: {e}"),
-        },
+        }
         Ok(None) => println!("             MISSING — re-run `ovp2 schedule install`"),
         Err(e) => println!("             WARN: cannot read registry: {e}"),
     }

--- a/crates/ovp-cli/src/commands/schedule.rs
+++ b/crates/ovp-cli/src/commands/schedule.rs
@@ -932,7 +932,8 @@ fn ensure_registry(cfg: &ScheduleConfig, reconcile: bool) -> Result<RegistryOutc
         // deleting it; a deleted built-in is restored disabled? No — it is
         // restored as the default ships it; disable it again if unwanted.
         let mut reg = super::scheduler::load_registry(&cfg.vault_root)?
-            .expect("registry_path exists but load returned None");
+            .expect("registry_path exists but load returned None")
+        .as_written;
         let mut inserted = false;
         for (pos, fresh_job) in fresh.jobs.iter().enumerate() {
             if reg.get(&fresh_job.id).is_none() {
@@ -948,7 +949,8 @@ fn ensure_registry(cfg: &ScheduleConfig, reconcile: bool) -> Result<RegistryOutc
         return Ok(RegistryOutcome::Unchanged);
     }
     let mut reg = super::scheduler::load_registry(&cfg.vault_root)?
-        .expect("registry_path exists but load returned None");
+        .expect("registry_path exists but load returned None")
+        .as_written;
     let before = reg.clone();
     reg.env_file = fresh.env_file.clone();
     // Overwrite each built-in job's config from the flags, but preserve the
@@ -1486,8 +1488,9 @@ fn status_with(
         // when omitted — so status never reports a file the ticks don't source
         // (codex P2). Only fall back to the install-time metadata when the
         // registry itself can't be read.
-        Ok(Some(reg)) => {
-            let raw = reg
+        Ok(Some(loaded)) => {
+            let raw = loaded
+                .registry
                 .env_file
                 .clone()
                 .unwrap_or_else(|| format!("{}/.ovp/daily.env", super::scheduler::VAULT_PLACEHOLDER));
@@ -1505,7 +1508,7 @@ fn status_with(
     match registry {
         Ok(Some(reg)) => match super::scheduler::load_state(&meta.vault_root) {
             Ok(state) => {
-                super::scheduler::print_jobs(&reg, &state, super::scheduler::local_now(), "  ")
+                super::scheduler::print_jobs(&reg.registry, &state, super::scheduler::local_now(), "  ")
             }
             // A malformed state file blocks `tick`, so surface it rather than
             // silently showing every job as never-run/due-now (codex P2).
@@ -1645,7 +1648,8 @@ mod tests {
         assert_eq!(ensure_registry(&c, false).unwrap(), RegistryOutcome::Seeded);
 
         // Operator edits the daily job the way the portal/CLI allows.
-        let mut reg = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap();
+        let mut reg = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap()
+            .as_written;
         let daily = reg.get_mut("daily").unwrap();
         daily.cadence = "every 4h".into();
         daily.argv.push("--max-sources".into());
@@ -1657,13 +1661,15 @@ mod tests {
         for _ in 0..3 {
             assert_eq!(ensure_registry(&c, false).unwrap(), RegistryOutcome::Unchanged);
         }
-        let after = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap();
+        let after = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap()
+            .as_written;
         assert_eq!(after, edited, "init must leave an edited registry alone");
 
         // install still reconciles — it carries the operator's flags, so
         // re-running it IS how you change the built-in job.
         assert_eq!(ensure_registry(&c, true).unwrap(), RegistryOutcome::Reconciled);
-        let reconciled = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap();
+        let reconciled = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap()
+            .as_written;
         assert_eq!(reconciled.get("daily").unwrap().cadence, "daily 09:00");
     }
 
@@ -1677,14 +1683,16 @@ mod tests {
 
         // Model an upgrade: a registry from before the `themes` built-in,
         // carrying operator edits that must survive the migration.
-        let mut reg = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap();
+        let mut reg = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap()
+            .as_written;
         reg.jobs.retain(|j| j.id != "themes");
         let daily = reg.get_mut("daily").unwrap();
         daily.cadence = "every 4h".into();
         super::super::scheduler::save_registry(dir.path(), &reg).unwrap();
 
         assert_eq!(ensure_registry(&c, false).unwrap(), RegistryOutcome::Migrated);
-        let after = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap();
+        let after = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap()
+            .as_written;
         // Inserted at its default position: BEFORE crystallize (registry
         // order is catch-up execution order — themes must re-cluster first).
         let ids: Vec<&str> = after.jobs.iter().map(|j| j.id.as_str()).collect();
@@ -1696,11 +1704,13 @@ mod tests {
 
         // Reinstall (reconcile) restores a missing built-in at its default
         // position too — never appended after crystallize.
-        let mut reg = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap();
+        let mut reg = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap()
+            .as_written;
         reg.jobs.retain(|j| j.id != "themes");
         super::super::scheduler::save_registry(dir.path(), &reg).unwrap();
         assert_eq!(ensure_registry(&c, true).unwrap(), RegistryOutcome::Reconciled);
-        let after = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap();
+        let after = super::super::scheduler::load_registry(dir.path()).unwrap().unwrap()
+            .as_written;
         let ids: Vec<&str> = after.jobs.iter().map(|j| j.id.as_str()).collect();
         assert_eq!(ids, vec!["daily", "themes", "crystallize"]);
     }
@@ -2353,7 +2363,8 @@ mod tests {
         let reg_path = super::super::scheduler::registry_path(vault.path());
         let mut reg = super::super::scheduler::load_registry(vault.path())
             .unwrap()
-            .unwrap();
+            .unwrap()
+            .as_written;
         reg.get_mut("crystallize").unwrap().enabled = false;
         // Operator also moved crystallize to a different weekly slot.
         reg.get_mut("crystallize").unwrap().cadence = "weekly Wed 03:00".into();
@@ -2371,7 +2382,8 @@ mod tests {
         );
         let reg2 = super::super::scheduler::load_registry(vault.path())
             .unwrap()
-            .unwrap();
+            .unwrap()
+            .as_written;
         // The daily cadence now reflects the new --time flag...
         assert_eq!(reg2.get("daily").unwrap().cadence, "daily 21:00");
         // ...but operator-owned fields survive: crystallize's enable state AND
@@ -2396,7 +2408,8 @@ mod tests {
         // Operator disables a job.
         let mut reg = super::super::scheduler::load_registry(vault.path())
             .unwrap()
-            .unwrap();
+            .unwrap()
+            .as_written;
         reg.get_mut("crystallize").unwrap().enabled = false;
         super::super::scheduler::save_registry(vault.path(), &reg).unwrap();
 
@@ -2407,7 +2420,8 @@ mod tests {
         assert_eq!(report.registry, RegistryOutcome::Reconciled);
         let reg2 = super::super::scheduler::load_registry(vault.path())
             .unwrap()
-            .unwrap();
+            .unwrap()
+            .as_written;
         // env file reconciled...
         assert_eq!(
             reg2.env_file.as_deref(),

--- a/crates/ovp-cli/src/commands/schedule.rs
+++ b/crates/ovp-cli/src/commands/schedule.rs
@@ -1508,6 +1508,10 @@ fn status_with(
     match registry {
         Ok(Some(reg)) => match super::scheduler::load_state(&meta.vault_root) {
             Ok(state) => {
+                // status is the diagnostic command — a quarantined job going
+                // unmentioned HERE is exactly the silence this change exists
+                // to remove.
+                super::scheduler::report_rejected(&reg.rejected);
                 super::scheduler::print_jobs(&reg.registry, &state, super::scheduler::local_now(), "  ")
             }
             // A malformed state file blocks `tick`, so surface it rather than

--- a/crates/ovp-cli/src/commands/scheduler.rs
+++ b/crates/ovp-cli/src/commands/scheduler.rs
@@ -11,6 +11,7 @@ use ovp_scheduler::{JobConfig, JobRunner, plan_tick, run_now_with};
 // Re-export the engine items the sibling `schedule` module (installer) and the
 // CLI dispatch reference, so call sites keep using `commands::scheduler::…`.
 pub use ovp_scheduler::{
+    LoadedRegistry, RejectedJob,
     Cadence, Registry, State, VAULT_PLACEHOLDER, default_registry, is_due, registry_path,
     resolve_vault,
 };
@@ -22,7 +23,7 @@ use crate::CliError;
 
 // -- persistence, error-mapped into CliError --------------------------------
 
-pub fn load_registry(vault_root: &Path) -> Result<Option<Registry>, CliError> {
+pub fn load_registry(vault_root: &Path) -> Result<Option<LoadedRegistry>, CliError> {
     ovp_scheduler::load_registry(vault_root).map_err(CliError::Io)
 }
 pub fn save_registry(vault_root: &Path, reg: &Registry) -> Result<(), CliError> {
@@ -227,6 +228,24 @@ fn missing_registry_err(vault_root: &Path) -> CliError {
     ))
 }
 
+/// Print quarantined jobs. Loud on stdout AND stderr: the desktop scheduler
+/// only forwards a child's stderr to `eprintln`, which Finder swallows, so a
+/// stderr-only warning is invisible to exactly the operator who needs it.
+fn report_rejected(rejected: &[RejectedJob]) {
+    if rejected.is_empty() {
+        return;
+    }
+    println!(
+        "scheduler: {} job(s) QUARANTINED — they will not run until fixed:",
+        rejected.len()
+    );
+    for r in rejected {
+        println!("  - {}: {}", r.id, r.reason);
+        eprintln!("scheduler: job '{}' quarantined: {}", r.id, r.reason);
+    }
+    println!("  (the remaining jobs still run; edit .ovp/schedule.json to fix)");
+}
+
 /// Give every registry job a state entry it lacks, so a job with no recorded
 /// run first fires at its NEXT occurrence, not immediately on the first tick (an
 /// unseeded job has no last-run, so `is_due` treats every past occurrence as
@@ -237,7 +256,7 @@ fn missing_registry_err(vault_root: &Path) -> CliError {
 /// over a malformed state file fails loud rather than installing a timer whose
 /// every tick would then error (codex P2).
 pub fn seed_missing_state(vault_root: &Path) -> Result<(), CliError> {
-    let Some(reg) = load_registry(vault_root)? else {
+    let Some(reg) = load_registry(vault_root)?.map(|l| l.registry) else {
         return Ok(());
     };
     let mut state = load_state(vault_root)?; // validates an existing file
@@ -259,7 +278,10 @@ pub fn seed_missing_state(vault_root: &Path) -> Result<(), CliError> {
 /// hint and returns `None` instead of erroring when nothing is installed.
 fn require_registry(vault_root: &Path) -> Result<Option<Registry>, CliError> {
     match load_registry(vault_root)? {
-        Some(reg) => Ok(Some(reg)),
+        Some(loaded) => {
+            report_rejected(&loaded.rejected);
+            Ok(Some(loaded.registry))
+        }
         None => {
             println!(
                 "scheduler: no registry at {} — run `ovp2 schedule install --vault-root {}`",
@@ -319,12 +341,18 @@ pub fn run_tick(vault_root: &Path) -> Result<(), CliError> {
     // can't slip an edit between the read and the launch. Held across the whole
     // dispatch so a concurrent tick/run-now can't double-spawn a job.
     let _lock = acquire_dispatch_lock(vault_root)?;
-    let Some(reg) = load_registry(vault_root)? else {
+    let Some(loaded) = load_registry(vault_root)? else {
         return Err(CliError::Io(format!(
             "scheduler tick: no registry at {} — run `ovp2 schedule install`",
             registry_path(vault_root).display()
         )));
     };
+    // A broken job must not take the healthy ones down with it: report it and
+    // dispatch the rest. This is the failure CLAUDE.md calls the most expensive
+    // one in the repo — a cadence the installed binary does not understand used
+    // to stop EVERY job, and from the GUI it looked like nothing happening.
+    report_rejected(&loaded.rejected);
+    let reg = loaded.registry;
     let mut state = load_state(vault_root)?;
     let runner = shell_runner(vault_root, &reg)?;
     let now = local_now();
@@ -384,7 +412,9 @@ pub fn run_run_now(
     // A mutating command must FAIL on a missing registry, not exit 0, so a
     // script/desktop client can't record false success.
     let _lock = acquire_dispatch_lock(vault_root)?;
-    let reg = load_registry(vault_root)?.ok_or_else(|| missing_registry_err(vault_root))?;
+    let loaded = load_registry(vault_root)?.ok_or_else(|| missing_registry_err(vault_root))?;
+    report_rejected(&loaded.rejected);
+    let reg = loaded.registry;
     let state = load_state(vault_root)?;
     // Recency skip UNDER the dispatch lock: if a tick (or another trigger)
     // dispatched this job moments ago, a forced re-run is a duplicate, not
@@ -420,7 +450,11 @@ pub fn run_set_enabled(vault_root: &Path, id: &str, enabled: bool) -> Result<(),
     // can't act on a stale snapshot and two enable/disable calls can't lose an
     // update. Missing registry is an error for this mutator.
     let _lock = acquire_dispatch_lock(vault_root)?;
-    let mut reg = load_registry(vault_root)?.ok_or_else(|| missing_registry_err(vault_root))?;
+    // as_written, NOT registry: saving the filtered view would delete a
+    // quarantined job as a side effect of an unrelated edit.
+    let mut reg = load_registry(vault_root)?
+        .ok_or_else(|| missing_registry_err(vault_root))?
+        .as_written;
     let job = reg
         .get_mut(id)
         .ok_or_else(|| CliError::Io(format!("no job '{id}' in the registry")))?;

--- a/crates/ovp-cli/src/commands/scheduler.rs
+++ b/crates/ovp-cli/src/commands/scheduler.rs
@@ -231,7 +231,7 @@ fn missing_registry_err(vault_root: &Path) -> CliError {
 /// Print quarantined jobs. Loud on stdout AND stderr: the desktop scheduler
 /// only forwards a child's stderr to `eprintln`, which Finder swallows, so a
 /// stderr-only warning is invisible to exactly the operator who needs it.
-fn report_rejected(rejected: &[RejectedJob]) {
+pub fn report_rejected(rejected: &[RejectedJob]) {
     if rejected.is_empty() {
         return;
     }

--- a/crates/ovp-scheduler/src/lib.rs
+++ b/crates/ovp-scheduler/src/lib.rs
@@ -314,17 +314,78 @@ impl Registry {
 
     /// Validate every cadence up front so a hand-edited typo fails loud at load
     /// rather than silently skipping a job at tick time.
+    ///
+    /// Whole-registry verdict, kept for callers that genuinely need "is every
+    /// job usable". Loading uses [`Registry::partition`] instead — see there
+    /// for why an all-or-nothing answer is the wrong shape at load time.
     pub fn validate(&self) -> Result<(), String> {
-        let mut seen = std::collections::BTreeSet::new();
-        for job in &self.jobs {
-            if !seen.insert(job.id.as_str()) {
-                return Err(format!("duplicate job id '{}'", job.id));
-            }
-            job.parsed_cadence()
-                .map_err(|e| format!("job '{}': {e}", job.id))?;
+        let (_, rejected) = self.clone().partition();
+        match rejected.first() {
+            Some(r) => Err(format!("job '{}': {}", r.id, r.reason)),
+            None => Ok(()),
         }
-        Ok(())
     }
+
+    /// Split into the jobs that can run and the ones that cannot.
+    ///
+    /// A single unparseable cadence used to fail the whole load, which meant
+    /// `schedule list` and `tick` exited non-zero and **every** job stopped —
+    /// not just the broken one. Worse, the desktop app writes a tick's stderr
+    /// to `eprintln` only, so from the GUI that looked like nothing happening
+    /// at all. The usual way in is a `schedule.json` edited to a cadence syntax
+    /// the installed binary does not know yet, which is a routine ordering
+    /// mistake, not corruption.
+    ///
+    /// So quarantine per job: the healthy ones keep running and the broken ones
+    /// are reported by id and reason. A duplicate id keeps the FIRST occurrence
+    /// — that is what `get()` already resolves to, so quarantining the later
+    /// one matches the behaviour the rest of the code already has.
+    pub fn partition(mut self) -> (Registry, Vec<RejectedJob>) {
+        let mut seen = std::collections::BTreeSet::new();
+        let mut kept = Vec::new();
+        let mut rejected = Vec::new();
+        for job in std::mem::take(&mut self.jobs) {
+            if !seen.insert(job.id.clone()) {
+                rejected.push(RejectedJob {
+                    id: job.id,
+                    reason: "duplicate job id (the first one is used)".to_string(),
+                });
+                continue;
+            }
+            match job.parsed_cadence() {
+                Ok(_) => kept.push(job),
+                Err(e) => rejected.push(RejectedJob { id: job.id, reason: e }),
+            }
+        }
+        // `..self` rather than restating fields: a field added later must be
+        // carried through automatically, not silently reset to its default.
+        (Registry { jobs: kept, ..self }, rejected)
+    }
+}
+
+/// A job the registry could not use, and why. Reported, never silently dropped:
+/// a job missing from `schedule list` with no explanation is indistinguishable
+/// from one that was never configured.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RejectedJob {
+    pub id: String,
+    pub reason: String,
+}
+
+/// A loaded registry plus whatever could not be used.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoadedRegistry {
+    /// Only the jobs that can actually run. Dispatch reads THIS.
+    pub registry: Registry,
+    pub rejected: Vec<RejectedJob>,
+    /// The registry exactly as it sits on disk, quarantined jobs included.
+    ///
+    /// Edit-and-save paths (`schedule disable`, `set-cadence`, install
+    /// migration) must go through this, never through `registry`: saving the
+    /// filtered view would DELETE the operator's broken job definition as a
+    /// side effect of an unrelated edit. Quarantine hides a job from the
+    /// dispatcher; it must never erase it from the file.
+    pub as_written: Registry,
 }
 
 /// The built-in default registry seeded on install: a daily reader run and a
@@ -532,7 +593,13 @@ pub fn state_path(vault_root: &Path) -> PathBuf {
     vault_root.join(STATE_REL)
 }
 
-pub fn load_registry(vault_root: &Path) -> Result<Option<Registry>, String> {
+/// Load the registry, quarantining individual unusable jobs.
+///
+/// Still `Err` when the FILE is the problem (missing read permission,
+/// unparseable JSON) — that is genuinely all-or-nothing and there is no
+/// partial registry to salvage. A bad cadence inside an otherwise valid file
+/// is not: it takes down one job, and everything else must keep running.
+pub fn load_registry(vault_root: &Path) -> Result<Option<LoadedRegistry>, String> {
     let path = registry_path(vault_root);
     if !path.exists() {
         return Ok(None);
@@ -541,8 +608,13 @@ pub fn load_registry(vault_root: &Path) -> Result<Option<Registry>, String> {
         std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
     let reg: Registry =
         serde_json::from_str(&text).map_err(|e| format!("parse {}: {e}", path.display()))?;
-    reg.validate()?;
-    Ok(Some(reg))
+    let as_written = reg.clone();
+    let (registry, rejected) = reg.partition();
+    Ok(Some(LoadedRegistry {
+        registry,
+        rejected,
+        as_written,
+    }))
 }
 
 pub fn save_registry(vault_root: &Path, reg: &Registry) -> Result<(), String> {
@@ -671,6 +743,10 @@ pub struct TickPlan {
     pub skipped_not_due: Vec<String>,
     /// Job ids skipped because disabled.
     pub skipped_disabled: Vec<String>,
+    /// Job ids skipped because their cadence does not parse — broken, not
+    /// waiting. Kept apart from `skipped_not_due` so a job that will NEVER run
+    /// cannot read as one that simply is not due yet.
+    pub skipped_invalid: Vec<String>,
 }
 
 pub fn plan_tick(reg: &Registry, state: &State, now: NaiveDateTime) -> TickPlan {
@@ -680,10 +756,12 @@ pub fn plan_tick(reg: &Registry, state: &State, now: NaiveDateTime) -> TickPlan 
             plan.skipped_disabled.push(job.id.clone());
             continue;
         }
-        // A cadence that fails to parse was rejected at load; stay defensive and
-        // skip rather than panic in the dispatcher.
+        // A cadence that fails to parse is quarantined at load, but stay
+        // defensive here for a registry built in memory. Its own bucket, NOT
+        // `skipped_not_due`: "not due" reads as "fine, just not time yet",
+        // while the truth is the job is broken and will never run.
         let Ok(cadence) = job.parsed_cadence() else {
-            plan.skipped_not_due.push(job.id.clone());
+            plan.skipped_invalid.push(job.id.clone());
             continue;
         };
         if is_due(cadence, state.last_run_of(&job.id), now) {
@@ -1050,7 +1128,7 @@ mod tests {
         assert!(load_registry(v).unwrap().is_none());
         let reg = default_registry("live", (9, 0), false, None);
         save_registry(v, &reg).unwrap();
-        assert_eq!(load_registry(v).unwrap().unwrap(), reg);
+        assert_eq!(load_registry(v).unwrap().unwrap().as_written, reg);
         let mut state = State::default();
         state.record("daily", dt("2026-07-12T09:05:00"), "ok");
         save_state(v, &state).unwrap();
@@ -1252,6 +1330,114 @@ mod tests {
         assert_eq!(*runner.ran.borrow(), vec!["crystallize".to_string()]);
         assert!(new_state.runs.contains_key("crystallize"));
         assert!(run_now_with(&reg, &State::default(), "nope", now, &runner).is_err());
+    }
+
+    /// Write a registry file whose second job has a cadence this binary cannot
+    /// parse — the exact shape of the failure CLAUDE.md documents (schedule.json
+    /// edited to a syntax newer than the installed binary).
+    fn registry_with_one_bad_cadence(v: &Path) {
+        std::fs::create_dir_all(v.join(".ovp")).unwrap();
+        let raw = r#"{
+          "version": 1,
+          "jobs": [
+            {"id":"daily","cadence":"daily 09:00","argv":["daily"],"enabled":true,"description":"d"},
+            {"id":"future","cadence":"every 3rd tuesday","argv":["x"],"enabled":true,"description":"f"},
+            {"id":"themes","cadence":"weekly Sun 08:00","argv":["themes"],"enabled":true,"description":"t"}
+          ]
+        }"#;
+        std::fs::write(v.join(REGISTRY_REL), raw).unwrap();
+    }
+
+    #[test]
+    fn one_unparseable_cadence_does_not_stop_the_other_jobs() {
+        // The whole point. This used to make load_registry return Err, which
+        // made `schedule list` and `tick` exit non-zero — every job stopped,
+        // not just the broken one, and from the GUI it looked like nothing
+        // happening at all.
+        let dir = tempfile::tempdir().unwrap();
+        registry_with_one_bad_cadence(dir.path());
+
+        let loaded = load_registry(dir.path()).unwrap().unwrap();
+        let ids: Vec<&str> = loaded.registry.jobs.iter().map(|j| j.id.as_str()).collect();
+        assert_eq!(ids, vec!["daily", "themes"], "healthy jobs survive");
+        assert_eq!(loaded.rejected.len(), 1);
+        assert_eq!(loaded.rejected[0].id, "future");
+        assert!(
+            loaded.rejected[0].reason.contains("invalid cadence"),
+            "the reason must name the problem: {}",
+            loaded.rejected[0].reason
+        );
+    }
+
+    #[test]
+    fn a_quarantined_job_is_kept_in_the_file_not_deleted() {
+        // Quarantine hides a job from the dispatcher. If an unrelated edit
+        // (`schedule disable`) then saved the FILTERED view, the operator's
+        // broken definition would be erased instead of fixed — a worse
+        // outcome than the bug this whole change exists to fix.
+        let dir = tempfile::tempdir().unwrap();
+        registry_with_one_bad_cadence(dir.path());
+
+        let loaded = load_registry(dir.path()).unwrap().unwrap();
+        let mut edited = loaded.as_written;
+        assert_eq!(edited.jobs.len(), 3, "as_written keeps the broken job");
+        edited.get_mut("daily").unwrap().enabled = false;
+        save_registry(dir.path(), &edited).unwrap();
+
+        let after = load_registry(dir.path()).unwrap().unwrap();
+        assert_eq!(after.as_written.jobs.len(), 3, "still three on disk");
+        assert_eq!(after.rejected.len(), 1, "still quarantined, still present");
+    }
+
+    #[test]
+    fn a_broken_job_is_reported_as_invalid_not_as_not_due() {
+        // "not due" reads as "fine, just not time yet". A job that will NEVER
+        // run must not hide in that bucket.
+        let mut reg = default_jobs_registry();
+        reg.jobs.push(JobConfig {
+            id: "broken".into(),
+            cadence: "every 3rd tuesday".into(),
+            argv: vec!["x".into()],
+            enabled: true,
+            description: "b".into(),
+            ..reg.jobs[0].clone()
+        });
+        let plan = plan_tick(&reg, &State::default(), dt("2026-07-12T09:30:00"));
+        assert_eq!(plan.skipped_invalid, vec!["broken".to_string()]);
+        assert!(!plan.skipped_not_due.contains(&"broken".to_string()));
+    }
+
+    #[test]
+    fn a_duplicate_id_quarantines_the_later_copy_and_keeps_the_first() {
+        // `get()` already resolves to the first occurrence, so quarantining the
+        // later one matches the behaviour the rest of the code already has.
+        let dir = tempfile::tempdir().unwrap();
+        let v = dir.path();
+        std::fs::create_dir_all(v.join(".ovp")).unwrap();
+        std::fs::write(
+            v.join(REGISTRY_REL),
+            r#"{"version":1,"jobs":[
+              {"id":"daily","cadence":"daily 09:00","argv":["first"],"enabled":true,"description":"a"},
+              {"id":"daily","cadence":"daily 10:00","argv":["second"],"enabled":true,"description":"b"}
+            ]}"#,
+        )
+        .unwrap();
+        let loaded = load_registry(v).unwrap().unwrap();
+        assert_eq!(loaded.registry.jobs.len(), 1);
+        assert_eq!(loaded.registry.jobs[0].argv, vec!["first".to_string()]);
+        assert_eq!(loaded.rejected.len(), 1);
+        assert!(loaded.rejected[0].reason.contains("duplicate"));
+    }
+
+    #[test]
+    fn a_file_level_problem_is_still_fatal() {
+        // Per-job quarantine must not swallow a genuinely unusable FILE —
+        // there is no partial registry to salvage from unparseable JSON.
+        let dir = tempfile::tempdir().unwrap();
+        let v = dir.path();
+        std::fs::create_dir_all(v.join(".ovp")).unwrap();
+        std::fs::write(v.join(REGISTRY_REL), "{not json").unwrap();
+        assert!(load_registry(v).is_err());
     }
 
     #[test]

--- a/crates/ovp-scheduler/src/lib.rs
+++ b/crates/ovp-scheduler/src/lib.rs
@@ -779,6 +779,10 @@ pub struct TickReport {
     pub ran: Vec<(String, bool)>,
     pub skipped_not_due: Vec<String>,
     pub skipped_disabled: Vec<String>,
+    /// Jobs whose cadence does not parse. Carried through rather than dropped
+    /// at this boundary: an embedder that only sees `ran` + the two benign skip
+    /// buckets cannot tell a broken job from an idle one.
+    pub skipped_invalid: Vec<String>,
 }
 
 /// In-memory tick (no persistence): run every due job via `runner` and return
@@ -796,6 +800,7 @@ pub fn tick_with(
     let mut report = TickReport {
         skipped_not_due: plan.skipped_not_due,
         skipped_disabled: plan.skipped_disabled,
+        skipped_invalid: plan.skipped_invalid,
         ..Default::default()
     };
     for id in &plan.due {

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -2005,7 +2005,15 @@ fn handle_schedule(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
         }
     };
     match ovp_scheduler::load_registry(&state.vault_root) {
-        Ok(Some(reg)) => {
+        Ok(Some(loaded)) => {
+            // Quarantined jobs ride along so the portal can show them red
+            // instead of leaving an operator wondering where a job went.
+            let rejected: Vec<serde_json::Value> = loaded
+                .rejected
+                .iter()
+                .map(|r| serde_json::json!({ "id": r.id, "reason": r.reason }))
+                .collect();
+            let reg = loaded.registry;
             let jobs: Vec<serde_json::Value> = reg
                 .jobs
                 .iter()
@@ -2065,6 +2073,7 @@ fn handle_schedule(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
                     "present": true,
                     "registry_rel": ovp_scheduler::REGISTRY_REL,
                     "jobs": jobs,
+                    "rejected": rejected,
                 })
                 .to_string(),
             )
@@ -2143,7 +2152,8 @@ fn handle_schedule_features(state: &AppState, body: &str) -> Response<std::io::C
     };
 
     let mut reg = match ovp_scheduler::load_registry(&state.vault_root) {
-        Ok(Some(r)) => r,
+        // as_written: this path saves, and must not drop quarantined jobs.
+        Ok(Some(r)) => r.as_written,
         Ok(None) => {
             return json_response(
                 404,


### PR DESCRIPTION
## The failure

`Registry::validate` returned `Err` on the **first** unparseable cadence and `load_registry` propagated it, so one bad entry made `schedule list` and `schedule tick` exit non-zero — and **no job ran**, not just the broken one.

The way in is routine: `.ovp/schedule.json` edited to a cadence syntax the installed binary does not know yet. CLAUDE.md calls this the most expensive failure in the repo, and the desktop scheduler only forwards a child's stderr to `eprintln`, which Finder swallows — so from the GUI it presented as *nothing happening at all*.

Verified against a copy of the real registry with one future-syntax cadence injected:

```
# shipped binary
$ ovp2 schedule list --vault-root <copy>
error: io: job 'future-syntax': invalid cadence 'every 3rd tuesday': ...
exit 1        # and none of the other three jobs listed or dispatched

# this branch
$ ovp2 schedule list --vault-root <copy>
scheduler: 1 job(s) QUARANTINED — they will not run until fixed:
  - future-syntax: invalid cadence 'every 3rd tuesday': expected 'daily HH:MM', ...
  (the remaining jobs still run; edit .ovp/schedule.json to fix)
jobs (3): ...
exit 0
```

## Design

- **Per-job quarantine.** `Registry::partition` splits runnable from broken; `load_registry` returns both. A **file**-level problem (unreadable, unparseable JSON) is still fatal — there is no partial registry to salvage from that.
- **Quarantine hides a job; it must never erase it.** The first cut had `LoadedRegistry` carrying only the filtered view, which meant an unrelated `schedule disable` would have saved that view back and **deleted** the operator's broken job definition — worse than the bug being fixed. `as_written` now carries the on-disk registry verbatim and every edit-and-save path goes through it.
- **`skipped_invalid` is its own bucket.** Folding a broken job into `skipped_not_due` was a small lie: "not due" reads as "fine, just not time yet" for a job that will never run.
- **Duplicate ids** quarantine the *later* copy, matching what `get()` already resolves to.

## Codex gate: FAIL then fixed

The P1 landed on an overclaim of mine. I added `rejected` to `/api/schedule` and wrote in the commit message "so the portal can show them" — but nothing consumed it. The field existed; the promise did not. And the portal's empty branch keyed on `jobs.length === 0`, so an all-quarantined registry rendered as **"no jobs configured"** — sending the operator to look for a config that exists and is broken.

Fixed: typed `rejected` in the API client, a warn card listing each quarantined job with its reason and the registry path, a distinct all-quarantined message, EN + ZH. Plus two P2s from the same pass — `TickReport` was dropping `skipped_invalid` at the `tick_with` boundary, and `schedule status` (the *diagnostic* command) never reported quarantine while list/tick/run-now did.

## Tests

5 new scheduler tests: one bad cadence does not stop the others; a quarantined job survives an unrelated edit-and-save; broken reports as invalid not not-due; duplicate id keeps the first; a file-level problem is still fatal. 32 scheduler / 187 CLI / 216 portal tests pass.

## Scope

C3.2 only. `consecutive_failures` consumption (backoff + time-gated alerting), the run-summary card, and structured `doctor` output are separate changes — one knob at a time.

## Acceptance

Portal changes need `scripts/deploy-portal.sh <vault>` to be visible; `npm run build` passing is not the acceptance criterion here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invalid scheduled jobs are quarantined individually, allowing valid jobs to continue running.
  * CLI and web interfaces show skipped jobs with their IDs and rejection reasons.
  * Automation panels provide guidance when jobs are quarantined or all configured jobs are unavailable.
  * Registry edits preserve quarantined jobs instead of removing them.
  * Added Simplified Chinese translations for quarantine-related statuses and guidance.

* **Bug Fixes**
  * Duplicate or invalid schedules no longer prevent the entire registry from loading.
  * Quarantined jobs remain intact during schedule updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->