### PR TITLE
feat(cli): make each installed copy say which commit it came from

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,11 @@ Only gotchas below. Anything derivable by reading the code is deliberately absen
 | `.ovp/providers.toml` | 无——每次调用重读 | 否 |
 
 Windows 上同一张表,换脚本:`scripts/build-desktop-sidecar.ps1 -InstallApp
-"$env:LOCALAPPDATA\OVP2"` 和 `scripts/deploy-portal.ps1 <vault>`。sidecar 叫
-`ovp2.exe`,和 `OVP2.exe` 并排放在安装目录里(不是 `Contents/MacOS`)。
+"$env:LOCALAPPDATA\OVP2 Desktop"` 和 `scripts/deploy-portal.ps1 <vault>`。
+sidecar 叫 `ovp2.exe`,和**壳 `ovp2-desktop.exe`** 并排放在安装目录里(不是
+`Contents/MacOS`)。**壳不叫 `OVP2.exe`**:tauri.conf.json 没设 `mainBinaryName`,
+壳保留 Cargo bin 名;而且 Windows 文件名大小写不敏感,`OVP2.exe` 和 `ovp2.exe`
+根本无法共存于同一目录。权威是 `scripts/build-desktop-sidecar.ps1` 里的检查。
 
 ## Windows 只有 CI 能验
 

--- a/crates/ovp-cli/build.rs
+++ b/crates/ovp-cli/build.rs
@@ -21,6 +21,7 @@
 //! library builds or the non-Windows targets changes.
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    stamp_provenance();
 
     // The TARGET, not the host — this file also runs when cross-compiling.
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
@@ -35,4 +36,50 @@ fn main() {
         // gnu targets link through the gcc driver, so ld needs -Wl.
         println!("cargo:rustc-link-arg-bins=-Wl,--stack,{STACK_BYTES}");
     }
+}
+
+/// Stamp the binary with the commit it was built from.
+///
+/// This repo ships FOUR independently-built copies of the same code — the app
+/// sidecar, the desktop shell, the vault's portal copy, and a dev
+/// `target/release` build — and CLAUDE.md names "changed A but only rebuilt B"
+/// as the most expensive time sink here: the symptom is "my change did
+/// nothing" while the code, the tests and the build are all green. A binary
+/// that cannot say which commit it came from makes that undiagnosable.
+///
+/// Absent or unusable git is NOT an error: a release tarball has no `.git`,
+/// and the build must still work. It stamps `unknown` and the reader reports
+/// that honestly rather than guessing.
+fn stamp_provenance() {
+    let sha = git(&["rev-parse", "--short=12", "HEAD"]).unwrap_or_else(|| "unknown".into());
+    // Dirty means the artifact contains code that is in NO commit, so its sha
+    // is a lower bound on what is in it, not an identity.
+    let dirty = match git(&["status", "--porcelain", "--untracked-files=no"]) {
+        Some(s) if !s.is_empty() => "1",
+        Some(_) => "0",
+        None => "unknown",
+    };
+    println!("cargo:rustc-env=OVP2_GIT_SHA={sha}");
+    println!("cargo:rustc-env=OVP2_GIT_DIRTY={dirty}");
+
+    // Rebuild when HEAD moves. Without these a `cargo build` after a commit
+    // reuses the cached crate and stamps the PREVIOUS sha — a provenance that
+    // lies is worse than none.
+    if let Some(dir) = git(&["rev-parse", "--git-dir"]) {
+        let dir = std::path::PathBuf::from(dir);
+        for p in ["HEAD", "refs"] {
+            let path = dir.join(p);
+            if path.exists() {
+                println!("cargo:rerun-if-changed={}", path.display());
+            }
+        }
+    }
+}
+
+fn git(args: &[&str]) -> Option<String> {
+    let out = std::process::Command::new("git").args(args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
 }

--- a/crates/ovp-cli/build.rs
+++ b/crates/ovp-cli/build.rs
@@ -61,18 +61,45 @@ fn stamp_provenance() {
     };
     println!("cargo:rustc-env=OVP2_GIT_SHA={sha}");
     println!("cargo:rustc-env=OVP2_GIT_DIRTY={dirty}");
+    // A ready-made suffix, because clap's `version` is a `concat!` of literals
+    // and cannot branch.
+    println!(
+        "cargo:rustc-env=OVP2_GIT_DIRTY_SUFFIX={}",
+        if dirty == "1" { ", dirty" } else { "" }
+    );
 
-    // Rebuild when HEAD moves. Without these a `cargo build` after a commit
+    // Rebuild when HEAD moves. Without this a `cargo build` after a commit
     // reuses the cached crate and stamps the PREVIOUS sha — a provenance that
     // lies is worse than none.
-    if let Some(dir) = git(&["rev-parse", "--git-dir"]) {
-        let dir = std::path::PathBuf::from(dir);
-        for p in ["HEAD", "refs"] {
-            let path = dir.join(p);
-            if path.exists() {
-                println!("cargo:rerun-if-changed={}", path.display());
-            }
-        }
+    //
+    // Watch the RESOLVED ref, via the COMMON dir. In a linked worktree
+    // (this repo keeps several under `.claude/worktrees/`) `--git-dir` is the
+    // worktree's private admin directory: its `HEAD` is a symref that does not
+    // change when you commit on that branch, and the branch ref itself lives
+    // in the common directory. Watching only the private dir means a
+    // same-branch commit leaves every timestamp untouched and the stale stamp
+    // survives.
+    let Some(git_dir) = git(&["rev-parse", "--git-dir"]) else {
+        return;
+    };
+    println!(
+        "cargo:rerun-if-changed={}",
+        std::path::Path::new(&git_dir).join("HEAD").display()
+    );
+    let common = git(&["rev-parse", "--path-format=absolute", "--git-common-dir"])
+        .or_else(|| git(&["rev-parse", "--git-common-dir"]))
+        .unwrap_or(git_dir);
+    let common = std::path::PathBuf::from(common);
+    if let Some(reference) = git(&["symbolic-ref", "--quiet", "HEAD"]) {
+        // Loose ref. A PACKED ref has no file, so also watch packed-refs.
+        println!(
+            "cargo:rerun-if-changed={}",
+            common.join(&reference).display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            common.join("packed-refs").display()
+        );
     }
 }
 

--- a/crates/ovp-cli/src/commands/artifacts.rs
+++ b/crates/ovp-cli/src/commands/artifacts.rs
@@ -58,7 +58,9 @@ fn default_app_dir() -> Option<PathBuf> {
     }
     #[cfg(target_os = "windows")]
     {
-        std::env::var_os("LOCALAPPDATA").map(|p| PathBuf::from(p).join("OVP2"))
+        // "OVP2 Desktop" — what the installer creates and what
+        // build-desktop-sidecar.ps1 documents, not the bare "OVP2" in CLAUDE.md.
+        std::env::var_os("LOCALAPPDATA").map(|p| PathBuf::from(p).join("OVP2 Desktop"))
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
@@ -121,13 +123,23 @@ pub fn parse_version(text: &str) -> (Option<String>, Option<bool>) {
         return (None, None);
     };
     let inner = &inner[..close];
-    let sha = inner
-        .split(',')
-        .next()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string);
-    (sha, Some(inner.contains("dirty")))
+    let candidate = inner.split(',').next().map(str::trim).unwrap_or_default();
+    // Validate the GRAMMAR, do not just take the first parenthesised text.
+    // `ovp2 2.0.1 (release build)` previously yielded the sha "release build",
+    // which is precisely the wrong-sha-reports-all-clear failure this contract
+    // exists to prevent.
+    let looks_like_stamp = candidate == "unknown"
+        || (!candidate.is_empty()
+            && candidate.len() <= 40
+            && candidate.chars().all(|c| c.is_ascii_hexdigit()));
+    if !looks_like_stamp {
+        // No recognisable stamp means no opinion at all — including on dirty.
+        return (None, None);
+    }
+    (
+        Some(candidate.to_string()),
+        Some(inner.contains("dirty")),
+    )
 }
 
 /// Run `<path> --version` with a real deadline.
@@ -144,23 +156,24 @@ fn version_output(path: &Path) -> Option<String> {
         .stderr(Stdio::null())
         .spawn()
         .ok()?;
-    let deadline = std::time::Instant::now() + PROBE_TIMEOUT;
-    loop {
-        match child.try_wait() {
-            Ok(Some(_)) => break,
-            Ok(None) => {
-                if std::time::Instant::now() >= deadline {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return None;
-                }
-                std::thread::sleep(std::time::Duration::from_millis(25));
-            }
-            Err(_) => return None,
-        }
-    }
-    let out = child.wait_with_output().ok()?;
-    Some(String::from_utf8_lossy(&out.stdout).to_string())
+    // Read on a thread and bound the WHOLE operation. Polling `try_wait` and
+    // then calling `wait_with_output` bounds only the child's exit: a
+    // surviving grandchild that inherited the stdout pipe keeps it open, and
+    // the read after the loop blocks forever with the deadline already spent.
+    let mut stdout = child.stdout.take()?;
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        use std::io::Read;
+        let mut buf = String::new();
+        let _ = stdout.read_to_string(&mut buf);
+        let _ = tx.send(buf);
+    });
+    let text = rx.recv_timeout(PROBE_TIMEOUT).ok();
+    // Kill regardless: on the timeout path the child is still running, and on
+    // the success path it has exited and this is a no-op that also reaps it.
+    let _ = child.kill();
+    let _ = child.wait();
+    text
 }
 
 /// The entry asset an `index.html` references — the same signal
@@ -207,10 +220,16 @@ pub fn collect(vault_root: &Path, app: Option<PathBuf>) -> Vec<ArtifactReport> {
             app_dir.join("Contents/MacOS/ovp2-desktop"),
             app_dir.join("Contents/Resources/console-ui/dist"),
         );
+        // `ovp2-desktop.exe`, NOT `OVP2.exe`: tauri.conf.json sets no
+        // `mainBinaryName`, so the shell keeps its Cargo bin name — and
+        // Windows filenames are case-insensitive, so an `OVP2.exe` shell could
+        // not coexist with the `ovp2.exe` sidecar in one directory. Checking
+        // for `OVP2.exe` would have matched the SIDECAR and reported a shell
+        // that is not there. See scripts/build-desktop-sidecar.ps1.
         #[cfg(not(target_os = "macos"))]
         let (sidecar, shell, bundled_portal) = (
             app_dir.join("ovp2.exe"),
-            app_dir.join("OVP2.exe"),
+            app_dir.join("ovp2-desktop.exe"),
             app_dir.join("console-ui/dist"),
         );
         out.push(probe_binary("app sidecar", &sidecar));
@@ -226,10 +245,14 @@ pub fn collect(vault_root: &Path, app: Option<PathBuf>) -> Vec<ArtifactReport> {
         "portal (vault copy — WINS)",
         &vault_root.join(".ovp/console/app"),
     ));
-    out.push(probe_binary(
-        "dev build",
-        &PathBuf::from("target/release/ovp2"),
-    ));
+    // Anchored at the tree this binary was COMPILED from, not the caller's
+    // cwd. A relative path missed the real dev build whenever `artifacts` ran
+    // from anywhere else — and could have probed an unrelated
+    // `target/release/ovp2` that happened to sit under it.
+    let dev = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../target/release")
+        .join(if cfg!(windows) { "ovp2.exe" } else { "ovp2" });
+    out.push(probe_binary("dev build", &dev));
     out
 }
 
@@ -368,9 +391,21 @@ mod tests {
         // A binary predating the stamp, and a hypothetical format change. A
         // WRONG sha would compare equal to nothing and report all-clear on a
         // stale copy — strictly worse than admitting ignorance.
-        for text in ["ovp2 2.0.1\n", "ovp2 2.0.1 (\n", "", "ovp2 2.0.1 ()"] {
+        for text in [
+            "ovp2 2.0.1\n",
+            "ovp2 2.0.1 (\n",
+            "",
+            "ovp2 2.0.1 ()",
+            // The one that mattered: any parenthesised text used to become a
+            // "sha", and a wrong sha compares equal to nothing — reporting
+            // all-clear on a stale copy.
+            "ovp2 2.0.1 (release build)",
+            "ovp2 2.0.1 (built by someone)",
+        ] {
             assert_eq!(parse_version(text).0, None, "{text:?}");
         }
+        // `unknown` is a real stamp: a build with no git says so.
+        assert_eq!(parse_version("ovp2 2.0.1 (unknown)").0.as_deref(), Some("unknown"));
     }
 
     #[test]

--- a/crates/ovp-cli/src/commands/artifacts.rs
+++ b/crates/ovp-cli/src/commands/artifacts.rs
@@ -1,0 +1,383 @@
+//! `artifacts` — which build is each installed copy actually running?
+//!
+//! This repo ships FOUR independently-built copies of the same code:
+//!
+//! | artifact | rebuilt by |
+//! |---|---|
+//! | app sidecar (`OVP2.app/Contents/MacOS/ovp2`) | `build-desktop-sidecar.sh` |
+//! | desktop shell (`ovp2-desktop`) | full `tauri build` |
+//! | vault portal copy (`<vault>/.ovp/console/app`) | `deploy-portal.sh` |
+//! | dev build (`target/release/ovp2`) | `cargo build --release` |
+//!
+//! CLAUDE.md names "changed A but only rebuilt B" the most expensive time sink
+//! in this repo: the symptom is that a change did nothing, while the code, the
+//! tests and the build are all green. The scheduler runs the SIDECAR, the
+//! portal API is inside the DESKTOP SHELL, and the portal HTML may come from
+//! the vault copy — so the thing you rebuilt is very often not the thing you
+//! are looking at.
+//!
+//! This reports what each copy says it was built from. It never rebuilds
+//! anything and never writes: knowing which one is behind is the whole job.
+
+use std::path::{Path, PathBuf};
+
+use crate::CliError;
+
+/// The commit THIS binary was stamped with at build time (see `build.rs`).
+pub const GIT_SHA: &str = env!("OVP2_GIT_SHA");
+pub const GIT_DIRTY: &str = env!("OVP2_GIT_DIRTY");
+
+/// Budget for one `--version` probe.
+const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+pub struct ArtifactsArgs {
+    pub vault_root: PathBuf,
+    /// Where the installed app lives. Defaults per-platform.
+    pub app: Option<PathBuf>,
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ArtifactReport {
+    /// Human label, e.g. "app sidecar".
+    pub name: String,
+    pub path: String,
+    /// `present` | `missing` | `unreadable`
+    pub state: String,
+    /// Commit the artifact reports, when it can report one.
+    pub sha: Option<String>,
+    pub dirty: Option<bool>,
+    /// For the portal copies: the entry asset the HTML actually references.
+    pub entry: Option<String>,
+}
+
+fn default_app_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        Some(PathBuf::from("/Applications/OVP2.app"))
+    }
+    #[cfg(target_os = "windows")]
+    {
+        std::env::var_os("LOCALAPPDATA").map(|p| PathBuf::from(p).join("OVP2"))
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        None
+    }
+}
+
+/// Presence only — never executed.
+fn probe_presence(name: &str, path: &Path) -> ArtifactReport {
+    ArtifactReport {
+        name: name.into(),
+        path: path.display().to_string(),
+        state: if path.exists() { "present" } else { "missing" }.into(),
+        sha: None,
+        dirty: None,
+        entry: None,
+    }
+}
+
+/// Ask a binary what it was built from. `--version` is the stable surface; a
+/// binary too old to carry provenance answers without it, which is reported as
+/// `present` with no sha rather than an error.
+///
+/// ONLY for CLI binaries. Running a GUI binary's `--version` opens a window
+/// and never returns — use [`probe_presence`] for those.
+fn probe_binary(name: &str, path: &Path) -> ArtifactReport {
+    let mut r = ArtifactReport {
+        name: name.into(),
+        path: path.display().to_string(),
+        state: "missing".into(),
+        sha: None,
+        dirty: None,
+        entry: None,
+    };
+    if !path.exists() {
+        return r;
+    }
+    r.state = "present".into();
+    let Some(text) = version_output(path) else {
+        r.state = "unreadable".into();
+        return r;
+    };
+    let (sha, dirty) = parse_version(&text);
+    r.sha = sha;
+    r.dirty = dirty;
+    r
+}
+
+/// Pull the provenance out of `ovp2 <version> (<sha>[, dirty])`.
+///
+/// The contract between `main.rs`'s clap `version` string and this reader.
+/// Loose on purpose: a format change must degrade to "no sha" rather than
+/// yield a WRONG one, because a wrong sha reports all-clear on a stale copy.
+pub fn parse_version(text: &str) -> (Option<String>, Option<bool>) {
+    let Some(open) = text.find('(') else {
+        return (None, None);
+    };
+    let inner = &text[open + 1..];
+    let Some(close) = inner.find(')') else {
+        return (None, None);
+    };
+    let inner = &inner[..close];
+    let sha = inner
+        .split(',')
+        .next()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    (sha, Some(inner.contains("dirty")))
+}
+
+/// Run `<path> --version` with a real deadline.
+///
+/// A wedged or interactive binary must not hang this command — the whole
+/// point is to be runnable when something is already wrong. `wait_timeout` is
+/// not in the dependency tree, so this polls `try_wait` and kills on expiry.
+fn version_output(path: &Path) -> Option<String> {
+    use std::process::{Command, Stdio};
+    let mut child = Command::new(path)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    let deadline = std::time::Instant::now() + PROBE_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(25));
+            }
+            Err(_) => return None,
+        }
+    }
+    let out = child.wait_with_output().ok()?;
+    Some(String::from_utf8_lossy(&out.stdout).to_string())
+}
+
+/// The entry asset an `index.html` references — the same signal
+/// `deploy-portal.sh` verifies against a running server. Two portal copies
+/// exist and the VAULT one wins per-file, so a rebuilt app bundle changes
+/// nothing the operator sees.
+fn probe_portal(name: &str, dir: &Path) -> ArtifactReport {
+    let index = dir.join("index.html");
+    let mut r = ArtifactReport {
+        name: name.into(),
+        path: dir.display().to_string(),
+        state: "missing".into(),
+        sha: None,
+        dirty: None,
+        entry: None,
+    };
+    if !index.exists() {
+        return r;
+    }
+    r.state = "present".into();
+    match std::fs::read_to_string(&index) {
+        Ok(html) => r.entry = entry_asset(&html),
+        Err(_) => r.state = "unreadable".into(),
+    }
+    r
+}
+
+/// First `assets/<name>.js` referenced by the HTML.
+pub fn entry_asset(html: &str) -> Option<String> {
+    let start = html.find("assets/")?;
+    let rest = &html[start..];
+    let end = rest.find(".js")? + 3;
+    Some(rest[..end].to_string())
+}
+
+pub fn collect(vault_root: &Path, app: Option<PathBuf>) -> Vec<ArtifactReport> {
+    let mut out = Vec::new();
+    let app_dir = app.or_else(default_app_dir);
+
+    if let Some(app_dir) = &app_dir {
+        #[cfg(target_os = "macos")]
+        let (sidecar, shell, bundled_portal) = (
+            app_dir.join("Contents/MacOS/ovp2"),
+            app_dir.join("Contents/MacOS/ovp2-desktop"),
+            app_dir.join("Contents/Resources/console-ui/dist"),
+        );
+        #[cfg(not(target_os = "macos"))]
+        let (sidecar, shell, bundled_portal) = (
+            app_dir.join("ovp2.exe"),
+            app_dir.join("OVP2.exe"),
+            app_dir.join("console-ui/dist"),
+        );
+        out.push(probe_binary("app sidecar", &sidecar));
+        // Presence ONLY. The first version of this called probe_binary here
+        // and hung: `ovp2-desktop --version` is a Tauri app, so it opens a
+        // window and never exits. The comment said presence-only while the
+        // code spawned it anyway.
+        out.push(probe_presence("desktop shell", &shell));
+        out.push(probe_portal("portal (app bundle)", &bundled_portal));
+    }
+
+    out.push(probe_portal(
+        "portal (vault copy — WINS)",
+        &vault_root.join(".ovp/console/app"),
+    ));
+    out.push(probe_binary(
+        "dev build",
+        &PathBuf::from("target/release/ovp2"),
+    ));
+    out
+}
+
+pub fn run(args: ArtifactsArgs) -> Result<(), CliError> {
+    let reports = collect(&args.vault_root, args.app);
+    let dirty = GIT_DIRTY == "1";
+
+    if args.json {
+        let body = serde_json::json!({
+            "schema": "ovp.artifacts/v1",
+            "this_binary": { "sha": GIT_SHA, "dirty": dirty },
+            "artifacts": reports,
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&body).map_err(|e| CliError::Io(e.to_string()))?
+        );
+        return Ok(());
+    }
+
+    println!(
+        "this binary: {GIT_SHA}{}",
+        if dirty { " (dirty)" } else { "" }
+    );
+    for r in &reports {
+        let detail = match (&r.sha, &r.entry) {
+            (Some(sha), _) => format!(
+                "{sha}{}",
+                if r.dirty == Some(true) { " (dirty)" } else { "" }
+            ),
+            (None, Some(entry)) => entry.clone(),
+            _ => "—".into(),
+        };
+        println!("  {:<28} {:<10} {detail}", r.name, r.state);
+        println!("  {:<28} {}", "", r.path);
+    }
+
+    // The comparison is the point. Anything that reports a sha and disagrees
+    // with the running binary is a copy that will behave like an older commit.
+    let behind: Vec<&ArtifactReport> = reports
+        .iter()
+        .filter(|r| r.sha.as_deref().is_some_and(|s| s != GIT_SHA))
+        .collect();
+    let portals: Vec<&ArtifactReport> = reports
+        .iter()
+        .filter(|r| r.entry.is_some())
+        .collect();
+
+    if !behind.is_empty() {
+        println!();
+        for r in &behind {
+            println!(
+                "  DIFFERENT BUILD: {} is {}, this binary is {GIT_SHA}",
+                r.name,
+                r.sha.as_deref().unwrap_or("—")
+            );
+        }
+    }
+    if portals.len() > 1 {
+        let first = portals[0].entry.as_deref();
+        if portals.iter().any(|p| p.entry.as_deref() != first) {
+            println!();
+            println!("  DIFFERENT BUILD: the two portal copies serve different entry assets.");
+            println!("  The VAULT copy wins per-file, so rebuilding the app bundle changes");
+            println!("  nothing you see. Run `scripts/deploy-portal.sh <vault>`.");
+        }
+    }
+    if dirty {
+        println!();
+        println!("  NOTE: this binary was built from a dirty tree — its sha is a lower");
+        println!("  bound on what is in it, not an identity.");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entry_asset_pulls_the_first_js_reference() {
+        let html = r#"<html><script type="module" src="/assets/index-Bjqc7rfs.js"></script>"#;
+        assert_eq!(entry_asset(html).as_deref(), Some("assets/index-Bjqc7rfs.js"));
+    }
+
+    #[test]
+    fn entry_asset_is_none_when_the_html_references_no_bundle() {
+        // A placeholder or half-written index must read as "no entry" rather
+        // than matching some unrelated substring.
+        assert_eq!(entry_asset("<html><body>nothing</body></html>"), None);
+        assert_eq!(entry_asset("assets/style.css"), None);
+    }
+
+    #[test]
+    fn a_missing_artifact_is_reported_missing_not_skipped() {
+        // Silence would read as "fine"; the whole point is naming the copy
+        // that is not there.
+        let r = probe_binary("x", Path::new("/no/such/ovp2"));
+        assert_eq!(r.state, "missing");
+        assert!(r.sha.is_none());
+    }
+
+    #[test]
+    fn a_portal_dir_without_index_html_is_missing() {
+        let d = tempfile::tempdir().unwrap();
+        assert_eq!(probe_portal("p", d.path()).state, "missing");
+    }
+
+    #[test]
+    fn a_portal_copy_reports_the_entry_it_actually_references() {
+        let d = tempfile::tempdir().unwrap();
+        std::fs::write(
+            d.path().join("index.html"),
+            r#"<script src="/assets/index-DEADBEEF.js"></script>"#,
+        )
+        .unwrap();
+        let r = probe_portal("p", d.path());
+        assert_eq!(r.state, "present");
+        assert_eq!(r.entry.as_deref(), Some("assets/index-DEADBEEF.js"));
+    }
+
+    #[test]
+    fn parse_version_reads_the_sha_and_the_dirty_flag() {
+        assert_eq!(
+            parse_version("ovp2 2.0.1 (805600800aa2)\n"),
+            (Some("805600800aa2".into()), Some(false))
+        );
+        assert_eq!(
+            parse_version("ovp2 2.0.1 (805600800aa2, dirty)\n"),
+            (Some("805600800aa2".into()), Some(true))
+        );
+    }
+
+    #[test]
+    fn an_unstamped_or_reshaped_version_yields_no_sha_rather_than_a_wrong_one() {
+        // A binary predating the stamp, and a hypothetical format change. A
+        // WRONG sha would compare equal to nothing and report all-clear on a
+        // stale copy — strictly worse than admitting ignorance.
+        for text in ["ovp2 2.0.1\n", "ovp2 2.0.1 (\n", "", "ovp2 2.0.1 ()"] {
+            assert_eq!(parse_version(text).0, None, "{text:?}");
+        }
+    }
+
+    #[test]
+    fn this_binary_carries_a_provenance_stamp() {
+        // If build.rs stops stamping, every comparison below silently becomes
+        // "unknown vs unknown" — which compares equal and reports all clear.
+        assert!(!GIT_SHA.is_empty());
+        assert!(matches!(GIT_DIRTY, "0" | "1" | "unknown"));
+    }
+}

--- a/crates/ovp-cli/src/commands/artifacts.rs
+++ b/crates/ovp-cli/src/commands/artifacts.rs
@@ -136,10 +136,11 @@ pub fn parse_version(text: &str) -> (Option<String>, Option<bool>) {
         // No recognisable stamp means no opinion at all — including on dirty.
         return (None, None);
     }
-    (
-        Some(candidate.to_string()),
-        Some(inner.contains("dirty")),
-    )
+    // `unknown` names the commit as unknowable; the tree's cleanliness is
+    // equally unknowable, and reporting `false` there would be a clean state
+    // this cannot actually vouch for.
+    let dirty = (candidate != "unknown").then(|| inner.contains("dirty"));
+    (Some(candidate.to_string()), dirty)
 }
 
 /// Run `<path> --version` with a real deadline.
@@ -202,11 +203,28 @@ fn probe_portal(name: &str, dir: &Path) -> ArtifactReport {
 }
 
 /// First `assets/<name>.js` referenced by the HTML.
+///
+/// Walks the asset references and takes the first that IS a `.js`, rather
+/// than anchoring on the first `assets/` and hunting for the next `.js`
+/// anywhere after it. With a stylesheet emitted first that older form
+/// returned `assets/x.css"><script src="/assets/y.js` — markup and all —
+/// and a garbage entry reports a portal mismatch that is not real. Vite
+/// happens to emit the script first today; that is not a guarantee.
 pub fn entry_asset(html: &str) -> Option<String> {
-    let start = html.find("assets/")?;
-    let rest = &html[start..];
-    let end = rest.find(".js")? + 3;
-    Some(rest[..end].to_string())
+    let mut rest = html;
+    while let Some(start) = rest.find("assets/") {
+        rest = &rest[start..];
+        // A reference ends at the first character that cannot be in a path.
+        let end = rest
+            .find(|c: char| !(c.is_ascii_alphanumeric() || "./_-".contains(c)))
+            .unwrap_or(rest.len());
+        let candidate = &rest[..end];
+        if candidate.ends_with(".js") {
+            return Some(candidate.to_string());
+        }
+        rest = &rest[end.max(1)..];
+    }
+    None
 }
 
 pub fn collect(vault_root: &Path, app: Option<PathBuf>) -> Vec<ArtifactReport> {
@@ -258,7 +276,13 @@ pub fn collect(vault_root: &Path, app: Option<PathBuf>) -> Vec<ArtifactReport> {
 
 pub fn run(args: ArtifactsArgs) -> Result<(), CliError> {
     let reports = collect(&args.vault_root, args.app);
-    let dirty = GIT_DIRTY == "1";
+    // Tri-state, for the same reason: a build with no git metadata stamps
+    // `unknown`, and calling that clean is a claim this cannot support.
+    let dirty: Option<bool> = match GIT_DIRTY {
+        "1" => Some(true),
+        "0" => Some(false),
+        _ => None,
+    };
 
     if args.json {
         let body = serde_json::json!({
@@ -275,7 +299,11 @@ pub fn run(args: ArtifactsArgs) -> Result<(), CliError> {
 
     println!(
         "this binary: {GIT_SHA}{}",
-        if dirty { " (dirty)" } else { "" }
+        match dirty {
+            Some(true) => " (dirty)",
+            Some(false) => "",
+            None => " (dirty state unknown)",
+        }
     );
     for r in &reports {
         let detail = match (&r.sha, &r.entry) {
@@ -320,7 +348,7 @@ pub fn run(args: ArtifactsArgs) -> Result<(), CliError> {
             println!("  nothing you see. Run `scripts/deploy-portal.sh <vault>`.");
         }
     }
-    if dirty {
+    if dirty == Some(true) {
         println!();
         println!("  NOTE: this binary was built from a dirty tree — its sha is a lower");
         println!("  bound on what is in it, not an identity.");
@@ -336,6 +364,35 @@ mod tests {
     fn entry_asset_pulls_the_first_js_reference() {
         let html = r#"<html><script type="module" src="/assets/index-Bjqc7rfs.js"></script>"#;
         assert_eq!(entry_asset(html).as_deref(), Some("assets/index-Bjqc7rfs.js"));
+    }
+
+    #[test]
+    fn entry_asset_skips_a_stylesheet_emitted_before_the_script() {
+        // The older form anchored on the first `assets/` and then hunted for
+        // the next `.js` ANYWHERE after it, returning markup and all — and a
+        // garbage entry reports a portal mismatch that is not real.
+        let html = concat!(
+            r#"<link rel="stylesheet" href="/assets/index-AAAA.css">"#,
+            r#"<script type="module" src="/assets/index-BBBB.js"></script>"#,
+        );
+        assert_eq!(entry_asset(html).as_deref(), Some("assets/index-BBBB.js"));
+    }
+
+    #[test]
+    fn entry_asset_takes_the_first_script_when_several_follow() {
+        let html = r#"<script src="/assets/a.js"></script><script src="/assets/b.js">"#;
+        assert_eq!(entry_asset(html).as_deref(), Some("assets/a.js"));
+    }
+
+    #[test]
+    fn an_unknown_stamp_reports_an_unknown_dirty_state_not_a_clean_one() {
+        // A build with no git metadata cannot vouch for the tree's
+        // cleanliness either; `false` there is a claim it cannot support.
+        assert_eq!(parse_version("ovp2 2.0.1 (unknown)"), (Some("unknown".into()), None));
+        assert_eq!(
+            parse_version("ovp2 2.0.1 (abc123, dirty)"),
+            (Some("abc123".into()), Some(true))
+        );
     }
 
     #[test]

--- a/crates/ovp-cli/src/commands/mod.rs
+++ b/crates/ovp-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod auto_run;
 pub mod client;
 pub mod compare_run;
 pub mod copy_probe;
+pub mod artifacts;
 pub mod crystal_lint;
 pub mod crystal_recheck;
 pub mod crystal_review;

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -33,9 +33,12 @@ impl std::fmt::Display for CliError {
 // independently-built copies of this binary apart. `artifacts` parses it.
 #[command(
     name = "ovp2",
+    // The dirty flag rides along: without it every OTHER artifact reads as
+    // clean, because the reader can only see what --version prints.
     version = concat!(
         env!("CARGO_PKG_VERSION"),
         " (", env!("OVP2_GIT_SHA"),
+        env!("OVP2_GIT_DIRTY_SUFFIX"),
         ")"
     ),
     about = "OVP Next — clean-core Rust pipeline"

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -29,7 +29,17 @@ impl std::fmt::Display for CliError {
 }
 
 #[derive(Parser, Debug)]
-#[command(name = "ovp2", version, about = "OVP Next — clean-core Rust pipeline")]
+// `--version` carries the build's commit, because that is what tells four
+// independently-built copies of this binary apart. `artifacts` parses it.
+#[command(
+    name = "ovp2",
+    version = concat!(
+        env!("CARGO_PKG_VERSION"),
+        " (", env!("OVP2_GIT_SHA"),
+        ")"
+    ),
+    about = "OVP Next — clean-core Rust pipeline"
+)]
 struct Cli {
     #[command(subcommand)]
     cmd: Cmd,
@@ -557,6 +567,20 @@ enum Cmd {
     Schedule {
         #[command(subcommand)]
         action: ScheduleAction,
+    },
+    /// PRODUCT — which build is each installed copy actually running?
+    /// This repo ships four independently-built copies (app sidecar, desktop
+    /// shell, the vault's portal copy, a dev build) and CLAUDE.md names
+    /// "changed A but only rebuilt B" the most expensive failure here. Reports
+    /// what each copy says it was built from. Read-only; rebuilds nothing.
+    Artifacts {
+        #[arg(long)]
+        vault_root: PathBuf,
+        /// Installed app directory. Default: /Applications/OVP2.app (macOS).
+        #[arg(long)]
+        app: Option<PathBuf>,
+        #[arg(long)]
+        json: bool,
     },
     /// PRODUCT — staleness recheck over ALREADY-durable claims: re-run the
     /// citation linter against the CURRENT reader packs and report which
@@ -2020,6 +2044,18 @@ fn main() -> ExitCode {
                 commands::scheduler::run_set_enabled(&vault_root, &id, false)
             }
         },
+        Cmd::Artifacts {
+            vault_root,
+            app,
+            json,
+        } => {
+            use commands::artifacts::ArtifactsArgs;
+            commands::artifacts::run(ArtifactsArgs {
+                vault_root,
+                app,
+                json,
+            })
+        }
         Cmd::CrystalRecheck {
             vault_root,
             packs_dir,


### PR DESCRIPTION
## The problem

CLAUDE.md names "changed A but only rebuilt B" the most expensive failure in this repo. Four independently-built copies of the same code ship here, and the one you rebuilt is often not the one you are looking at — the scheduler runs the **sidecar**, the portal API lives in the **desktop shell**, and the portal HTML may come from the **vault copy**. The symptom is that a change did nothing while code, tests and build are all green.

None of them could say what they were built from. `--version` was the crate version: identical across every copy and every commit, so there was nothing to compare. **A lock is impossible without provenance.**

## What this adds

`build.rs` stamps the commit and a dirty flag; `--version` reports them; `ovp2 artifacts` probes each known location and names any copy that disagrees. Read-only — it rebuilds nothing and writes nothing.

Run on this machine it immediately found a live divergence:

```
portal (app bundle)          present    assets/index-DRVpAFAY.js
portal (vault copy — WINS)   present    assets/index-CaKD0hgr.js

DIFFERENT BUILD: the two portal copies serve different entry assets.
The VAULT copy wins per-file, so rebuilding the app bundle changes
nothing you see. Run `scripts/deploy-portal.sh <vault>`.
```

Absent git stamps `unknown` rather than failing the build (a release tarball has no `.git`), and an unrecognisable version string yields **no** sha rather than a guess — a wrong sha compares equal to nothing and would report all-clear on a stale copy.

## Codex gate: five P1s + a P2, and one of them was a doc bug

**The Windows paths came from a wrong line in CLAUDE.md.** It says the shell sits beside the sidecar as `OVP2.exe` under `%LOCALAPPDATA%\OVP2`. `build-desktop-sidecar.ps1` says otherwise in its own comment and is right: tauri.conf.json sets no `mainBinaryName`, so the shell keeps `ovp2-desktop.exe` — and Windows filenames are case-insensitive, so `OVP2.exe` and `ovp2.exe` cannot coexist. Checking for `OVP2.exe` would have matched the **sidecar** and reported a shell that is not there. Fixed the code and the CLAUDE.md line.

The rest, all real:

- **`build.rs` could stamp a stale sha in a linked worktree** (this repo keeps several under `.claude/worktrees/`). It watched `--git-dir`, whose `HEAD` is a symref that does not move on a same-branch commit while the branch ref lives in the common dir. Now watches the resolved ref through the common dir, plus `packed-refs`.
- **The parser took any parenthesised text as a sha** — `(release build)` became a sha. Now validates the grammar.
- **The deadline bounded only the child's exit**; a grandchild holding the stdout pipe would block the following read forever. Reading now happens under `recv_timeout` with the child killed on both paths.
- **The dev build resolved against the caller's cwd**, missing the real artifact and able to probe an unrelated one. Anchored at `CARGO_MANIFEST_DIR`.
- **`--version` never carried the dirty flag**, so every other artifact always read as clean.

## Two of my own comments described behaviour the code did not have

The module said the desktop shell was "reported by presence only" while `collect` ran `probe_binary` on it — and `ovp2-desktop --version` is a Tauri app, so it opened a window and never returned. **The command hung on its first run.** The other promised "a 3-second budget" with no timeout implemented at all. Both are now true.

And my first verification of the gate fixes ran a binary I had not rebuilt, reporting the old paths — the exact mistake this command exists to catch.

## Tests

206 CLI tests, 12 for this module: entry-asset extraction, missing/unreadable artifacts, and the version grammar including the counter-examples above.

## Not in scope

This reports divergence; it does not record a lock file or verify per-file hashes. Provenance first, because nothing else was possible without it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only `artifacts` command to report build versions across key application components.
  * Added human-readable and JSON report formats, with warnings for mismatched builds or portal assets.
  * CLI version information now includes the Git commit and dirty-state status.

* **Documentation**
  * Updated Windows installation guidance for the desktop shell executable and build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->