### PR TITLE
fix(daily): record pinboard skip in report warnings and point to providers.toml

### DIFF
--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -648,7 +648,7 @@ export const en = {
   'auto.jobsAria': 'Scheduled jobs',
   'auto.toggle.pinboard': 'Pinboard live sync',
   'auto.toggle.pinboardHint':
-    'Toggle on the Pinboard node (or here). Needs PINBOARD_TOKEN in .ovp/daily.env.',
+    'Toggle on the Pinboard node (or here). Needs PINBOARD_TOKEN in .ovp/providers.toml.',
   'auto.clock':
     'Clock: the desktop app ticks every ~10 minutes while it is open. Closing the app pauses automatic runs (unless you also installed an OS schedule with `ovp2 schedule install`).',
   'auto.loading': 'Loading schedule…',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -614,7 +614,7 @@ export const zh: Record<keyof typeof en, string> = {
   'auto.jobsAria': '定时任务',
   'auto.toggle.pinboard': 'Pinboard live 同步',
   'auto.toggle.pinboardHint':
-    '在 Pinboard 节点上开关。需在 .ovp/daily.env 配置 PINBOARD_TOKEN。',
+    '在 Pinboard 节点上开关。需在 .ovp/providers.toml 配置 PINBOARD_TOKEN。',
   'auto.clock':
     '时钟：桌面 App 在打开期间约每 10 分钟检查一次到点任务。关掉 App 后自动跑会暂停（除非你还用 `ovp2 schedule install` 装了系统定时）。',
   'auto.loading': '加载定时配置…',

--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -176,7 +176,7 @@ fn run_inner(
         && args.pinboard_fixture.is_none()
         && std::env::var("PINBOARD_TOKEN").ok().filter(|t| !t.trim().is_empty()).is_none()
     {
-        Some("PINBOARD_TOKEN is not set (add it to .ovp/daily.env to enable live capture)".to_string())
+        Some("PINBOARD_TOKEN is not set (add it to .ovp/providers.toml to enable live capture)".to_string())
     } else {
         None
     };
@@ -204,6 +204,7 @@ fn run_inner(
         && let Some(reason) = pinboard_skip
     {
         sayln!("  pinboard: skipped ({reason})");
+        report.warnings.push(format!("pinboard: {reason}"));
     } else if args.pinboard_fixture.is_some() || args.pinboard_live {
         let mut fetch = build_pinboard_fetch(&args)?;
         let opts = ovp_intake::PinboardSyncOptions {

--- a/crates/ovp-cli/tests/m31_e2e.rs
+++ b/crates/ovp-cli/tests/m31_e2e.rs
@@ -632,3 +632,36 @@ fn daily_periodic_refresh_rebuilds_projection_mid_run() {
     // …but the end-of-run projection is still built.
     assert!(vault0.join(".ovp/index/index.json").exists(), "final index still written at N=0");
 }
+
+#[test]
+fn daily_pinboard_skip_records_warning_in_report() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = tmp.path().join("cache");
+    set_test_cache(&cache_dir);
+    let vault = tmp.path().join("vault");
+    std::fs::create_dir_all(vault.join("50-Inbox/01-Raw")).unwrap();
+
+    let mut cmd = bin();
+    cmd.env_remove("PINBOARD_TOKEN");
+    cmd.args([
+        "daily",
+        "--vault-root", vault.to_str().unwrap(),
+        "--date", DATE,
+        "--run-id", "daily-pinboard-skip",
+        "--pinboard-live",
+        "--cache-dir", cache_dir.to_str().unwrap(),
+    ]);
+    let stdout = run_ok(&mut cmd);
+    assert!(stdout.contains("pinboard: skipped (PINBOARD_TOKEN is not set"));
+
+    let report_path = vault.join(".ovp/reports/daily-pinboard-skip.json");
+    assert!(report_path.exists(), "report exists: {}", report_path.display());
+    let raw = std::fs::read_to_string(&report_path).unwrap();
+    let val: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    let warnings = val.get("warnings").and_then(|w| w.as_array()).expect("warnings array in report");
+    assert!(!warnings.is_empty(), "expected warnings in report, got: {val}");
+    assert!(
+        warnings.iter().any(|w| w.as_str().unwrap_or("").contains("pinboard: PINBOARD_TOKEN is not set")),
+        "expected pinboard skip in warnings: {warnings:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- Fix misleading error prompt in `crates/ovp-cli/src/commands/daily.rs` when PINBOARD_TOKEN is missing (now points to `.ovp/providers.toml`).
- When pinboard capture is armed (`--pinboard-live` or `--pinboard-fixture`) and soft-skipped (due to missing token, no watermark, etc.), record the skip reason into `report.warnings` so it is visible in the run report instead of failing silently.
- Add an end-to-end regression test in `crates/ovp-cli/tests/m31_e2e.rs`.
- Update corresponding i18n hints in `console-ui`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated English and Chinese guidance to point to `.ovp/providers.toml` for configuring `PINBOARD_TOKEN`.
  * Pinboard skip messages now provide the correct configuration location.
  * Skipped Pinboard runs are now recorded as warnings in the daily report, in addition to being shown in the console.

* **Tests**
  * Added coverage confirming that missing Pinboard credentials produce a visible skip message and a corresponding report warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->