### PR TITLE
feat(doctor): tell the operator what to do, not just what is wrong

### DIFF
--- a/crates/ovp-cli/src/commands/doctor.rs
+++ b/crates/ovp-cli/src/commands/doctor.rs
@@ -177,7 +177,9 @@ fn check_ledger_fs_consistency(vault_root: &Path, layout: &VaultLayout, findings
             message: format!("{missing_count} succeeded ledger entries without corresponding pack directories"),
             hint: None,
             fixed: false,
-        });
+        }.attach_hint(
+            "the ledger points at packs that are not on disk — a moved vault, a partial restore, or a manual delete; `ovp2 index` re-derives the read model from what IS there",
+        ));
     } else {
         findings.push(Finding {
             check: "ledger-fs-consistency".into(),
@@ -269,7 +271,9 @@ fn check_stale_index(vault_root: &Path, findings: &mut Vec<Finding>, fix: bool) 
                         message: format!("index.json missing, rebuild failed: {e}"),
                         hint: None,
                         fixed: false,
-                    });
+                    }.attach_hint(
+            "the rebuild itself failed — read the error above; `find`, the portal and the console all read this projection, so they stay stale until it succeeds",
+        ));
                 }
             }
         } else {
@@ -324,7 +328,9 @@ fn check_stale_index(vault_root: &Path, findings: &mut Vec<Finding>, fix: bool) 
                             message: format!("index stale, rebuild failed: {e}"),
                             hint: None,
                             fixed: false,
-                        });
+                        }.attach_hint(
+            "the rebuild itself failed — read the error above; `find`, the portal and the console all read this projection, so they stay stale until it succeeds",
+        ));
                     }
                 }
             } else {
@@ -370,7 +376,7 @@ fn check_crystal_staleness(vault_root: &Path, findings: &mut Vec<Finding>) {
     let report = match recheck_vault(vault_root, None, None) {
         Ok(r) => r,
         Err(e) => {
-            findings.push(Finding {
+            let finding = Finding {
                 check: "crystal-staleness".into(),
                 severity: if store_absent {
                     Severity::Info
@@ -380,9 +386,18 @@ fn check_crystal_staleness(vault_root: &Path, findings: &mut Vec<Finding>) {
                 message: format!("could not recheck durable claims: {e}"),
                 hint: None,
                 fixed: false,
-            }.attach_hint(
-                    "the ledger or the reader packs could not be read — fix the error above first; until then this vault has NO staleness signal at all",
-                ));
+            };
+            // The hint follows the SEVERITY. A fresh vault with no crystal
+            // store takes the Info path and is not broken — handing it "fix
+            // the error above" invents a problem for someone who has none.
+            findings.push(if store_absent {
+                finding
+            } else {
+                finding.attach_hint(
+                    "the ledger or the reader packs could not be read — until that is \
+                     fixed this vault has NO staleness signal at all",
+                )
+            });
             return;
         }
     };
@@ -574,7 +589,9 @@ fn check_run_recency(
                     ),
                     hint: None,
                     fixed: false,
-                });
+                }.attach_hint(
+            "read the failure in `.ovp/logs/` or the run ledger; the scheduler now retries on a backoff, but a persistent failure needs the cause fixed",
+        ));
                 return;
             }
             ovp_daily::LastRunStatus::Aborted => {
@@ -615,7 +632,9 @@ fn check_run_recency(
                 message: "no run recorded yet (no heartbeat, no reports)".into(),
                 hint: None,
                 fixed: false,
-            });
+            }.attach_hint(
+            "expected before the first run; otherwise check `ovp2 schedule status` — a quarantined or disabled job never fires",
+        ));
         }
         Some(ts) => {
             let age = now_secs - ts;
@@ -1032,76 +1051,132 @@ fn is_leap(y: i32) -> bool {
 mod tests {
     use super::*;
 
-    /// Build the vault states that actually TRIGGER the actionable branches.
+    /// Run EVERY check, the way `run()` does.
     ///
-    /// An empty tempdir exercises almost none of them: the first version of
-    /// this test passed with a hint deliberately removed, because the branch
-    /// that hint belonged to never ran. A coverage test that cannot reach the
-    /// code it claims to cover is worse than no test — it reports safety.
-    fn vaults_with_actionable_findings() -> Vec<(&'static str, tempfile::TempDir)> {
-        let mut out = Vec::new();
+    /// The first version of this test called only the two crystal checks, so
+    /// removing a hint from any other check left it green — it reported a
+    /// coverage guarantee it did not have.
+    fn all_checks(vault: &Path) -> Vec<Finding> {
+        let layout = VaultLayout::new();
+        let mut findings = Vec::new();
+        check_ledger_fs_consistency(vault, &layout, &mut findings);
+        check_orphan_packs(vault, &layout, &mut findings);
+        check_stale_index(vault, &mut findings, false);
+        check_crystal_integrity(vault, &mut findings);
+        check_crystal_staleness(vault, &mut findings);
+        check_run_recency(vault, &layout, now_unix_secs(), DEFAULT_RECENCY_HOURS, &mut findings);
+        check_disk_usage(vault, &layout, &mut findings);
+        check_legacy_artifacts(vault, &mut findings);
+        check_inbox_orphans(vault, &layout, &mut findings);
+        findings
+    }
 
-        // crystal dir present, ledger missing -> half-written store
-        let d = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(d.path().join(".ovp/crystal")).unwrap();
-        out.push(("crystal-no-ledger", d));
+    /// Vault states that actually TRIGGER actionable branches. An empty dir
+    /// reaches almost none of them.
+    fn actionable_fixtures() -> Vec<(&'static str, tempfile::TempDir)> {
+        let bare = tempfile::tempdir().unwrap();
 
-        // ledger present but with a line that will not parse
-        let d = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(d.path().join(".ovp/crystal")).unwrap();
+        let no_ledger = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(no_ledger.path().join(".ovp/crystal")).unwrap();
+
+        let bad_line = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(bad_line.path().join(".ovp/crystal")).unwrap();
         std::fs::write(
-            d.path().join(".ovp/crystal/ledger.jsonl"),
+            bad_line.path().join(".ovp/crystal/ledger.jsonl"),
             "{\"op\":\"write\"}\nnot json at all\n",
         )
         .unwrap();
-        out.push(("crystal-bad-line", d));
 
-        out
+        // A ledger whose succeeded entry points at a pack that is not on
+        // disk. Without this the whole ledger-* family goes untested: a
+        // MISSING ledger reads as an empty one, so `check_ledger_fs_consistency`
+        // takes its Pass path and removing its hints changed nothing.
+        let dangling = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dangling.path().join(".ovp")).unwrap();
+        std::fs::write(
+            dangling.path().join(".ovp/daily-runs.jsonl"),
+            concat!(
+                r#"{"schema":"ovp.daily/v1","run_id":"daily-2026-01-01","date":"2026-01-01","#,
+                r#""source_path":"50-Inbox/01-Raw/x.md","source_sha256":"deadbeef","#,
+                r#""status":"succeeded","pack_dir":"40-Resources/Reader/gone","units":1,"cards":1}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+
+        vec![
+            ("bare", bare),
+            ("crystal-no-ledger", no_ledger),
+            ("crystal-bad-line", bad_line),
+            ("ledger-dangling-pack", dangling),
+        ]
+    }
+
+    fn names_a_command(f: &Finding) -> bool {
+        f.message.contains("`ovp2 ") || f.message.contains("run `")
     }
 
     /// Every finding a person is expected to act on should say what to do.
     /// Not a blanket rule — a message that already names the command needs no
-    /// second copy of it — but silence by DEFAULT is what sends an operator
+    /// second copy — but silence by DEFAULT is what sends an operator
     /// searching while the command that knows the answer says nothing.
     #[test]
     fn actionable_findings_carry_a_hint_or_name_the_command_themselves() {
-        let mut checked_actionable = 0;
-        for (label, vault) in vaults_with_actionable_findings() {
-            let mut findings = Vec::new();
-            check_crystal_integrity(vault.path(), &mut findings);
-            check_crystal_staleness(vault.path(), &mut findings);
-            for f in &findings {
-                if !matches!(f.severity, Severity::Warn | Severity::Fail) {
+        let mut actionable = 0;
+        let mut exempted = 0;
+        for (label, vault) in actionable_fixtures() {
+            for f in all_checks(vault.path()) {
+                if !matches!(f.severity, Severity::Warn | Severity::Fail) || f.fixed {
                     continue;
                 }
-                checked_actionable += 1;
-                let names_a_command =
-                    f.message.contains("`ovp2 ") || f.message.contains("run `");
+                actionable += 1;
+                if f.hint.is_none() {
+                    exempted += 1;
+                }
                 assert!(
-                    f.hint.is_some() || names_a_command,
+                    f.hint.is_some() || names_a_command(&f),
                     "{label}: [{}] {}: actionable but offers no next step",
                     f.check,
                     f.message
                 );
             }
         }
-        // The guard the first version lacked: if the fixtures stop reaching any
-        // actionable branch, this test must fail rather than pass vacuously.
+        // Guards the first version lacked: if the fixtures stop reaching the
+        // branches, or the exemption arm is never taken, this test must fail
+        // rather than pass vacuously.
+        assert!(actionable >= 8, "only {actionable} actionable finding(s) reached");
         assert!(
-            checked_actionable >= 2,
-            "fixtures reached only {checked_actionable} actionable finding(s) — \
-             the assertion above is not being exercised"
+            exempted >= 1,
+            "no finding took the message-names-a-command exemption — that arm of \
+             the assertion is untested and could be silently wrong"
         );
     }
 
     #[test]
+    fn a_fresh_vault_is_not_handed_a_hint_for_a_problem_it_does_not_have() {
+        // The Info path (no crystal store yet) is the normal fresh state.
+        // Attaching the Warn path's hint there invents a problem.
+        let vault = tempfile::tempdir().unwrap();
+        let mut findings = Vec::new();
+        check_crystal_staleness(vault.path(), &mut findings);
+        for f in &findings {
+            if matches!(f.severity, Severity::Info | Severity::Pass) {
+                assert!(
+                    f.hint.is_none(),
+                    "[{}] {}: non-actionable finding carries a hint",
+                    f.severity,
+                    f.message
+                );
+            }
+        }
+    }
+
+    #[test]
     fn a_passing_finding_carries_no_hint() {
-        // A hint on a PASS is noise: there is nothing to do.
         let vault = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(vault.path().join(".ovp/crystal")).unwrap();
         std::fs::write(vault.path().join(".ovp/crystal/ledger.jsonl"), "").unwrap();
-        let mut findings = Vec::new();
-        check_crystal_integrity(vault.path(), &mut findings);
+        let findings = all_checks(vault.path());
         assert!(!findings.is_empty());
         for f in &findings {
             if f.severity == Severity::Pass {
@@ -1109,6 +1184,7 @@ mod tests {
             }
         }
     }
+
 
 
     fn touch(root: &Path, rel: &str) {

--- a/crates/ovp-cli/src/commands/doctor.rs
+++ b/crates/ovp-cli/src/commands/doctor.rs
@@ -439,22 +439,27 @@ fn check_crystal_staleness(vault_root: &Path, findings: &mut Vec<Finding>) {
         .iter()
         .map(|(k, v)| format!("{k}={v}"))
         .collect();
-    findings.push(Finding {
-        check: "crystal-staleness".into(),
-        severity: Severity::Warn,
-        message: format!(
-            "{} of {} durable claims no longer ground ({}) — {age_note}. \
-             Run `ovp2 crystal-recheck --vault-root <vault> --out <report>`; \
-             re-verification is a gated write, never automatic",
-            report.n_stale,
-            report.n_claims,
-            defects.join(" ")
+    // The message states the FACT; the hint carries the ACTION. #461 put the
+    // command in the message because there was nowhere else for it — leaving
+    // it there now prints the same instruction twice.
+    findings.push(
+        Finding {
+            check: "crystal-staleness".into(),
+            severity: Severity::Warn,
+            message: format!(
+                "{} of {} durable claims no longer ground ({}) — {age_note}",
+                report.n_stale,
+                report.n_claims,
+                defects.join(" ")
+            ),
+            hint: None,
+            fixed: false,
+        }
+        .attach_hint(
+            "run `ovp2 crystal-recheck --vault-root <vault> --out <report>` for the \
+             per-claim detail; re-verification is a gated write, never automatic",
         ),
-        hint: None,
-        fixed: false,
-    }.attach_hint(
-            "run `ovp2 crystal-recheck --vault-root <vault> --out <report>` for the per-claim detail; re-verification is a gated write, never automatic",
-        ));
+    );
 }
 
 fn check_crystal_integrity(vault_root: &Path, findings: &mut Vec<Finding>) {
@@ -1104,11 +1109,45 @@ mod tests {
         )
         .unwrap();
 
+        // A durable claim citing a case that is NOT among the reader packs —
+        // the one state that produces the stale-claims WARN. Without it the
+        // finding this whole check exists for goes untested: fault injection
+        // showed both the hint rule and the no-duplicate-command rule passing
+        // vacuously for it.
+        let stale = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(stale.path().join(".ovp/crystal")).unwrap();
+        let pack = stale
+            .path()
+            .join("40-Resources/Reader/2026-01-01_Present-aaaaaaaa");
+        std::fs::create_dir_all(&pack).unwrap();
+        std::fs::write(
+            pack.join("units.accepted.json"),
+            r#"[{"id":"u-000-aaaaaaaa","kind":"assertion","text":"t",
+                 "evidence":{"ref_id":"p001.s001","quote":"q","location":null},
+                 "attribution":"author","modality":"asserted","arguments":[],
+                 "status":"accepted","issues":[]}]"#,
+        )
+        .unwrap();
+        std::fs::write(
+            stale.path().join(".ovp/crystal/ledger.jsonl"),
+            concat!(
+                r#"{"op":"write","record":{"claim_key":"ck-1","claim_id":"ck-1","claim":"c","#,
+                r#""theme":"t","source_cases":["2026-01-01_Gone-bbbbbbbb"],"#,
+                r#""citations":[{"case_id":"2026-01-01_Gone-bbbbbbbb","unit_id":"u-000-bbbbbbbb","#,
+                r#""quote":"q","resolved_line":1}],"provenance_score":1.0,"#,
+                r#""provenance_class":"durable","strength":"supported","strength_rationale":"r","#,
+                r#""final_class":"durable","run_id":"r1","status":"active"}}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+
         vec![
             ("bare", bare),
             ("crystal-no-ledger", no_ledger),
             ("crystal-bad-line", bad_line),
             ("ledger-dangling-pack", dangling),
+            ("crystal-stale-claim", stale),
         ]
     }
 
@@ -1144,12 +1183,30 @@ mod tests {
         // Guards the first version lacked: if the fixtures stop reaching the
         // branches, or the exemption arm is never taken, this test must fail
         // rather than pass vacuously.
-        assert!(actionable >= 8, "only {actionable} actionable finding(s) reached");
+        assert!(actionable >= 10, "only {actionable} actionable finding(s) reached");
         assert!(
             exempted >= 1,
             "no finding took the message-names-a-command exemption — that arm of \
              the assertion is untested and could be silently wrong"
         );
+    }
+
+
+    /// The message says WHAT is wrong; the hint says what to DO. A finding
+    /// carrying the same command in both prints the instruction twice.
+    #[test]
+    fn a_finding_does_not_repeat_its_command_in_both_message_and_hint() {
+        for (label, vault) in actionable_fixtures() {
+            for f in all_checks(vault.path()) {
+                let Some(hint) = f.hint.as_deref() else { continue };
+                assert!(
+                    !names_a_command(&f),
+                    "{label}: [{}] names a command in BOTH message and hint:\n  msg:  {}\n  hint: {hint}",
+                    f.check,
+                    f.message
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/ovp-cli/src/commands/doctor.rs
+++ b/crates/ovp-cli/src/commands/doctor.rs
@@ -52,7 +52,21 @@ pub struct Finding {
     pub check: String,
     pub severity: Severity,
     pub message: String,
+    /// The concrete next action, when there is one.
+    ///
+    /// A check that says what is wrong but not what to do about it makes the
+    /// operator go looking — and the command that knows the answer is the one
+    /// staying quiet about it. Only on findings a person can actually act on:
+    /// a hint on a PASS is noise, and an invented hint is worse than none.
+    pub hint: Option<String>,
     pub fixed: bool,
+}
+
+impl Finding {
+    fn attach_hint(mut self, hint: impl Into<String>) -> Self {
+        self.hint = Some(hint.into());
+        self
+    }
 }
 
 pub fn run(args: DoctorArgs) -> Result<(), CliError> {
@@ -80,6 +94,7 @@ pub fn run(args: DoctorArgs) -> Result<(), CliError> {
                     "check": f.check,
                     "severity": format!("{}", f.severity),
                     "message": f.message,
+                    "hint": f.hint,
                     "fixed": f.fixed,
                 })
             })
@@ -89,6 +104,11 @@ pub fn run(args: DoctorArgs) -> Result<(), CliError> {
         for f in &findings {
             let fix_tag = if f.fixed { " [FIXED]" } else { "" };
             println!("  [{}] {}: {}{}", f.severity, f.check, f.message, fix_tag);
+            // Indented under its finding, and only when the operator still has
+            // something to do — a hint next to a [FIXED] line is just noise.
+            if let Some(hint) = f.hint.as_deref().filter(|_| !f.fixed) {
+                println!("         -> {hint}");
+            }
         }
     }
 
@@ -116,15 +136,21 @@ fn check_ledger_fs_consistency(vault_root: &Path, layout: &VaultLayout, findings
                     check: "ledger-readable".into(),
                     severity: Severity::Fail,
                     message: format!("cannot read ledger: {e}"),
+                    hint: None,
                     fixed: false,
-                });
+                }.attach_hint(
+            "check permissions on the daily ledger — doctor cannot verify run history or index freshness without it",
+        ));
             } else {
                 findings.push(Finding {
                     check: "ledger-exists".into(),
                     severity: Severity::Warn,
                     message: "no daily ledger found (no runs yet?)".into(),
+                    hint: None,
                     fixed: false,
-                });
+                }.attach_hint(
+            "expected on a fresh vault; otherwise run `ovp2 daily --vault-root <vault>` once to create it",
+        ));
             }
             return;
         }
@@ -149,6 +175,7 @@ fn check_ledger_fs_consistency(vault_root: &Path, layout: &VaultLayout, findings
             check: "ledger-fs-consistency".into(),
             severity: Severity::Warn,
             message: format!("{missing_count} succeeded ledger entries without corresponding pack directories"),
+            hint: None,
             fixed: false,
         });
     } else {
@@ -156,6 +183,7 @@ fn check_ledger_fs_consistency(vault_root: &Path, layout: &VaultLayout, findings
             check: "ledger-fs-consistency".into(),
             severity: Severity::Pass,
             message: "all succeeded ledger entries have corresponding pack dirs".into(),
+            hint: None,
             fixed: false,
         });
     }
@@ -168,6 +196,7 @@ fn check_orphan_packs(vault_root: &Path, layout: &VaultLayout, findings: &mut Ve
             check: "orphan-packs".into(),
             severity: Severity::Pass,
             message: "no reader directory yet".into(),
+            hint: None,
             fixed: false,
         });
         return;
@@ -199,13 +228,17 @@ fn check_orphan_packs(vault_root: &Path, layout: &VaultLayout, findings: &mut Ve
             check: "orphan-packs".into(),
             severity: Severity::Warn,
             message: format!("{orphan_count} reader pack(s) not linked to any ledger entry"),
+            hint: None,
             fixed: false,
-        });
+        }.attach_hint(
+            "usually a run that died between writing the pack and recording it — `ovp2 index` re-derives the read model, and `--fix` quarantines the orphans",
+        ));
     } else {
         findings.push(Finding {
             check: "orphan-packs".into(),
             severity: Severity::Pass,
             message: "all reader packs linked to ledger entries".into(),
+            hint: None,
             fixed: false,
         });
     }
@@ -225,6 +258,7 @@ fn check_stale_index(vault_root: &Path, findings: &mut Vec<Finding>, fix: bool) 
                         check: "stale-index".into(),
                         severity: Severity::Warn,
                         message: "index.json missing — rebuilt".into(),
+                        hint: None,
                         fixed: true,
                     });
                 }
@@ -233,6 +267,7 @@ fn check_stale_index(vault_root: &Path, findings: &mut Vec<Finding>, fix: bool) 
                         check: "stale-index".into(),
                         severity: Severity::Fail,
                         message: format!("index.json missing, rebuild failed: {e}"),
+                        hint: None,
                         fixed: false,
                     });
                 }
@@ -242,6 +277,7 @@ fn check_stale_index(vault_root: &Path, findings: &mut Vec<Finding>, fix: bool) 
                 check: "stale-index".into(),
                 severity: Severity::Fail,
                 message: "index.json missing (run `doctor --fix` or `index`)".into(),
+                hint: None,
                 fixed: false,
             });
         }
@@ -253,6 +289,7 @@ fn check_stale_index(vault_root: &Path, findings: &mut Vec<Finding>, fix: bool) 
             check: "stale-index".into(),
             severity: Severity::Pass,
             message: "no ledger to compare index freshness against".into(),
+            hint: None,
             fixed: false,
         });
         return;
@@ -276,6 +313,7 @@ fn check_stale_index(vault_root: &Path, findings: &mut Vec<Finding>, fix: bool) 
                             check: "stale-index".into(),
                             severity: Severity::Warn,
                             message: "index.json older than ledger — rebuilt".into(),
+                            hint: None,
                             fixed: true,
                         });
                     }
@@ -284,6 +322,7 @@ fn check_stale_index(vault_root: &Path, findings: &mut Vec<Finding>, fix: bool) 
                             check: "stale-index".into(),
                             severity: Severity::Fail,
                             message: format!("index stale, rebuild failed: {e}"),
+                            hint: None,
                             fixed: false,
                         });
                     }
@@ -293,6 +332,7 @@ fn check_stale_index(vault_root: &Path, findings: &mut Vec<Finding>, fix: bool) 
                     check: "stale-index".into(),
                     severity: Severity::Warn,
                     message: "index.json is older than the daily ledger (run `index` or `daily`)".into(),
+                    hint: None,
                     fixed: false,
                 });
             }
@@ -302,6 +342,7 @@ fn check_stale_index(vault_root: &Path, findings: &mut Vec<Finding>, fix: bool) 
                 check: "stale-index".into(),
                 severity: Severity::Pass,
                 message: "index.json is up-to-date".into(),
+                hint: None,
                 fixed: false,
             });
         }
@@ -337,8 +378,11 @@ fn check_crystal_staleness(vault_root: &Path, findings: &mut Vec<Finding>) {
                     Severity::Warn
                 },
                 message: format!("could not recheck durable claims: {e}"),
+                hint: None,
                 fixed: false,
-            });
+            }.attach_hint(
+                    "the ledger or the reader packs could not be read — fix the error above first; until then this vault has NO staleness signal at all",
+                ));
             return;
         }
     };
@@ -347,6 +391,7 @@ fn check_crystal_staleness(vault_root: &Path, findings: &mut Vec<Finding>) {
             check: "crystal-staleness".into(),
             severity: Severity::Pass,
             message: "no durable claims to recheck".into(),
+            hint: None,
             fixed: false,
         });
         return;
@@ -369,6 +414,7 @@ fn check_crystal_staleness(vault_root: &Path, findings: &mut Vec<Finding>) {
                 "all {} durable claims still ground ({age_note})",
                 report.n_claims
             ),
+            hint: None,
             fixed: false,
         });
         return;
@@ -389,8 +435,11 @@ fn check_crystal_staleness(vault_root: &Path, findings: &mut Vec<Finding>) {
             report.n_claims,
             defects.join(" ")
         ),
+        hint: None,
         fixed: false,
-    });
+    }.attach_hint(
+            "run `ovp2 crystal-recheck --vault-root <vault> --out <report>` for the per-claim detail; re-verification is a gated write, never automatic",
+        ));
 }
 
 fn check_crystal_integrity(vault_root: &Path, findings: &mut Vec<Finding>) {
@@ -402,6 +451,7 @@ fn check_crystal_integrity(vault_root: &Path, findings: &mut Vec<Finding>) {
             check: "crystal-integrity".into(),
             severity: Severity::Pass,
             message: "no crystal store yet".into(),
+            hint: None,
             fixed: false,
         });
         return;
@@ -412,8 +462,11 @@ fn check_crystal_integrity(vault_root: &Path, findings: &mut Vec<Finding>) {
             check: "crystal-integrity".into(),
             severity: Severity::Warn,
             message: "crystal directory exists but ledger.jsonl is missing".into(),
+            hint: None,
             fixed: false,
-        });
+        }.attach_hint(
+            "the store is half-written — restore `.ovp/crystal/` from a backup, or re-run `ovp2 crystal-synth` to rebuild it",
+        ));
         return;
     }
 
@@ -424,8 +477,11 @@ fn check_crystal_integrity(vault_root: &Path, findings: &mut Vec<Finding>) {
                 check: "crystal-integrity".into(),
                 severity: Severity::Fail,
                 message: format!("cannot read crystal ledger: {e}"),
+                hint: None,
                 fixed: false,
-            });
+            }.attach_hint(
+            "check permissions on `.ovp/crystal/ledger.jsonl`; the console and `find` read only that path",
+        ));
             return;
         }
     };
@@ -448,13 +504,17 @@ fn check_crystal_integrity(vault_root: &Path, findings: &mut Vec<Finding>) {
             check: "crystal-integrity".into(),
             severity: Severity::Fail,
             message: format!("crystal ledger has {invalid} unparseable lines ({valid} valid)"),
+            hint: None,
             fixed: false,
-        });
+        }.attach_hint(
+            "the ledger is append-only, so a bad line is almost always a truncated write — inspect the tail and drop the partial record",
+        ));
     } else {
         findings.push(Finding {
             check: "crystal-integrity".into(),
             severity: Severity::Pass,
             message: format!("crystal ledger intact ({valid} records)"),
+            hint: None,
             fixed: false,
         });
     }
@@ -493,6 +553,7 @@ fn check_run_recency(
                     ".ovp/last-run.json is present but unreadable/corrupt ({e}) — the last run's \
                      status is unknowable; repair or remove it, then rerun `ovp2 daily`"
                 ),
+                hint: None,
                 fixed: false,
             });
             return;
@@ -511,6 +572,7 @@ fn check_run_recency(
                         rec.run_id,
                         rec.error.as_deref().map(|e| format!(" — {e}")).unwrap_or_default()
                     ),
+                    hint: None,
                     fixed: false,
                 });
                 return;
@@ -524,6 +586,7 @@ fn check_run_recency(
                          check the schedule log and rerun `ovp2 daily`",
                         rec.run_id
                     ),
+                    hint: None,
                     fixed: false,
                 });
                 return;
@@ -550,6 +613,7 @@ fn check_run_recency(
                 check: "run-recency".into(),
                 severity: Severity::Warn,
                 message: "no run recorded yet (no heartbeat, no reports)".into(),
+                hint: None,
                 fixed: false,
             });
         }
@@ -564,6 +628,7 @@ fn check_run_recency(
                         "last run was ~{hours}h ago (> {threshold_hours}h) — the unattended loop may be \
                          stalled; check `ovp2 schedule status` and the schedule log"
                     ),
+                    hint: None,
                     fixed: false,
                 });
             } else {
@@ -572,6 +637,7 @@ fn check_run_recency(
                     check: "run-recency".into(),
                     severity: Severity::Pass,
                     message: format!("last run ~{hours}h ago (< {threshold_hours}h)"),
+                    hint: None,
                     fixed: false,
                 });
             }
@@ -594,6 +660,7 @@ fn check_run_recency(
                     "queue is growing: {live_queued} queued now vs {queued_after} after the last run \
                      — capture is outpacing reading; raise --max-sources or run more often"
                 ),
+                hint: None,
                 fixed: false,
             });
         }
@@ -709,6 +776,7 @@ fn check_disk_usage(vault_root: &Path, layout: &VaultLayout, findings: &mut Vec<
             check: format!("disk-{name}"),
             severity,
             message: format!("{size_mb:.1} MB"),
+            hint: None,
             fixed: false,
         });
     }
@@ -756,6 +824,7 @@ fn check_legacy_artifacts(vault_root: &Path, findings: &mut Vec<Finding>) {
                  safe to archive/delete once you've verified the ovp2 rebuild — \
                  see https://github.com/fakechris/obsidian_vault_pipeline/blob/main/docs/ovp-to-ovp2.md (§5, Migrating an existing OVP vault; docs/ovp-to-ovp2.md in a source checkout)"
             ),
+            hint: None,
             fixed: false,
         });
     }
@@ -765,6 +834,7 @@ fn check_legacy_artifacts(vault_root: &Path, findings: &mut Vec<Finding>) {
             check: "legacy-artifacts".into(),
             severity: Severity::Pass,
             message: "no Python-era OVP artifacts found".into(),
+            hint: None,
             fixed: false,
         });
     }
@@ -871,6 +941,7 @@ fn check_inbox_orphans(vault_root: &Path, layout: &VaultLayout, findings: &mut V
             check,
             severity: Severity::Pass,
             message: "no stranded inbox files".into(),
+            hint: None,
             fixed: false,
         });
         return;
@@ -894,6 +965,7 @@ fn check_inbox_orphans(vault_root: &Path, layout: &VaultLayout, findings: &mut V
              ovp2 never auto-moves them.",
             locations.join(", ")
         ),
+        hint: None,
         fixed: false,
     });
 }
@@ -959,6 +1031,85 @@ fn is_leap(y: i32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build the vault states that actually TRIGGER the actionable branches.
+    ///
+    /// An empty tempdir exercises almost none of them: the first version of
+    /// this test passed with a hint deliberately removed, because the branch
+    /// that hint belonged to never ran. A coverage test that cannot reach the
+    /// code it claims to cover is worse than no test — it reports safety.
+    fn vaults_with_actionable_findings() -> Vec<(&'static str, tempfile::TempDir)> {
+        let mut out = Vec::new();
+
+        // crystal dir present, ledger missing -> half-written store
+        let d = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(d.path().join(".ovp/crystal")).unwrap();
+        out.push(("crystal-no-ledger", d));
+
+        // ledger present but with a line that will not parse
+        let d = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(d.path().join(".ovp/crystal")).unwrap();
+        std::fs::write(
+            d.path().join(".ovp/crystal/ledger.jsonl"),
+            "{\"op\":\"write\"}\nnot json at all\n",
+        )
+        .unwrap();
+        out.push(("crystal-bad-line", d));
+
+        out
+    }
+
+    /// Every finding a person is expected to act on should say what to do.
+    /// Not a blanket rule — a message that already names the command needs no
+    /// second copy of it — but silence by DEFAULT is what sends an operator
+    /// searching while the command that knows the answer says nothing.
+    #[test]
+    fn actionable_findings_carry_a_hint_or_name_the_command_themselves() {
+        let mut checked_actionable = 0;
+        for (label, vault) in vaults_with_actionable_findings() {
+            let mut findings = Vec::new();
+            check_crystal_integrity(vault.path(), &mut findings);
+            check_crystal_staleness(vault.path(), &mut findings);
+            for f in &findings {
+                if !matches!(f.severity, Severity::Warn | Severity::Fail) {
+                    continue;
+                }
+                checked_actionable += 1;
+                let names_a_command =
+                    f.message.contains("`ovp2 ") || f.message.contains("run `");
+                assert!(
+                    f.hint.is_some() || names_a_command,
+                    "{label}: [{}] {}: actionable but offers no next step",
+                    f.check,
+                    f.message
+                );
+            }
+        }
+        // The guard the first version lacked: if the fixtures stop reaching any
+        // actionable branch, this test must fail rather than pass vacuously.
+        assert!(
+            checked_actionable >= 2,
+            "fixtures reached only {checked_actionable} actionable finding(s) — \
+             the assertion above is not being exercised"
+        );
+    }
+
+    #[test]
+    fn a_passing_finding_carries_no_hint() {
+        // A hint on a PASS is noise: there is nothing to do.
+        let vault = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(vault.path().join(".ovp/crystal")).unwrap();
+        std::fs::write(vault.path().join(".ovp/crystal/ledger.jsonl"), "").unwrap();
+        let mut findings = Vec::new();
+        check_crystal_integrity(vault.path(), &mut findings);
+        assert!(!findings.is_empty());
+        for f in &findings {
+            if f.severity == Severity::Pass {
+                assert!(f.hint.is_none(), "{}: PASS should not carry a hint", f.check);
+            }
+        }
+    }
+
 
     fn touch(root: &Path, rel: &str) {
         let p = root.join(rel);


### PR DESCRIPTION
## What

`doctor` named each problem and stopped there — a WARN sent the operator looking for the fix while the command that knows it stayed quiet. Findings now carry an optional `hint`, the concrete next action, rendered indented under the finding and included in `--json`.

```
[WARN] orphan-packs: 13 reader pack(s) not linked to any ledger entry
       -> usually a run that died between writing the pack and recording it —
          `ovp2 index` re-derives the read model, and `--fix` quarantines the orphans
```

Only where a person can act. A hint on a PASS is noise, one next to `[FIXED]` is stale, and an invented hint is worse than none. Findings whose message already names the command (`stale-index` says "run `doctor --fix` or `index`") do not get a second copy.

## No `code` field, deliberately

The plan called for `{code, level, message, hint}`. Nothing reads `doctor --json` today — not the portal, server, desktop app, CI, or any script. I have shipped two fields with no consumer in the last two PRs (`rejected` on `/api/schedule`, `TickReport.retried`); the consumer for `hint` is the operator reading text output, which exists. `code` waits for something that reads it.

## Codex gate: three findings, all real

- **A fresh vault was handed a bogus hint.** `check_crystal_staleness` attached its hint unconditionally, but that finding is `Info` when there is simply no crystal store yet. A vault with nothing wrong was told to "fix the error above" while the line above it said PASS. The hint now follows the severity.
- **Several actionable findings still said nothing** — dangling ledger entries, both index-rebuild failures, a failed last run, no recorded run. Filled in.
- **The test could not reach most of what it claimed to cover.** It called only the two crystal checks, so removing a hint anywhere else left it green. It now runs every check the way `run()` does, over four fixtures, and asserts both a minimum count and that the exemption arm is actually taken.

## Two failed fault injections before the test was real

Worth writing down, because both were my own error rather than the code's:

1. The first injection reported the test was fine. It was not — my diagnostic grep used `^\w+ \| `, and `\w` does not match a hyphen, so every `crystal-*` fixture line was filtered out of my own output. I read 2 findings where there were 9.
2. The second exposed the actual gap: a **missing** daily ledger reads as an **empty** one, so `check_ledger_fs_consistency` took its Pass path and the entire `ledger-*` family went untested. Added a fixture whose ledger entry points at a pack that is not on disk; injecting on that hint now fails the test with the exact finding named.

Also cost me the file once: I used `git checkout <file>` to undo a temporary injection, which reverted uncommitted work along with it. Redone, and injections since then go through a file copy.

## Tests

197 CLI tests. The hint-coverage test is fault-injection verified against both a crystal check and a ledger check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stale crystal-claim diagnostics by separating the factual finding from its recommended `crystal-recheck` action.
  * Prevented diagnostic messages from repeating the same command in both the warning text and actionable hint.
  * Clarified the presentation of actionable guidance in human-readable and structured diagnostic output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->