### PR TITLE
feat(portal): surface a silently failing scheduled job on every page

### DIFF
--- a/console-ui/src/components/AutomationPanel.tsx
+++ b/console-ui/src/components/AutomationPanel.tsx
@@ -6,7 +6,7 @@
  * web / github node state comes from argv features. Click a node for detail.
  */
 import { useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import {
   Archive,
   BookOpen,
@@ -451,6 +451,7 @@ function JobStrip({
 }
 
 export default function AutomationPanel() {
+  const [searchParams] = useSearchParams();
   const { t } = useI18n();
   const [data, setData] = useState<SchedulePayload | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -495,6 +496,19 @@ export default function AutomationPanel() {
       cancelled = true;
     };
   }, []);
+
+  // Honour `?job=<id>`: the banner links here to show a SPECIFIC failing job,
+  // and landing on `daily` instead makes that click a dead end. Its own effect
+  // keyed on the param, not part of the mount fetch — otherwise clicking a
+  // second failing job while already on this page would change the URL and
+  // move nothing. Router-aware rather than `window.location.search`: the
+  // published static build uses HashRouter, where the query is inside the hash.
+  useEffect(() => {
+    const wanted = searchParams.get('job');
+    if (!wanted || !data) return;
+    const match = data.jobs.find((j) => j.id === wanted);
+    if (match) selectJob(match);
+  }, [searchParams, data]);
 
   const activeJob =
     data?.jobs.find((j) => j.id === activeJobId) ?? data?.jobs[0] ?? null;

--- a/console-ui/src/components/RunBanner.tsx
+++ b/console-ui/src/components/RunBanner.tsx
@@ -29,6 +29,10 @@ import { STATIC_MODE, fetchSchedule, startRunNow, type ScheduleJob } from '../li
 import { useModel } from '../model';
 import RunActivity from './RunActivity';
 
+/** How often to re-read the schedule. Independent of the daily banner: a
+ *  non-daily job's state changes on its own cadence. */
+const SCHEDULE_POLL_MS = 60_000;
+
 /** Re-render tick so the age string advances. A minute is granular enough for
  * a wall-clock banner; the interval is cleared on unmount. */
 export function useNowTick(intervalMs = 60_000): number {
@@ -92,19 +96,27 @@ export default function RunBanner() {
   useEffect(() => {
     if (STATIC_MODE) return;
     let cancelled = false;
-    fetchSchedule()
-      .then((s) => {
-        if (cancelled) return;
-        setDailyJob(s.jobs.find((j) => j.id === 'daily') ?? null);
-        setFailing(failingJobs(s.jobs));
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setDailyJob(null);
-        setFailing([]);
-      });
+    const load = () =>
+      fetchSchedule()
+        .then((s) => {
+          if (cancelled) return;
+          setDailyJob(s.jobs.find((j) => j.id === 'daily') ?? null);
+          setFailing(failingJobs(s.jobs));
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setDailyJob(null);
+          setFailing([]);
+        });
+    load();
+    // Poll on its own clock. Keying this to the DAILY banner meant a
+    // non-daily job could fail — or recover — while `bannerLevel` and
+    // `runId` both sat still, leaving a new failure invisible or a fixed one
+    // falsely flagged until a reload.
+    const timer = window.setInterval(load, SCHEDULE_POLL_MS);
     return () => {
       cancelled = true;
+      window.clearInterval(timer);
     };
   }, [bannerLevel, banner.runId]);
 
@@ -203,13 +215,13 @@ export default function RunBanner() {
   return (
     <div className={`run-banner-wrap ${level}`}>
       {failing.length > 0 && (
-        <div className="run-banner-failing">
+        <div className="run-banner-failing" role="status" aria-live="polite">
           {failing.map((j) => (
             <button
               key={j.id}
               type="button"
               className="run-banner-failing-item"
-              onClick={() => navigate('/system')}
+              onClick={() => navigate(`/system?job=${encodeURIComponent(j.id)}`)}
               title={j.reason ?? undefined}
             >
               {t('banner.jobFailing', {

--- a/console-ui/src/components/RunBanner.tsx
+++ b/console-ui/src/components/RunBanner.tsx
@@ -22,6 +22,8 @@ import {
   shouldClearRetry,
   type BannerLevel,
   type RetryPending,
+  failingJobs,
+  type FailingJob,
 } from '../lib/derive';
 import { STATIC_MODE, fetchSchedule, startRunNow, type ScheduleJob } from '../lib/api';
 import { useModel } from '../model';
@@ -55,6 +57,9 @@ export default function RunBanner() {
   const [retryPending, setRetryPending] = useState<RetryPending | null>(null);
   const [retryError, setRetryError] = useState<string | null>(null);
   const [dailyJob, setDailyJob] = useState<ScheduleJob | null>(null);
+  // The banner already fetched every job and threw all but `daily` away, so a
+  // crystallize failing for days was visible ONLY on the hidden System page.
+  const [failing, setFailing] = useState<FailingJob[]>([]);
 
   const banner = lastRunBanner(model, now);
   // Retry stays pending until the heartbeat actually moves the banner off
@@ -91,9 +96,12 @@ export default function RunBanner() {
       .then((s) => {
         if (cancelled) return;
         setDailyJob(s.jobs.find((j) => j.id === 'daily') ?? null);
+        setFailing(failingJobs(s.jobs));
       })
       .catch(() => {
-        if (!cancelled) setDailyJob(null);
+        if (cancelled) return;
+        setDailyJob(null);
+        setFailing([]);
       });
     return () => {
       cancelled = true;
@@ -194,6 +202,26 @@ export default function RunBanner() {
 
   return (
     <div className={`run-banner-wrap ${level}`}>
+      {failing.length > 0 && (
+        <div className="run-banner-failing">
+          {failing.map((j) => (
+            <button
+              key={j.id}
+              type="button"
+              className="run-banner-failing-item"
+              onClick={() => navigate('/system')}
+              title={j.reason ?? undefined}
+            >
+              {t('banner.jobFailing', {
+                id: j.id,
+                streak: j.streak,
+                when: formatRunWhen(j.lastRun) || '—',
+              })}
+              {j.reason ? ` — ${j.reason}` : ''}
+            </button>
+          ))}
+        </div>
+      )}
       <div className="run-banner-bar">
         <button
           type="button"

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -230,9 +230,11 @@ body {
   font: inherit;
   font-size: 0.8rem;
   line-height: 1.35;
-  color: var(--warn-fg, #7a4a00);
-  background: var(--warn-bg, #fdf3e0);
-  border-bottom: 1px solid var(--warn-border, #f0dcb8);
+  /* The real tokens. `--warn-fg` does not exist — an invented name falls back
+     to the literal, which in dark mode lands around 2:1 against the surface. */
+  color: var(--warn-text);
+  background: var(--warn-bg);
+  border-bottom: 1px solid var(--warn-border);
   /* One line: a stderr first-line can be long and this sits above the fold on
      every page. The full text is on the title attribute. */
   overflow: hidden;

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -211,6 +211,37 @@ body {
   border-bottom: 1px solid var(--border);
   background: var(--surface);
 }
+/* Scheduler jobs that are failing, above the daily banner. The daily run gets
+   the banner proper; these are the ones that were previously visible only on
+   the hidden System page. Amber, not red: the daily loop is still healthy —
+   the point is to stop a job failing for days from being silent, not to make
+   the whole portal look broken. */
+.run-banner-failing {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+.run-banner-failing-item {
+  width: 100%;
+  text-align: start;
+  border: 0;
+  cursor: pointer;
+  padding: 0.3rem 0.75rem;
+  font: inherit;
+  font-size: 0.8rem;
+  line-height: 1.35;
+  color: var(--warn-fg, #7a4a00);
+  background: var(--warn-bg, #fdf3e0);
+  border-bottom: 1px solid var(--warn-border, #f0dcb8);
+  /* One line: a stderr first-line can be long and this sits above the fold on
+     every page. The full text is on the title attribute. */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.run-banner-failing-item:hover {
+  filter: brightness(0.97);
+}
 .run-banner-bar {
   display: flex;
   align-items: stretch;

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -38,6 +38,7 @@ export const en = {
 
   // run-liveness banner (fixed top strip, every page)
   'banner.none': 'No runs yet',
+  'banner.jobFailing': '{id} has been failing since {when} ({streak}x) — open System',
   'banner.completed': 'Last run: completed {when} ({ago})',
   'banner.completedCounts': 'Last run: completed {when} ({ago}) · {read} read · {queued} queued',
   'banner.running': 'Run in progress · started {when} ({ago})',

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -38,7 +38,7 @@ export const en = {
 
   // run-liveness banner (fixed top strip, every page)
   'banner.none': 'No runs yet',
-  'banner.jobFailing': '{id} has been failing since {when} ({streak}x) — open System',
+  'banner.jobFailing': '{id} is failing — {streak} attempt(s), last {when}. Open System',
   'banner.completed': 'Last run: completed {when} ({ago})',
   'banner.completedCounts': 'Last run: completed {when} ({ago}) · {read} read · {queued} queued',
   'banner.running': 'Run in progress · started {when} ({ago})',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -38,7 +38,7 @@ export const zh: Record<keyof typeof en, string> = {
 
   // run-liveness banner (fixed top strip, every page)
   'banner.none': '尚无运行记录',
-  'banner.jobFailing': '{id} 自 {when} 起持续失败({streak} 次)——打开系统页',
+  'banner.jobFailing': '{id} 正在失败——已尝试 {streak} 次,最后一次 {when}。打开系统页',
   'banner.completed': '最近运行：已完成 {when}（{ago}）',
   'banner.completedCounts': '最近运行：已完成 {when}（{ago}）· 阅读 {read} · 队列 {queued}',
   'banner.running': '运行进行中 · 开始 {when}（{ago}）',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -38,6 +38,7 @@ export const zh: Record<keyof typeof en, string> = {
 
   // run-liveness banner (fixed top strip, every page)
   'banner.none': '尚无运行记录',
+  'banner.jobFailing': '{id} 自 {when} 起持续失败({streak} 次)——打开系统页',
   'banner.completed': '最近运行：已完成 {when}（{ago}）',
   'banner.completedCounts': '最近运行：已完成 {when}（{ago}）· 阅读 {read} · 队列 {queued}',
   'banner.running': '运行进行中 · 开始 {when}（{ago}）',

--- a/console-ui/src/lib/derive.failingJobs.test.ts
+++ b/console-ui/src/lib/derive.failingJobs.test.ts
@@ -23,10 +23,18 @@ describe('firstErrorLine', () => {
     );
   });
 
-  it('prefers the LAST error line — a run may log a recovered error first', () => {
+  it('takes the last line, so a recovered error earlier in the run does not win', () => {
     expect(firstErrorLine('error: transient, retrying\nworking\nerror: fatal, giving up')).toBe(
       'error: fatal, giving up',
     );
+  });
+
+  it('keeps a cause that carries no error keyword', () => {
+    // Keyword matching returned "Error: job failed" here and threw the actual
+    // cause away — neither of the lines below would match an error vocabulary.
+    expect(
+      firstErrorLine('Error: job failed\nCaused by:\nPermission denied (os error 13)'),
+    ).toBe('Permission denied (os error 13)');
   });
 
   it('falls back to the newest line when nothing reads as an error', () => {

--- a/console-ui/src/lib/derive.failingJobs.test.ts
+++ b/console-ui/src/lib/derive.failingJobs.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { failingJobs, firstErrorLine, type ScheduleJobLike } from './derive';
+
+const job = (over: Partial<ScheduleJobLike>): ScheduleJobLike => ({
+  id: 'j',
+  enabled: true,
+  last_status: 'ok',
+  last_run: '2026-08-25T09:00:00',
+  ...over,
+});
+
+describe('firstErrorLine', () => {
+  it('picks the diagnosis, not the first line of progress chatter', () => {
+    // Verbatim from the live vault: a crystallize failure whose tail OPENS
+    // with progress output and whose cause is the last line. Taking line one
+    // showed the operator "embedding 1 pack(s) with Xenova/…".
+    const real = [
+      'crystal-synth: embedding 1 pack(s) with Xenova/paraphrase-multilingual-MiniLM-L12-v2 for llm cluster mode',
+      'error: gate: crystal-synth: strength verdicts incomplete for wave 3 — missing=["l3-x"]',
+    ].join('\n');
+    expect(firstErrorLine(real)).toBe(
+      'error: gate: crystal-synth: strength verdicts incomplete for wave 3 — missing=["l3-x"]',
+    );
+  });
+
+  it('prefers the LAST error line — a run may log a recovered error first', () => {
+    expect(firstErrorLine('error: transient, retrying\nworking\nerror: fatal, giving up')).toBe(
+      'error: fatal, giving up',
+    );
+  });
+
+  it('falls back to the newest line when nothing reads as an error', () => {
+    // The newest thing a dying run said beats the oldest.
+    expect(firstErrorLine('step one\nstep two\nstep three')).toBe('step three');
+  });
+
+  it('bounds a long line so it cannot blow out a one-line banner', () => {
+    const long = 'x'.repeat(400);
+    const out = firstErrorLine(long)!;
+    expect(out).toHaveLength(160);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('treats empty and whitespace-only tails as no reason', () => {
+    for (const t of [null, undefined, '', '   \n\n  ']) {
+      expect(firstErrorLine(t)).toBeNull();
+    }
+  });
+});
+
+describe('failingJobs', () => {
+  it('surfaces a job whose last run failed', () => {
+    // The live case this exists for: crystallize had been in `error` for two
+    // days while every page showed a green banner, because the banner only
+    // ever looked at `daily`.
+    const out = failingJobs([
+      job({ id: 'crystallize', last_status: 'error', consecutive_failures: 1, last_error: 'error: gate: boom' }),
+      job({ id: 'themes' }),
+    ]);
+    expect(out).toEqual([
+      {
+        id: 'crystallize',
+        streak: 1,
+        lastRun: '2026-08-25T09:00:00',
+        reason: 'error: gate: boom',
+      },
+    ]);
+  });
+
+  it('excludes daily, which the banner already reports from the heartbeat', () => {
+    // Listing it here too would double-report the same run, with a poorer
+    // status than the heartbeat carries.
+    const out = failingJobs([job({ id: 'daily', last_status: 'error' })]);
+    expect(out).toEqual([]);
+  });
+
+  it('ignores disabled jobs', () => {
+    // A paused job is not a failure to act on — it is a decision.
+    const out = failingJobs([
+      job({ id: 'x', enabled: false, last_status: 'error' }),
+    ]);
+    expect(out).toEqual([]);
+  });
+
+  it('ignores ok and seeded rows', () => {
+    const out = failingJobs([
+      job({ id: 'a', last_status: 'ok' }),
+      job({ id: 'b', last_status: 'seeded' }),
+    ]);
+    expect(out).toEqual([]);
+  });
+
+  it('orders by streak so the longest-running failure is read first', () => {
+    const out = failingJobs([
+      job({ id: 'b', last_status: 'error', consecutive_failures: 1 }),
+      job({ id: 'a', last_status: 'error', consecutive_failures: 5 }),
+    ]);
+    expect(out.map((j) => j.id)).toEqual(['a', 'b']);
+  });
+
+  it('defaults a missing counter to a streak of 1 rather than 0', () => {
+    // An older server omits the field; reporting "0 consecutive failures"
+    // next to a failed job reads as "not really failing".
+    const out = failingJobs([job({ id: 'a', last_status: 'error' })]);
+    expect(out[0].streak).toBe(1);
+  });
+
+  it('tolerates a null schedule', () => {
+    expect(failingJobs(null)).toEqual([]);
+    expect(failingJobs(undefined)).toEqual([]);
+  });
+});

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -1918,3 +1918,96 @@ export function resolveThemeClaimsSort(
   if (isDir(urlDir)) clear.push('dir');
   return { filter, sort, dir, clear };
 }
+
+// ---------------------------------------------------------------------------
+// Silently failing scheduler jobs
+// ---------------------------------------------------------------------------
+
+/** A scheduled job that is failing, condensed for the always-visible banner. */
+export interface FailingJob {
+  id: string;
+  /** Failures since the last success. 1 for a first failure. */
+  streak: number;
+  /** Local `YYYY-MM-DDTHH:MM:SS` of the last attempt. */
+  lastRun: string;
+  /** The most diagnostic line of the recorded stderr tail — see
+   *  [`firstErrorLine`]; deliberately not simply the first. */
+  reason: string | null;
+}
+
+/** Longest reason the banner will render, ELLIPSIS INCLUDED. */
+const REASON_MAX = 160;
+
+/** Lines that read as a diagnosis rather than progress chatter. */
+const ERROR_LINE = /^(error|fatal|panic|thread '.*' panicked)\b|(^|\s)(error|failed|panic)[:!]/i;
+
+/**
+ * The most diagnostic line of a stderr tail, bounded for a one-line banner.
+ *
+ * NOT simply the first line. The tail is the last 12 lines of stderr, and on a
+ * real crystallize failure its head was progress chatter
+ * ("embedding 1 pack(s) with Xenova/…") while the actual cause
+ * ("error: gate: strength verdicts incomplete") was the final line. Prefer a
+ * line that reads as an error; otherwise take the LAST non-blank one, since
+ * the newest thing a dying run said beats the oldest.
+ */
+export function firstErrorLine(tail: string | null | undefined): string | null {
+  if (!tail) return null;
+  const lines = tail
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  if (lines.length === 0) return null;
+  // Last match, not first: a run can log a recovered error before the fatal one.
+  const line =
+    [...lines].reverse().find((l) => ERROR_LINE.test(l)) ?? lines[lines.length - 1];
+  // -1 for the ellipsis: the cap counts what is RENDERED, so slicing to the
+  // cap and then appending would overshoot it.
+  return line.length > REASON_MAX
+    ? `${line.slice(0, REASON_MAX - 1)}…`
+    : line;
+}
+
+/**
+ * Scheduled jobs whose last run FAILED, worst streak first.
+ *
+ * The banner is on every page and already fetches the whole schedule, but it
+ * only ever looked at `daily`. So a `crystallize` that has been failing for
+ * days is visible ONLY to someone who opens the hidden System page and selects
+ * that job — which is the silent-failure shape this is meant to remove.
+ *
+ * `daily` is excluded on purpose: the banner reports it from the heartbeat,
+ * with live progress and a richer status than the schedule row carries.
+ * Listing it here too would double-report the same run.
+ */
+export function failingJobs(
+  jobs: readonly ScheduleJobLike[] | null | undefined,
+  opts: { exclude?: readonly string[] } = {},
+): FailingJob[] {
+  const exclude = new Set(opts.exclude ?? ['daily']);
+  return (jobs ?? [])
+    .filter(
+      (j) =>
+        j.enabled !== false &&
+        j.last_status === 'error' &&
+        !exclude.has(j.id),
+    )
+    .map((j) => ({
+      id: j.id,
+      streak: Math.max(1, j.consecutive_failures ?? 1),
+      lastRun: j.last_run ?? '',
+      reason: firstErrorLine(j.last_error),
+    }))
+    .sort((a, b) => b.streak - a.streak || a.id.localeCompare(b.id));
+}
+
+/** The subset of `ScheduleJob` this module needs — keeps derive.ts free of
+ *  the API module's import graph. */
+export interface ScheduleJobLike {
+  id: string;
+  enabled?: boolean;
+  last_status?: string;
+  last_run?: string;
+  last_error?: string | null;
+  consecutive_failures?: number;
+}

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -1930,26 +1930,26 @@ export interface FailingJob {
   streak: number;
   /** Local `YYYY-MM-DDTHH:MM:SS` of the last attempt. */
   lastRun: string;
-  /** The most diagnostic line of the recorded stderr tail — see
-   *  [`firstErrorLine`]; deliberately not simply the first. */
+  /** The run's final word — see [`firstErrorLine`]. */
   reason: string | null;
 }
 
 /** Longest reason the banner will render, ELLIPSIS INCLUDED. */
 const REASON_MAX = 160;
 
-/** Lines that read as a diagnosis rather than progress chatter. */
-const ERROR_LINE = /^(error|fatal|panic|thread '.*' panicked)\b|(^|\s)(error|failed|panic)[:!]/i;
-
 /**
- * The most diagnostic line of a stderr tail, bounded for a one-line banner.
+ * The run's final word: the LAST non-blank line of its stderr tail.
  *
- * NOT simply the first line. The tail is the last 12 lines of stderr, and on a
- * real crystallize failure its head was progress chatter
- * ("embedding 1 pack(s) with Xenova/…") while the actual cause
- * ("error: gate: strength verdicts incomplete") was the final line. Prefer a
- * line that reads as an error; otherwise take the LAST non-blank one, since
- * the newest thing a dying run said beats the oldest.
+ * Not the first. The tail is the last 12 lines of stderr and on a real
+ * crystallize failure it OPENED with progress chatter ("embedding 1 pack(s)
+ * with Xenova/…") while the cause ("error: gate: strength verdicts
+ * incomplete") was the final line.
+ *
+ * An earlier version pattern-matched for error-looking lines, which was worse
+ * in both directions: it missed causes that carry no keyword
+ * (`Caused by:` / `Permission denied (os error 13)`) and it matched summaries
+ * that do (`summary: failed: 0`). Taking the last line handles all of those,
+ * and needs no vocabulary to keep up to date.
  */
 export function firstErrorLine(tail: string | null | undefined): string | null {
   if (!tail) return null;
@@ -1957,29 +1957,13 @@ export function firstErrorLine(tail: string | null | undefined): string | null {
     .split('\n')
     .map((l) => l.trim())
     .filter((l) => l.length > 0);
-  if (lines.length === 0) return null;
-  // Last match, not first: a run can log a recovered error before the fatal one.
-  const line =
-    [...lines].reverse().find((l) => ERROR_LINE.test(l)) ?? lines[lines.length - 1];
+  const line = lines[lines.length - 1];
+  if (!line) return null;
   // -1 for the ellipsis: the cap counts what is RENDERED, so slicing to the
   // cap and then appending would overshoot it.
-  return line.length > REASON_MAX
-    ? `${line.slice(0, REASON_MAX - 1)}…`
-    : line;
+  return line.length > REASON_MAX ? `${line.slice(0, REASON_MAX - 1)}…` : line;
 }
 
-/**
- * Scheduled jobs whose last run FAILED, worst streak first.
- *
- * The banner is on every page and already fetches the whole schedule, but it
- * only ever looked at `daily`. So a `crystallize` that has been failing for
- * days is visible ONLY to someone who opens the hidden System page and selects
- * that job — which is the silent-failure shape this is meant to remove.
- *
- * `daily` is excluded on purpose: the banner reports it from the heartbeat,
- * with live progress and a richer status than the schedule row carries.
- * Listing it here too would double-report the same run.
- */
 export function failingJobs(
   jobs: readonly ScheduleJobLike[] | null | undefined,
   opts: { exclude?: readonly string[] } = {},


### PR DESCRIPTION
## The gap, with live evidence

`RunBanner` sits on every page and already fetched the whole schedule — then kept only `daily`. So a scheduled job that had been failing for days was visible **only** to someone who opened the hidden System page and selected that job, while every page showed a green banner.

This vault is in that state right now:

```
crystallize  error  cf=1  last=2026-08-23T10:04:08  (2d ago)
daily        ok     cf=0  last=2026-08-25T20:07:25
themes       ok     cf=0  last=2026-08-23T09:33:38
```

Failing jobs now render above the banner — which job, how many attempts, when the last one was, and the run's final stderr line — clicking through to that job on System. Amber, not red: the daily loop is healthy, and the point is to stop a multi-day failure being silent, not to make the portal look broken. `daily` is excluded; the banner already reports it from the heartbeat with live progress.

Logic is in `derive.ts` as pure functions because console-ui tests run in node with no DOM.

## What C3.1 turned out NOT to need

The planned run-length compression and "show raw" reveal solve **Cabinet's** problem, not ours. Cabinet renders a live ANSI PTY stream where a spinner frame repeats 300×. Our stderr tail is bounded **at capture** to 12 lines / 2048 bytes, keeps the newest bytes, and carries no ANSI — the real sample is 562 bytes over 2 unique lines. Compression would remove nothing, and `AutomationPanel` already shows the whole tail, so there is nothing hidden for a reveal to reveal.

## Real data corrected the implementation twice

- **`firstErrorLine` was the *first* line.** Run against the live failure it showed the operator `crystal-synth: embedding 1 pack(s) with Xenova/…` — progress chatter — while the cause, `error: gate: strength verdicts incomplete`, was the last line.
- **Then it pattern-matched for error-looking lines**, which codex showed was wrong in both directions: it missed causes carrying no keyword (`Caused by:` → `Permission denied (os error 13)`) and matched summaries that do (`summary: failed: 0`). It is now simply the last non-blank line — the run's final word. Simpler, handles every counter-example, no vocabulary to maintain.

## Codex gate: six findings, all fixed

Two P1s: **`--warn-fg` does not exist** (I invented the token and gave it a light-mode literal fallback, ~2:1 contrast in dark mode — and my own grep "confirmed" it existed because the only file referencing it was the one I had just written); and **the schedule was refetched only when the daily banner changed**, so a non-daily job could fail or recover invisibly. Four P2s: the misleading "failing since" wording, the click-through landing on `daily`, no live region, and the line heuristic above.

## Tests

229 portal tests, 13 new for `failingJobs` / `firstErrorLine`, including both codex counter-examples and the verbatim live failure tail as a fixture.

## Acceptance

Needs `scripts/deploy-portal.sh <vault>` to be visible — `npm run build` passing is not the acceptance criterion. This is the second portal PR waiting on that (the other is the scheduler-quarantine card in #462, already merged), so one deploy verifies both.
