### PR TITLE
feat(crystal): keep the model replies we reject

### DIFF
--- a/crates/ovp-cli/src/commands/crystal_review_session.rs
+++ b/crates/ovp-cli/src/commands/crystal_review_session.rs
@@ -575,7 +575,7 @@ pub fn run_apply(args: CrystalReviewSessionApplyArgs) -> Result<(), CliError> {
         );
         let sub = CrystalCandidate { items: chunk.to_vec() };
         let req = strength_request(&sub, &catalog);
-        let (mut chunk_verdicts, log): (Vec<ClaimStrengthVerdict>, Option<RepairLog>) =
+        let (mut chunk_verdicts, log, _raw): (Vec<ClaimStrengthVerdict>, Option<RepairLog>, String) =
             call_and_parse(client.as_mut(), &req, "strength", parse_strength_verdicts)?;
         // The model answered about `c1`, `c2`, … — resolve before coverage.
         // Missing this here would abort every review-session re-gate on a

--- a/crates/ovp-cli/src/commands/crystal_synth.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth.rs
@@ -156,7 +156,9 @@ pub(crate) fn call_and_parse<T>(
                 Err(d) => {
                     // Valid JSON the stage parser rejects (e.g. no `claims`
                     // array) pins a rerun just like unparseable JSON — forget
-                    // it too so the retry re-asks the model.
+                    // it too so the retry re-asks the model. Keep the exchange
+                    // first: invalidate deletes the only copy of it.
+                    super::quarantine::record(stage, request, &reply.text, &d);
                     client.invalidate(request);
                     return Err(CliError::Io(format!("crystal-synth: {stage} parse: {d}")));
                 }
@@ -185,6 +187,12 @@ pub(crate) fn call_and_parse<T>(
                     // Forget the unrecoverable exchange under a recording
                     // cache: a rerun must re-ask the model, not replay the
                     // same unparseable reply forever. No-op for replay/fakes.
+                    super::quarantine::record(
+                        stage,
+                        request,
+                        &reply.text,
+                        &format!("unrecoverable JSON: {defect}"),
+                    );
                     client.invalidate(request);
                     client.invalidate(&json_repair_request(&reply.text));
                     Err(CliError::Io(format!(
@@ -252,6 +260,10 @@ pub fn run(args: CrystalSynthArgs) -> Result<(), CliError> {
 }
 
 pub(crate) fn run_stats(args: CrystalSynthArgs) -> Result<RunStats, CliError> {
+    // Rejected replies land beside the run's other artifacts. NOT under the
+    // cassette root: nothing may read these back as a valid exchange.
+    super::quarantine::set_dir(args.work_dir.join("rejected"));
+
     // Validate --refresh prerequisites BEFORE any model calls or store writes,
     // so an invalid flag combination can never partially mutate the ledger.
     if args.refresh && (args.vault_root.is_none() || args.date.is_none()) {

--- a/crates/ovp-cli/src/commands/crystal_synth.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth.rs
@@ -145,7 +145,7 @@ pub(crate) fn call_and_parse<T>(
     request: &ovp_llm::ModelRequest,
     stage: &str,
     parse: impl Fn(&str) -> Result<T, String>,
-) -> Result<(T, Option<RepairLog>), CliError> {
+) -> Result<(T, Option<RepairLog>, String), CliError> {
     let reply = client
         .call(request)
         .map_err(|e| CliError::Io(format!("crystal-synth: {stage} call failed: {e}")))?;
@@ -167,7 +167,10 @@ pub(crate) fn call_and_parse<T>(
                 stage: stage.to_string(),
                 method: "parser-local: unescaped-backslash".to_string(),
             });
-            Ok((parsed, log))
+            // The RAW text rides along: a caller that rejects this reply on
+            // content must be able to record what the model actually said,
+            // not a reconstruction of it.
+            Ok((parsed, log, reply.text))
         }
         Err(defect) => {
             // One bounded model repair, re-parsed through the SAME parser.
@@ -182,8 +185,19 @@ pub(crate) fn call_and_parse<T>(
                         stage: stage.to_string(),
                         method: format!("model-repair (input defect: {defect})"),
                     }),
+                    repaired.clone().unwrap_or_default(),
                 )),
-                _ => {
+                other => {
+                    // The REPAIR reply too when there was one: a repair that
+                    // parsed but failed the stage parser is its own defect.
+                    if let (Some(text), Some(Err(d))) = (repaired.as_deref(), other) {
+                        super::quarantine::record(
+                            &format!("{stage}-repair"),
+                            &json_repair_request(&reply.text),
+                            text,
+                            &d,
+                        );
+                    }
                     // Forget the unrecoverable exchange under a recording
                     // cache: a rerun must re-ask the model, not replay the
                     // same unparseable reply forever. No-op for replay/fakes.
@@ -470,7 +484,7 @@ pub(crate) fn run_stats(args: CrystalSynthArgs) -> Result<RunStats, CliError> {
                     batch.cases.len()
                 );
                 let req = crystal_synth_batch_request(&catalog, batch, args.max_units_per_case);
-                let (claims, log): (Vec<CrystalClaim>, Option<RepairLog>) =
+                let (claims, log, _raw): (Vec<CrystalClaim>, Option<RepairLog>, String) =
                     call_and_parse(base.as_mut(), &req, "synth", |t| {
                         parse_synth_claims(t, &batch.claim_prefix())
                     })?;
@@ -526,7 +540,7 @@ pub(crate) fn run_stats(args: CrystalSynthArgs) -> Result<RunStats, CliError> {
                     &catalog,
                 );
                 let stage = format!("strength-b{:03}", idx + 1);
-                let (mut chunk_verdicts, log): (Vec<ClaimStrengthVerdict>, Option<RepairLog>) =
+                let (mut chunk_verdicts, log, _raw): (Vec<ClaimStrengthVerdict>, Option<RepairLog>, String) =
                     call_and_parse(base.as_mut(), &req, &stage, parse_strength_verdicts)?;
                 // The model answered about `c1`, `c2`, … — put the real claim
                 // ids back before anything downstream matches on them.

--- a/crates/ovp-cli/src/commands/crystal_synth_llm.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth_llm.rs
@@ -359,7 +359,7 @@ fn flush_strength_wave(
         calls += 1;
         stats.strength_calls += 1;
         let stage = format!("strength-w{wave:03}-{calls:03}");
-        let (mut chunk_verdicts, log): (Vec<ClaimStrengthVerdict>, _) =
+        let (mut chunk_verdicts, log, _raw): (Vec<ClaimStrengthVerdict>, _, String) =
             call_and_parse(client, &req, &stage, parse_strength_verdicts)?;
         if let Some(l) = log {
             repairs.push(l);
@@ -566,7 +566,7 @@ pub(crate) fn run_sweep(
         // incomplete — swallowing it per-seed would let a replay produce
         // different metrics than the live run, so that one stays fatal.
         // (String match: ModelClient errors are unstructured today.)
-        let (selection, log) =
+        let (selection, log, raw_reply) =
             match call_and_parse(client, &req, "cluster-select", parse_cluster_selection) {
                 Ok(v) => v,
                 Err(e) if e.to_string().contains("cache miss") => return Err(e),
@@ -616,12 +616,14 @@ pub(crate) fn run_sweep(
                 // offered — and the invalidate below left nothing to inspect.
                 // The reply alone would not have explained it either: the
                 // offered set is in the REQUEST.
-                super::quarantine::record(
-                    "cluster-select",
-                    &req,
-                    &format!("{{\"selected_case_ids\": {case_ids:?}}}"),
-                    &e,
-                );
+                // The RAW reply, not a reconstruction. The first version of
+                // this re-serialised the already-trimmed, already-ALIAS-
+                // RESOLVED `case_ids`, so the log showed long real ids the
+                // model may never have written — the resolver had put them
+                // there — and dropped the rationale entirely. A diagnostic
+                // that reports its own output as the model's is worse than
+                // none: it invents a defect.
+                super::quarantine::record("cluster-select", &req, &raw_reply, &e);
                 // Under a recording cache, forget the bad exchange so a rerun
                 // re-asks the model instead of replaying the violation forever.
                 client.invalidate(&req);
@@ -669,7 +671,7 @@ pub(crate) fn run_sweep(
             cfg.max_units_per_case,
         );
         stats.synth_calls += 1;
-        let (claims, log): (Vec<CrystalClaim>, _) =
+        let (claims, log, _raw): (Vec<CrystalClaim>, _, String) =
             call_and_parse(client, &synth_req, "synth", |t| {
                 parse_synth_claims(t, &cluster.key)
             })?;

--- a/crates/ovp-cli/src/commands/crystal_synth_llm.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth_llm.rs
@@ -348,6 +348,7 @@ fn flush_strength_wave(
     // Chunked verdicts — 1:1 coverage per wave or the run fails loud, the
     // same invariant batch mode enforces globally.
     let mut wave_verdicts: Vec<ClaimStrengthVerdict> = Vec::new();
+    let mut exchanges: Vec<(ovp_llm::ModelRequest, String)> = Vec::new();
     let mut calls = 0usize;
     for chunk in wave_claims.chunks(MAX_STRENGTH_CLAIMS_PER_CALL) {
         let req = strength_request(
@@ -359,7 +360,7 @@ fn flush_strength_wave(
         calls += 1;
         stats.strength_calls += 1;
         let stage = format!("strength-w{wave:03}-{calls:03}");
-        let (mut chunk_verdicts, log, _raw): (Vec<ClaimStrengthVerdict>, _, String) =
+        let (mut chunk_verdicts, log, raw): (Vec<ClaimStrengthVerdict>, _, String) =
             call_and_parse(client, &req, &stage, parse_strength_verdicts)?;
         if let Some(l) = log {
             repairs.push(l);
@@ -373,11 +374,27 @@ fn flush_strength_wave(
             },
             &mut chunk_verdicts,
         );
+        // Hold the exchange until coverage is judged below. A coverage failure
+        // is a CONTENT defect like any other: without this the bad reply is
+        // never recorded AND its cassette is never invalidated, so under a
+        // recording cache a rerun replays the same invalid response forever.
+        exchanges.push((req, raw));
         wave_verdicts.extend(chunk_verdicts);
     }
     let ids: Vec<String> = wave_claims.iter().map(|c| c.id.clone()).collect();
     let coverage = strength_coverage(&ids, &wave_verdicts);
     if !coverage.complete() {
+        // Keep every chunk of the wave: the defect is a property of the SET
+        // (a verdict missing here may have been answered in another chunk),
+        // so a single chunk in isolation would not explain it.
+        let defect = format!(
+            "strength coverage incomplete — missing={:?} duplicate={:?} unknown={:?}",
+            coverage.missing, coverage.duplicate, coverage.unknown
+        );
+        for (req, raw) in &exchanges {
+            super::quarantine::record("strength", req, raw, &defect);
+            client.invalidate(req);
+        }
         return Err(CliError::Gate(format!(
             "crystal-synth: strength verdicts incomplete for wave {wave} — \
              missing={:?} duplicate={:?} unknown={:?}",

--- a/crates/ovp-cli/src/commands/crystal_synth_llm.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth_llm.rs
@@ -611,6 +611,17 @@ pub(crate) fn run_sweep(
             Ok(ids) => ids,
             Err(e) => {
                 stats.failed += 1;
+                // Keep the exchange BEFORE forgetting it. This is the branch
+                // that fired on 2026-08-27 — a selected id that was never
+                // offered — and the invalidate below left nothing to inspect.
+                // The reply alone would not have explained it either: the
+                // offered set is in the REQUEST.
+                super::quarantine::record(
+                    "cluster-select",
+                    &req,
+                    &format!("{{\"selected_case_ids\": {case_ids:?}}}"),
+                    &e,
+                );
                 // Under a recording cache, forget the bad exchange so a rerun
                 // re-asks the model instead of replaying the violation forever.
                 client.invalidate(&req);

--- a/crates/ovp-cli/src/commands/crystal_theme_pages.rs
+++ b/crates/ovp-cli/src/commands/crystal_theme_pages.rs
@@ -134,7 +134,7 @@ pub(crate) fn build_pages(
         // round-4 P1). Same failure path as a gate failure.
         let req = theme_page_request(&community.synth_theme(), &claims);
         let draft = match call_and_parse(client, &req, "theme-page", parse_theme_page) {
-            Ok((draft, _repair, _raw)) => draft,
+            Ok((draft, _repair, raw)) => (draft, raw),
             Err(e) => {
                 outcome
                     .failures
@@ -145,6 +145,7 @@ pub(crate) fn build_pages(
         // The model cites positional handles (c1, c2, …); the code owns the
         // handle → claim_key substitution. Unresolved handles survive into
         // the verifier and fail loud as UnknownClaim.
+        let (draft, draft_raw) = draft;
         let mut sections = draft.clone();
         resolve_handles(&mut sections, &claim_keys);
 
@@ -159,14 +160,13 @@ pub(crate) fn build_pages(
                 theme_page_repair_request(&community.synth_theme(), &claims, &draft, &listed);
             let repaired =
                 match call_and_parse(client, &repair_req, "theme-page-repair", parse_theme_page) {
-                    Ok((repaired, _log, _raw)) => repaired,
+                    Ok((repaired, _log, raw)) => (repaired, raw),
                     Err(e) => {
-                        super::quarantine::record(
-                            "theme-page-repair",
-                            &repair_req,
-                            "",
-                            &format!("{e:?}"),
-                        );
+                        // No record here: `call_and_parse` already wrote this
+                        // failure WITH the real reply, and a second write
+                        // under the same stage+key would overwrite it with an
+                        // empty one — deleting evidence inside the change
+                        // that exists to keep it.
                         client.invalidate(&req);
                         outcome
                             .failures
@@ -174,12 +174,20 @@ pub(crate) fn build_pages(
                         continue;
                     }
                 };
+            let (repaired, repair_raw) = repaired;
             let mut repaired_resolved = repaired;
             resolve_handles(&mut repaired_resolved, &claim_keys);
             defects = verify_page(&repaired_resolved, &known);
             if defects.is_empty() {
                 sections = repaired_resolved;
             } else {
+                // A page the verifier rejects is a content defect: keep both
+                // replies before forgetting them. `call_and_parse` never saw
+                // these — it parsed them fine; the gate is what refused.
+                let listed: Vec<String> = defects.iter().map(|d| d.to_string()).collect();
+                let defect = format!("verify_page: {}", listed.join("; "));
+                super::quarantine::record("theme-page", &req, &draft_raw, &defect);
+                super::quarantine::record("theme-page-repair", &repair_req, &repair_raw, &defect);
                 // Forget both exchanges so a rerun re-asks instead of
                 // replaying the same ungrounded page (no-op on replay).
                 client.invalidate(&req);

--- a/crates/ovp-cli/src/commands/crystal_theme_pages.rs
+++ b/crates/ovp-cli/src/commands/crystal_theme_pages.rs
@@ -134,7 +134,7 @@ pub(crate) fn build_pages(
         // round-4 P1). Same failure path as a gate failure.
         let req = theme_page_request(&community.synth_theme(), &claims);
         let draft = match call_and_parse(client, &req, "theme-page", parse_theme_page) {
-            Ok((draft, _repair)) => draft,
+            Ok((draft, _repair, _raw)) => draft,
             Err(e) => {
                 outcome
                     .failures
@@ -159,8 +159,14 @@ pub(crate) fn build_pages(
                 theme_page_repair_request(&community.synth_theme(), &claims, &draft, &listed);
             let repaired =
                 match call_and_parse(client, &repair_req, "theme-page-repair", parse_theme_page) {
-                    Ok((repaired, _log)) => repaired,
+                    Ok((repaired, _log, _raw)) => repaired,
                     Err(e) => {
+                        super::quarantine::record(
+                            "theme-page-repair",
+                            &repair_req,
+                            "",
+                            &format!("{e:?}"),
+                        );
                         client.invalidate(&req);
                         outcome
                             .failures
@@ -294,6 +300,9 @@ pub fn run(args: CrystalThemePagesArgs) -> Result<(), CliError> {
     let layout = VaultLayout::new();
     let store = args.vault_root.join(layout.crystal_store_dir());
     let pages_path = store.join("theme_pages.json");
+    // Without this every quarantine call in this command is a silent no-op —
+    // the sink is process-scoped and only crystal-synth was setting it.
+    super::quarantine::set_dir(store.join("rejected"));
 
     let themes = match ThemesFile::load(&store.join("themes.json")) {
         Ok(Some(themes)) => themes,

--- a/crates/ovp-cli/src/commands/crystal_themes.rs
+++ b/crates/ovp-cli/src/commands/crystal_themes.rs
@@ -467,7 +467,7 @@ pub fn run(args: CrystalThemesArgs) -> Result<(), CliError> {
             Some(client) => {
                 let titles = centroid_titles(&docs, &vectors, ms);
                 let req = theme_label_request(&kw, &titles);
-                let (parsed, _log) =
+                let (parsed, _log, _raw) =
                     call_and_parse(client.as_mut(), &req, "theme-label", parse_theme_label)?;
                 parsed
             }

--- a/crates/ovp-cli/src/commands/mod.rs
+++ b/crates/ovp-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod client;
 pub mod compare_run;
 pub mod copy_probe;
 pub mod artifacts;
+pub mod quarantine;
 pub mod crystal_lint;
 pub mod crystal_recheck;
 pub mod crystal_review;

--- a/crates/ovp-cli/src/commands/quarantine.rs
+++ b/crates/ovp-cli/src/commands/quarantine.rs
@@ -1,0 +1,164 @@
+//! Keep the model replies we REJECT.
+//!
+//! When a reply fails a content check the pipeline calls `client.invalidate`,
+//! which deletes the cassette so a rerun re-asks the model instead of replaying
+//! a bad exchange forever. That is right. The side effect is not: the only
+//! record of what the model actually said goes with it.
+//!
+//! On 2026-08-27 a live sweep reproduced a `cluster_select` failure — a case id
+//! that had never been offered — and there was nothing left to look at. The
+//! five REFUSALS in the same run were all on disk; the one failure was not.
+//! The diagnosis had to be inferred from the shape of an error message.
+//!
+//! So a rejected exchange is written here instead. Two properties matter:
+//!
+//! - **Not replayable.** This is not the cassette tree and nothing reads it
+//!   back. A bad reply must never come back as a good one.
+//! - **The REQUEST too.** Cassettes store only replies, keyed by a hash of the
+//!   request — so even a kept cassette cannot tell you what was asked. For an
+//!   "identifier that was never offered" defect, the offered set IS the
+//!   evidence.
+//!
+//! Best-effort throughout: a diagnostic that can fail a run is worse than no
+//! diagnostic.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use ovp_llm::{ModelMessage, ModelRequest, request_key};
+
+static DIR: OnceLock<PathBuf> = OnceLock::new();
+
+/// Point this process's rejected-reply log at `dir`. First call wins; later
+/// calls are ignored, so a nested stage cannot redirect the log mid-run.
+pub(crate) fn set_dir(dir: PathBuf) {
+    let _ = DIR.set(dir);
+}
+
+/// Where rejected replies are being written, if anywhere.
+pub(crate) fn dir() -> Option<&'static Path> {
+    DIR.get().map(PathBuf::as_path)
+}
+
+/// The user-facing text of a request — what the model was actually asked.
+fn request_text(req: &ModelRequest) -> String {
+    req.messages
+        .iter()
+        .map(|m| match m {
+            ModelMessage::User { content } => content.clone(),
+            other => format!("{other:?}"),
+        })
+        .collect::<Vec<_>>()
+        .join("\n---\n")
+}
+
+/// Record one rejected exchange. Never fails the caller.
+///
+/// `defect` should say what the check objected to, in the same words the
+/// operator will see in the error — the file is useless if you cannot tell
+/// which failure it belongs to.
+pub(crate) fn record(stage: &str, request: &ModelRequest, reply_text: &str, defect: &str) {
+    let Some(dir) = dir() else {
+        return;
+    };
+    if std::fs::create_dir_all(dir).is_err() {
+        return;
+    }
+    let key = request_key(request);
+    let safe_stage: String = stage
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' { c } else { '-' })
+        .collect();
+    let path = dir.join(format!("{safe_stage}-{}.json", &key[..key.len().min(12)]));
+    let body = serde_json::json!({
+        "schema": "ovp.crystal.rejected_reply/v1",
+        "stage": stage,
+        "prompt_id": request.cache_namespace,
+        "request_key": key,
+        "defect": defect,
+        // Both halves. The reply alone cannot explain an "identifier that was
+        // never offered" — you need to see what WAS offered.
+        "request": request_text(request),
+        "reply": reply_text,
+    });
+    if let Ok(s) = serde_json::to_string_pretty(&body) {
+        let _ = std::fs::write(&path, format!("{s}\n"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(ns: &str, user: &str) -> ModelRequest {
+        ModelRequest {
+            model: "m".into(),
+            system: Some("sys".into()),
+            messages: vec![ModelMessage::User {
+                content: user.into(),
+            }],
+            max_tokens: 16,
+            temperature: None,
+            tools: None,
+            cache_namespace: Some(ns.into()),
+        }
+    }
+
+    /// `set_dir` is process-wide and first-wins, so these exercise `write_to`
+    /// directly rather than fighting over the global.
+    fn write_to(dir: &Path, stage: &str, request: &ModelRequest, reply: &str, defect: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        let key = request_key(request);
+        let path = dir.join(format!("{stage}-{}.json", &key[..12]));
+        let body = serde_json::json!({
+            "schema": "ovp.crystal.rejected_reply/v1",
+            "stage": stage, "prompt_id": request.cache_namespace,
+            "request_key": key, "defect": defect,
+            "request": request_text(request), "reply": reply,
+        });
+        std::fs::write(path, serde_json::to_string_pretty(&body).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn a_record_carries_the_request_not_just_the_reply() {
+        // The reply alone cannot explain "id not in the offered set".
+        let d = tempfile::tempdir().unwrap();
+        let r = req("cluster_select/v2", "offered: c1, c2, c3");
+        write_to(d.path(), "cluster-select", &r, "{\"selected\":[\"c9\"]}", "not offered");
+        let f = std::fs::read_dir(d.path()).unwrap().next().unwrap().unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(f.path()).unwrap()).unwrap();
+        assert!(v["request"].as_str().unwrap().contains("c1, c2, c3"));
+        assert!(v["reply"].as_str().unwrap().contains("c9"));
+        assert_eq!(v["defect"], "not offered");
+        assert_eq!(v["prompt_id"], "cluster_select/v2");
+    }
+
+    #[test]
+    fn nothing_is_written_when_no_directory_is_set() {
+        // A diagnostic that fails a run is worse than no diagnostic, and the
+        // default must be silence rather than a guessed path.
+        // `DIR` is unset in this test binary unless another test set it, so
+        // assert on the accessor rather than on side effects.
+        if dir().is_none() {
+            let r = req("x/v1", "u");
+            record("stage", &r, "reply", "defect"); // must not panic
+        }
+    }
+
+    #[test]
+    fn the_filename_cannot_escape_the_directory() {
+        // `stage` reaches this from format! strings; a separator in it would
+        // otherwise write outside the log.
+        let d = tempfile::tempdir().unwrap();
+        let r = req("x/v1", "u");
+        let stage = "../../evil";
+        let safe: String = stage
+            .chars()
+            .map(|c| if c.is_ascii_alphanumeric() || c == '-' { c } else { '-' })
+            .collect();
+        assert!(!safe.contains('/') && !safe.contains(".."));
+        write_to(d.path(), &safe, &r, "reply", "defect");
+        assert_eq!(std::fs::read_dir(d.path()).unwrap().count(), 1);
+    }
+}

--- a/crates/ovp-cli/src/commands/quarantine.rs
+++ b/crates/ovp-cli/src/commands/quarantine.rs
@@ -23,21 +23,24 @@
 //! diagnostic.
 
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::RwLock;
 
 use ovp_llm::{ModelMessage, ModelRequest, request_key};
 
-static DIR: OnceLock<PathBuf> = OnceLock::new();
+static DIR: RwLock<Option<PathBuf>> = RwLock::new(None);
 
-/// Point this process's rejected-reply log at `dir`. First call wins; later
-/// calls are ignored, so a nested stage cannot redirect the log mid-run.
+/// Point this process's rejected-reply log at `dir`.
+///
+/// LAST call wins. The A/B harness runs `run_stats` once per arm in one
+/// process, and a first-wins lock would file arm B's rejections under arm A's
+/// directory — a log that misattributes is worse than a missing one.
 pub(crate) fn set_dir(dir: PathBuf) {
-    let _ = DIR.set(dir);
+    *DIR.write().unwrap_or_else(|e| e.into_inner()) = Some(dir);
 }
 
 /// Where rejected replies are being written, if anywhere.
-pub(crate) fn dir() -> Option<&'static Path> {
-    DIR.get().map(PathBuf::as_path)
+pub(crate) fn dir() -> Option<PathBuf> {
+    DIR.read().unwrap_or_else(|e| e.into_inner()).clone()
 }
 
 /// The user-facing text of a request — what the model was actually asked.
@@ -61,7 +64,7 @@ pub(crate) fn record(stage: &str, request: &ModelRequest, reply_text: &str, defe
     let Some(dir) = dir() else {
         return;
     };
-    if std::fs::create_dir_all(dir).is_err() {
+    if std::fs::create_dir_all(&dir).is_err() {
         return;
     }
     let key = request_key(request);
@@ -78,11 +81,22 @@ pub(crate) fn record(stage: &str, request: &ModelRequest, reply_text: &str, defe
         "defect": defect,
         // Both halves. The reply alone cannot explain an "identifier that was
         // never offered" — you need to see what WAS offered.
+        // The system prompt is part of what the model received; omitting it
+        // hides half the instructions when the defect is "it ignored them".
+        "system": request.system,
         "request": request_text(request),
         "reply": reply_text,
     });
     if let Ok(s) = serde_json::to_string_pretty(&body) {
-        let _ = std::fs::write(&path, format!("{s}\n"));
+        if std::fs::write(&path, format!("{s}\n")).is_ok() {
+            // 0600: these carry raw vault content and raw model output, and a
+            // work dir is not guaranteed to be gitignored or unsynced.
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+            }
+        }
     }
 }
 
@@ -104,8 +118,8 @@ mod tests {
         }
     }
 
-    /// `set_dir` is process-wide and first-wins, so these exercise `write_to`
-    /// directly rather than fighting over the global.
+    /// `set_dir` is process-wide, so these exercise the same body through a
+    /// local path rather than racing other tests for the global.
     fn write_to(dir: &Path, stage: &str, request: &ModelRequest, reply: &str, defect: &str) {
         std::fs::create_dir_all(dir).unwrap();
         let key = request_key(request);

--- a/crates/ovp-cli/src/commands/quarantine.rs
+++ b/crates/ovp-cli/src/commands/quarantine.rs
@@ -72,7 +72,17 @@ pub(crate) fn record(stage: &str, request: &ModelRequest, reply_text: &str, defe
         .chars()
         .map(|c| if c.is_ascii_alphanumeric() || c == '-' { c } else { '-' })
         .collect();
-    let path = dir.join(format!("{safe_stage}-{}.json", &key[..key.len().min(12)]));
+    // Collision-safe: a second rejection of the SAME stage+request is a
+    // second data point, not a correction of the first. Overwriting cost us
+    // a real reply once already.
+    let stem = format!("{safe_stage}-{}", &key[..key.len().min(12)]);
+    let mut path = dir.join(format!("{stem}.json"));
+    for n in 1..1000 {
+        if !path.exists() {
+            break;
+        }
+        path = dir.join(format!("{stem}-{n}.json"));
+    }
     let body = serde_json::json!({
         "schema": "ovp.crystal.rejected_reply/v1",
         "stage": stage,
@@ -158,6 +168,33 @@ mod tests {
             let r = req("x/v1", "u");
             record("stage", &r, "reply", "defect"); // must not panic
         }
+    }
+
+    #[test]
+    fn a_second_rejection_does_not_overwrite_the_first() {
+        // This is not hypothetical. A caller recorded a repair failure with an
+        // empty reply after `call_and_parse` had already recorded the same
+        // stage+request WITH the real reply — and the empty one won, deleting
+        // the evidence inside the change that exists to keep it.
+        let d = tempfile::tempdir().unwrap();
+        let r = req("x/v1", "u");
+        let key = request_key(&r);
+        let stem = format!("s-{}", &key[..12]);
+        std::fs::write(d.path().join(format!("{stem}.json")), "{\"reply\":\"the real one\"}")
+            .unwrap();
+        // Second record must pick a fresh name.
+        let mut path = d.path().join(format!("{stem}.json"));
+        for n in 1..1000 {
+            if !path.exists() {
+                break;
+            }
+            path = d.path().join(format!("{stem}-{n}.json"));
+        }
+        std::fs::write(&path, "{}").unwrap();
+        assert_eq!(std::fs::read_dir(d.path()).unwrap().count(), 2);
+        let first =
+            std::fs::read_to_string(d.path().join(format!("{stem}.json"))).unwrap();
+        assert!(first.contains("the real one"), "the first record survived");
     }
 
     #[test]

--- a/crates/ovp-cli/src/commands/tags_bootstrap.rs
+++ b/crates/ovp-cli/src/commands/tags_bootstrap.rs
@@ -392,7 +392,7 @@ pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
             let reply = match call_and_parse(client.as_mut(), &req, "tag-classify", |t| {
                 parse_tag_classify(t, batch_len)
             }) {
-                Ok((reply, _repair)) => reply,
+                Ok((reply, _repair, _raw)) => reply,
                 Err(e) => {
                     sayln!("  classify: batch failed ({e}) — keeping the floor for its sources");
                     continue;


### PR DESCRIPTION
## The gap

When a reply fails a content check the pipeline calls `client.invalidate`, so a rerun re-asks the model instead of replaying a bad exchange forever. That is right. The side effect was not: **the only record of what the model said went with it.**

On 2026-08-27 a live sweep reproduced a `cluster_select` failure — a case id that had never been offered — and there was nothing left to look at. The five *refusals* in that run were all on disk; the one *failure* was not, and the diagnosis had to be inferred from the shape of an error message.

## What this adds

Rejected exchanges land in `<work-dir>/rejected/`, mode 0600.

- **Not replayable.** Separate from the cassette tree, read by nothing.
- **The REQUEST too**, system prompt included. Cassettes store only replies, keyed by a hash of the request, so even a kept cassette cannot say what was *asked* — and for an "identifier that was never offered" defect, the offered set is the evidence.

## It immediately corrected a conclusion I had already reported

The first version filed a **reconstruction** as "the reply": it re-serialised the already-trimmed, already-alias-resolved `case_ids`. The log therefore showed long real ids — which the *resolver* had put there — and I read that as the model ignoring the handles from #467 and generating long ids. **It was not.** With the raw text captured, the same failure reads:

```json
"selected_case_ids": ["c1", "c3", "4", "c5", "c6"]
```

The model is using the handles. Four of five are right; one lost its `c` prefix. #467 is working better than I said, and the remaining defect is a different, smaller one.

A diagnostic that reports its own output as the observed behaviour is worse than no diagnostic — it manufactures a defect, and I was one step from acting on this one.

## Codex gate: 4 × P1, 3 × P2, all real

Beyond the reconstruction above:

- A repair reply that parses but fails the stage parser is its own defect; it was invalidated with no record.
- Files were **0644** while carrying raw vault content and raw model output, and a work dir is not guaranteed gitignored or unsynced.
- **`crystal-theme-pages` never called `set_dir`**, so every quarantine call in that command was a silent no-op.
- The sink was **first-wins**. The A/B harness runs both arms in ONE process, so arm B's rejections would have been filed under arm A's directory. A log that misattributes is worse than one that is missing.
- The system prompt was omitted — when the defect is "it did not follow the instructions", the instructions are the evidence.

Path traversal via the stage string was already blocked by an ASCII allowlist; there is a test.

## Known and not addressed

No retention or size bound. Identical requests overwrite, but a long-lived vault will accumulate distinct ones. Worth a cap; not in this change.

## Next, with data instead of guesswork

The surviving `c4` → `4` suggests integer handles (`"ref": 4`) would leave no prefix to drop. That is now measurable rather than inferred, which is the point of this PR.

## Verification

81 test suites green. Live run confirmed: 0600, raw reply present, and the `c4` → `4` defect visible for the first time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic capture of rejected AI responses for later inspection.
  * Rejected exchanges now include request, response, and validation details.
  * Output locations are initialized automatically for synthesis and page-building workflows.

* **Bug Fixes**
  * Improved preservation of failed responses, including repair and validation failures.
  * Ensured rejection records are saved before replay data is invalidated.
  * Prevented duplicate records from overwriting earlier rejected responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->